### PR TITLE
Fix Commit setting in dev/docker/build

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -1,8 +1,6 @@
 # BUILD IMAGE --------------------------------------------------------
 FROM golang:1.17-alpine as builder
 
-ARG GIT_COMMIT=unknown
-
 # Get build tools and required header files
 RUN apk add --no-cache build-base
 
@@ -10,6 +8,7 @@ WORKDIR /app
 COPY . .
 
 # Build the final node binary
+ARG GIT_COMMIT=unknown
 RUN go build -ldflags="-X 'main.Commit=$GIT_COMMIT'" -o bin/xmtpd cmd/xmtpd/main.go
 
 # ACTUAL IMAGE -------------------------------------------------------


### PR DESCRIPTION
In #71 I've missed a small bit trying to pass a build arg to the first/build stage of the docker build. I believe I have to declare the ARG in that stage if I want the build arg to be available.

I can confirm that currently the Commit is set to an empty string (as can be seen in APM Error Tracking as well):
```
/ # /usr/bin/xmtpd --version
2022-07-21T16:22:14.814Z	WARN	gowaku	logger not yet initialized
Version: / #
```