### PR TITLE
Customize lint rules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,10 @@
+run:
+  go: "1.17"
+linters:
+  # Disable all linters.
+  Default: true
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default-linters
+  enable:
+    - nakedret
+    - nilerr

--- a/store/query.go
+++ b/store/query.go
@@ -67,7 +67,7 @@ func buildSqlQuery(query *pb.HistoryQuery) (querySql string, args []interface{},
 
 	querySql, args = sb.Build()
 
-	return
+	return querySql, args, err
 }
 
 func addPagination(sb *sqlBuilder.SelectBuilder, pagination *pb.PagingInfo) {


### PR DESCRIPTION
## Summary
- Adds a `.golangci.yaml` file to customize the linters used
- Updates the code to be compliant with `nakedret`
- Turns on `nakedret` and `nilerr`

## Notes
- `nakedret` has a default of allowing naked returns on functions < 5 lines long. That seems sensible.
- The full list of available linters is [here](https://golangci-lint.run/usage/linters/#enabled-by-default-linters). We can debate the merits of adding more.