### PR TITLE
Add commit message to deploy run message

### DIFF
--- a/scripts/deploy/client.go
+++ b/scripts/deploy/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os/exec"
 
 	"github.com/hashicorp/go-tfe"
 )
@@ -41,8 +42,13 @@ func (c *client) updateVar(name string, value string) {
 }
 
 func (c client) startRun(commit string, apply bool) {
-	msg := fmt.Sprintf("triggered from xtmp-node-go commit %s", commit)
-	_, err := c.Runs.Create(c.ctx, tfe.RunCreateOptions{
+	msg := commit
+	out, err := exec.Command("git", "log", "--oneline", "-n 1").Output()
+	if err == nil {
+		msg = string(out)
+	}
+	msg = fmt.Sprintf("triggered from xtmp-node-go commit\n%s", msg)
+	_, err = c.Runs.Create(c.ctx, tfe.RunCreateOptions{
 		Message:   &msg,
 		Workspace: c.wsp,
 		AutoApply: &apply,


### PR DESCRIPTION
I find this not very informative

<img width="949" alt="Screen Shot 2022-07-19 at 11 20 40" src="https://user-images.githubusercontent.com/871693/179787495-2f00d6ae-dd59-41a3-84f3-cfec7ed71a59.png">

This PR attempts to add the actual commit message to that view.

I tested the exec expression on the side with

```
package main

import (
	"fmt"
	"os/exec"
)

func main() {
	out, err := exec.Command("git", "log", "--oneline", "-n 1").Output()
	if err != nil {
		fmt.Println(err)
	} else {
		fmt.Println(string(out))
	}
}
```
yielding
```
martin@Martins-MBP xmtp-node-go % go run ./m.go 
b0804a1 Add commit message to deploy run message


```

I'm not sure how a multiline message will look, but there's one way to find out.