### PR TITLE
Fix dumb context init panic

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -73,10 +73,10 @@ func New(options Options) (server *Server) {
 	id, err := peer.IDFromPublicKey(p2pPrvKey.GetPublic())
 	failOnErr(err, "deriving peer ID from private key")
 	server.logger = server.logger.With(logging.HostID("node", id))
-	server.ctx = logging.With(server.ctx, server.logger)
+	server.ctx = logging.With(context.Background(), server.logger)
 
 	server.db = createDbOrFail(options.Store.DbConnectionString, options.WaitForDB)
-	server.ctx, server.cancel = context.WithCancel(context.Background())
+	server.ctx, server.cancel = context.WithCancel(server.ctx)
 
 	if options.Metrics.Enable {
 		server.metricsServer = metrics.NewMetricsServer(options.Metrics.Address, options.Metrics.Port, server.logger)


### PR DESCRIPTION
Lesson for me, don't screw around with the code without retesting it again, no matter how minor it seems 🤦 
```
% scripts/xmtp-js.sh 
2022-06-10T10:26:22.150-0400    WARN    gowaku  logger not yet initialized
panic: cannot create context from nil parent

goroutine 1 [running]:
context.WithValue({0x0, 0x0}, {0x10135f8e0, 0x1020550e0}, {0x1014e6440, 0x14000a24000})
        /opt/homebrew/Cellar/go/1.17.5/libexec/src/context/context.go:525 +0x16c
github.com/status-im/go-waku/logging.With({0x0, 0x0}, 0x14000a24000)
        /Users/martin/go/pkg/mod/github.com/xmtp/go-waku@v0.0.0-20220607164009-b8c602bac49e/logging/context.go:19 +0x60
github.com/xmtp/xmtp-node-go/server.New({0xea60, {0x1013a94be, 0x7}, 0x1, 0x232a, {0x1013f847a, 0x7}, 0x0, {0x16faab595, 0x40}, ...})
        /Users/martin/go/xmtp-node-go/server/server.go:76 +0x4b4
main.main()
        /Users/martin/go/xmtp-node-go/main.go:75 +0x3f8
```

Introduced by https://github.com/xmtp/xmtp-node-go/pull/28. Odd that this wasn't caught by the test suite, because you basically cannot create a server.