### PR TITLE
Build docker image for just amd64 via buildx

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,9 +8,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ docker-image:
 # Also worth mentioning this is painfully slow due to QEMU
 docker-image-multiarch:
 	@docker buildx build \
-		--platform linux/amd64,linux/arm64 \
+		--platform linux/amd64 \
 		--tag ${DOCKER_IMAGE_NAME} \
 		--build-arg="GIT_COMMIT=${GIT_COMMIT}" \
 		-q \


### PR DESCRIPTION
This PR reduces our build time for production deployments down from 20m to 1-2m by removing qemu and not building an arm image. 

`docker run --rm -it snormorexmtp/docker-buildx-test --help` is built in this way if you want to try it out.