### PR TITLE
Use non-default postgres port for local db

### DIFF
--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     environment:
       POSTGRES_PASSWORD: xmtp
     ports:
-      - 5432:5432
+      - 15432:5432
   authz-db:
     image: postgres:13
     environment:

--- a/dev/run
+++ b/dev/run
@@ -3,8 +3,8 @@ set -e
 
 dev/up
 
-MESSAGE_DB_DSN="postgres://postgres:xmtp@localhost:5432/postgres?sslmode=disable"
-AUTHZ_DB_DSN="postgres://postgres:xmtp@localhost:5432/postgres?sslmode=disable"
+MESSAGE_DB_DSN="postgres://postgres:xmtp@localhost:15432/postgres?sslmode=disable"
+AUTHZ_DB_DSN="postgres://postgres:xmtp@localhost:15432/postgres?sslmode=disable"
 NODE_KEY="8a30dcb604b0b53627a5adc054dbf434b446628d4bd1eccc681d223f0550ce67"
 
 go run cmd/xmtpd/main.go \

--- a/pkg/store/query_test.go
+++ b/pkg/store/query_test.go
@@ -19,7 +19,7 @@ const TOPIC = "test"
 func NewMock() *sql.DB {
 	dsn, hasDsn := os.LookupEnv("MESSAGE_POSTGRES_CONNECTION_STRING")
 	if !hasDsn {
-		dsn = "postgres://postgres:xmtp@localhost:5432/postgres?sslmode=disable"
+		dsn = "postgres://postgres:xmtp@localhost:15432/postgres?sslmode=disable"
 	}
 	db := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))
 

--- a/pkg/testing/store.go
+++ b/pkg/testing/store.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	localTestDBDSNPrefix = "postgres://postgres:xmtp@localhost:5432"
+	localTestDBDSNPrefix = "postgres://postgres:xmtp@localhost:15432"
 	localTestDBDSNSuffix = "?sslmode=disable"
 )
 


### PR DESCRIPTION
Yesterday @PranayAnchuri ran into an issue while setting up his dev environment where he already had a version of postgres running on the default port 5432, which caused our docker compose up to fail with port already in use. So this PR changes the db port that our local instance listens on to 15432 rather than the default, to avoid any conflicts in the future.