### PR TITLE
Deflake some node tests

### DIFF
--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -185,7 +185,7 @@ func TestNode_DataPartition_WithoutResume(t *testing.T) {
 
 	// Disconnect and send a message to each node, expecting that the messages
 	// are not relayed to the other node.
-	test.Disconnect(t, n1, n2.Host().ID())
+	test.Disconnect(t, n1, n2)
 	test.ExpectNoPeers(t, n1)
 	test.ExpectNoPeers(t, n2)
 
@@ -286,7 +286,7 @@ func TestNode_DataPartition_WithResume(t *testing.T) {
 
 	// Disconnect and send a message to each node, expecting that the messages
 	// are not relayed to the other node.
-	test.Disconnect(t, n1, n2.Host().ID())
+	test.Disconnect(t, n1, n2)
 	test.ExpectNoPeers(t, n1)
 	test.ExpectNoPeers(t, n2)
 
@@ -366,8 +366,7 @@ func TestNodes_Deployment(t *testing.T) {
 				test.ExpectPeers(t, newN2, n1ID)
 
 				// Deploy ending; old instances disconnect from connected peers.
-				test.Disconnect(t, n1, n2ID)
-				test.Disconnect(t, n2, n1ID)
+				test.Disconnect(t, n1, n2)
 
 				// Expect new instances are still fully connected.
 				test.ExpectPeers(t, newN1, n2ID)
@@ -390,8 +389,7 @@ func TestNodes_Deployment(t *testing.T) {
 				test.ExpectPeers(t, newN2, n1ID)
 
 				// Deploy ending; old instances disconnect from connected peers.
-				test.Disconnect(t, n1, n2ID)
-				test.Disconnect(t, n2, n1ID)
+				test.Disconnect(t, n1, n2)
 
 				// Expect new instances are still fully connected.
 				test.ExpectPeers(t, newN1, n2ID)
@@ -413,8 +411,7 @@ func TestNodes_Deployment(t *testing.T) {
 				test.ExpectPeers(t, newN2, n1ID)
 
 				// Deploy ending; old instances disconnect from connected peers.
-				test.Disconnect(t, n1, n2ID)
-				test.Disconnect(t, n2, n1ID)
+				test.Disconnect(t, n1, n2)
 
 				// Expect new instances are fully disconnected.
 				test.ExpectNoPeers(t, newN1)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -31,21 +31,13 @@ func TestServer_StaticNodesReconnect(t *testing.T) {
 		n2.ListenAddresses()[0].String(),
 	})
 	defer cleanup()
-	serverID := server.wakuNode.Host().ID()
 
 	// Expect connect to static nodes.
 	test.ExpectPeers(t, server.wakuNode, n1ID, n2ID)
 
-	// Disconnect from static nodes via server.
-	test.Disconnect(t, server.wakuNode, n1ID)
-	test.Disconnect(t, server.wakuNode, n2ID)
-
-	// Expect reconnect to static nodes.
-	test.ExpectPeers(t, server.wakuNode, n1ID, n2ID)
-
-	// Disconnect from static nodes via the nodes.
-	test.Disconnect(t, n1, serverID)
-	test.Disconnect(t, n2, serverID)
+	// Disconnect from static nodes.
+	test.Disconnect(t, server.wakuNode, n1)
+	test.Disconnect(t, server.wakuNode, n2)
 
 	// Expect reconnect to static nodes.
 	test.ExpectPeers(t, server.wakuNode, n1ID, n2ID)

--- a/pkg/testing/node.go
+++ b/pkg/testing/node.go
@@ -42,9 +42,14 @@ func ConnectWithAddr(t *testing.T, n *wakunode.WakuNode, addr string) {
 	time.Sleep(100 * time.Millisecond)
 }
 
-func Disconnect(t *testing.T, n1 *wakunode.WakuNode, peerID peer.ID) {
-	err := n1.ClosePeerById(peerID)
+func Disconnect(t *testing.T, n1 *wakunode.WakuNode, n2 *wakunode.WakuNode) {
+	err := n1.ClosePeerById(n2.Host().ID())
 	require.NoError(t, err)
+	n1.Host().Peerstore().RemovePeer(n2.Host().ID())
+
+	err = n2.ClosePeerById(n1.Host().ID())
+	require.NoError(t, err)
+	n2.Host().Peerstore().RemovePeer(n1.Host().ID())
 }
 
 func NewTopic() string {

--- a/pkg/testing/relay.go
+++ b/pkg/testing/relay.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -53,8 +54,8 @@ func SubscribeExpect(t *testing.T, envC chan *protocol.Envelope, msgs []*pb.Waku
 
 func SubscribeExpectNone(t *testing.T, envC chan *protocol.Envelope) {
 	select {
-	case <-envC:
-		require.FailNow(t, "expected no message")
+	case env := <-envC:
+		require.FailNow(t, fmt.Sprintf("expected no message, got: %v", env.Message()))
 	case <-time.After(100 * time.Millisecond):
 	}
 }


### PR DESCRIPTION
A couple of the node tests are still failing intermittently, and it looks like it's because the hosts are reconnecting after the 1-sided disconnect, where if that reconnect raced the subscribe assertions, it would resume and fail the test. This PR changes the `test.Disconnect` helper to disconnect from both sides/hosts, and to explicitly remove the peer from their peerstores.