### PR TITLE
Add launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch file",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/${relativeFileDirname}",
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
I realized that I had an uncommitted launch.json file used for running the debugger.

It's probably an overly-simplistic model, just used for running a given file in the VSCode environment, with Delve enabled. But it's enough that you can run a test and have it stop at a breakpoint which covers 100% of my needs (and likely most of yours).

## Notes
Does assume your VSCode is configured to have the shell able to find the Go binary with the right version.