### PR TITLE
Improve the remote shell command

### DIFF
--- a/dev/aws-shell
+++ b/dev/aws-shell
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Open shell in one of our AWS containers.
+# Defaults to the node container on node-0 in the dev cluster.
+# Assumes aws cli is installed and configured as per
+# https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html
+# https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html
+
+region=${REGION:-us-east-2}
+cluster=${ENV:-dev}
+task=${TASK:-node-0}
+container=${CONTAINER:-$task}
+task=$(aws --region $region \
+        --query 'taskArns[0]' \
+        --output text \
+        ecs list-tasks \
+        --cluster $cluster \
+        --family $task)
+aws --region $region ecs execute-command \
+    --cluster $cluster \
+    --task $task \
+    --container $container \
+    --interactive \
+    --command "/bin/sh"


### PR DESCRIPTION
I keep having to edit it by hand as I poke at various nodes and containers. This version allows overriding all parameters through env vars, e.g.
```
$ TASK=node-1 CONTAINER=datadog-agent dev/aws-shell
```