### PR TITLE
rename ClientAuthn protocolID

### DIFF
--- a/pkg/authn/transport_authentication.go
+++ b/pkg/authn/transport_authentication.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const TransportAuthID_v01beta1 = libp2pProtocol.ID("/xmtplabs/xmtp-v1/clientauthn/0.1.0-beta1")
+const ClientAuthnID_v1_0_0 = libp2pProtocol.ID("/xmtplabs/xmtp-v1/clientauthn/1.0.0")
 
 var (
 	ErrInvalidPeerId     = errors.New("invalid peerId")
@@ -45,7 +45,7 @@ func NewXmtpAuthentication(ctx context.Context, h host.Host, log *zap.Logger) *X
 }
 
 func (xmtpAuth *XmtpAuthentication) Start() {
-	xmtpAuth.h.SetStreamHandler(TransportAuthID_v01beta1, xmtpAuth.onRequest)
+	xmtpAuth.h.SetStreamHandler(ClientAuthnID_v1_0_0, xmtpAuth.onRequest)
 	xmtpAuth.log.Info("Auth protocol started")
 }
 

--- a/pkg/authn/transport_authentication_test.go
+++ b/pkg/authn/transport_authentication_test.go
@@ -174,7 +174,7 @@ func TestRoundTrip(t *testing.T) {
 		require.NoError(t, err)
 		dest := node.h.Addrs()[0]
 
-		didSucceed, err := ClientAuth(ctx, log.Named("MockClient"), client, types.PeerId(node.h.ID()), dest, TransportAuthID_v01beta1, sampleAuthReq002.reqBytes)
+		didSucceed, err := ClientAuth(ctx, log.Named("MockClient"), client, types.PeerId(node.h.ID()), dest, ClientAuthnID_v1_0_0, sampleAuthReq002.reqBytes)
 		require.NoError(t, err)
 		require.False(t, didSucceed)
 


### PR DESCRIPTION
This PR updates the ClientAuthn protocol ID for release. 

1) Renames the variable to better reflect its actual purpose.
2) Removes the beta** tag and bumps to V1.

** Worth noting Waku retains the beta tags on all of their protocols (e.g: `const LightPushID_v20beta1 = libp2pProtocol.ID("/vac/waku/lightpush/2.0.0-beta1"`). 

I imagine if we are pushing protocols into the wild we'd want to avoid this behavior but I am open to pushback here. 