### PR TITLE
Fix --log-encoding

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,9 @@ func main() {
 	// Set encoding for logs (console, json, ...)
 	// Note that libp2p reads the encoding from GOLOG_LOG_FMT env var.
 	utils.InitLogger(options.LogEncoding)
+	if options.LogEncoding == "json" && os.Getenv("GOLOG_LOG_FMT") == "" {
+		utils.Logger().Warn("Set GOLOG_LOG_FMT=json to use json for libp2p logs")
+	}
 
 	if options.GenerateKey {
 		if err := server.WritePrivateKeyToFile(options.KeyFile, options.Overwrite); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -62,10 +62,6 @@ func New(options Options) (server *Server) {
 	var err error
 
 	server.logger = utils.Logger()
-	if options.LogEncoding == "json" && os.Getenv("GOLOG_LOG_FMT") == "" {
-		server.logger.Warn("Set GOLOG_LOG_FMT=json to use json for libp2p logs")
-	}
-
 	server.hostAddr, err = net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", options.Address, options.Port))
 	failOnErr(err, "invalid host address")
 


### PR DESCRIPTION
Looks like https://github.com/xmtp/xmtp-node-go/pull/24 lost the --log-encoding option. My go-waku updates moved the `InitLogger()` call out to the main go-waku module, which we are not using here, so we need to add it to our main module.