### PR TITLE
Fix xmtp_bootstrap_peers metric

### DIFF
--- a/metrics/peers.go
+++ b/metrics/peers.go
@@ -50,7 +50,7 @@ func EmitPeersByProtocol(ctx context.Context, host host.Host) {
 	}
 }
 
-func EmitBoostrapPeersConnected(ctx context.Context, host host.Host, bootstrapPeers map[peer.ID]bool) {
+func EmitBootstrapPeersConnected(ctx context.Context, host host.Host, bootstrapPeers map[peer.ID]bool) {
 	var bootstrapPeersFound int
 	for _, peer := range host.Network().Peers() {
 		if bootstrapPeers[peer] {

--- a/server/server.go
+++ b/server/server.go
@@ -235,7 +235,7 @@ func (server *Server) statusMetricsLoop(options Options) {
 		case <-ticker.C:
 			metrics.EmitPeersByProtocol(server.ctx, server.wakuNode.Host())
 			if len(bootstrapPeers) > 0 {
-				metrics.EmitBoostrapPeersConnected(server.ctx, server.wakuNode.Host(), bootstrapPeers)
+				metrics.EmitBootstrapPeersConnected(server.ctx, server.wakuNode.Host(), bootstrapPeers)
 			}
 		}
 	}


### PR DESCRIPTION
In #33 I based the new metric on `host.Peerstore().Peers()` which is more of a knowledge base of peers, and does not reflect actual connectedness. This PR moves that metric to `host.Network().Peers()` instead.