### PR TITLE
Fix fresh install of go deps

### DIFF
--- a/dev/up
+++ b/dev/up
@@ -8,9 +8,6 @@ if ! which golangci-lint &>/dev/null; then brew install golangci-lint; fi
 if ! which shellcheck &>/dev/null; then brew install shellcheck; fi
 if ! which protoc &>/dev/null; then brew install protobuf; fi
 if ! which protoc-gen-go &>/dev/null; then go install google.golang.org/protobuf/cmd/protoc-gen-go; fi
-if ! which protoc-gen-go-grpc &>/dev/null; then go install google.golang.org/grpc/cmd/protoc-gen-go-grpc; fi
-if ! which protoc-gen-grpc-gateway &>/dev/null; then go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway; fi
-if ! which protoc-gen-openapiv2 &>/dev/null; then go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2; fi
 if ! which mockgen &>/dev/null; then go install github.com/golang/mock/mockgen@latest; fi
 if ! which protolint &>/dev/null; then go install github.com/yoheimuta/protolint/cmd/protolint@latest; fi
 


### PR DESCRIPTION
Something @PranayAnchuri  discovered while setting up a new environment - we `go mod tidy` after the protoc deps install in `dev/up` but it's needed before that

Another follow-up on https://github.com/xmtp/xmtp-node-go/pull/54