### PR TITLE
Remove unused step in push flow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,8 +23,5 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v1
 
-      - name: Login to Digital Ocean Registry
-        run: doctl registry login --expiry-seconds 10000
-
-      - name: Build and Push to Digital Ocean Registry
+      - name: Build and Push to Docker Hub
         run: make docker-image-multiarch


### PR DESCRIPTION
## Summary
I realized there was still a Digital Ocean specific step in the `push` workflow.