### PR TITLE
Log root span start/finish

### DIFF
--- a/pkg/logging/context.go
+++ b/pkg/logging/context.go
@@ -1,11 +1,23 @@
 package logging
 
 import (
+	"context"
+
 	"github.com/status-im/go-waku/logging"
+	"github.com/status-im/go-waku/waku/v2/utils"
+	"go.uber.org/zap"
 )
 
 var (
 	// Re-export the go-waku helpers.
 	With = logging.With
-	From = logging.From
 )
+
+// From returns a logger from the context or the default logger.
+func From(ctx context.Context) *zap.Logger {
+	logger := logging.From(ctx)
+	if logger == nil {
+		logger = utils.Logger()
+	}
+	return logger
+}


### PR DESCRIPTION
One of my theories on why we're not getting traces is that maybe we aren't properly finishing the root traces for some reason and thus APM doesn't have a proper trace tree to show. Looking at the code I'm not seeing reasons why the deferred Finishes wouldn't be running, but I'd like to confirm this with some logs. These should log only the top level spans so shouldn't be too noisy but we can ditch these later if we don't like them.
