### PR TITLE
Pad node key hex if necessary

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -372,13 +372,13 @@ func getPrivKey(options Options) (*ecdsa.PrivateKey, error) {
 	var prvKey *ecdsa.PrivateKey
 	var err error
 	if options.NodeKey != "" {
-		if prvKey, err = crypto.HexToECDSA(options.NodeKey); err != nil {
+		if prvKey, err = hexToECDSA(options.NodeKey); err != nil {
 			return nil, fmt.Errorf("error converting key into valid ecdsa key: %w", err)
 		}
 	} else {
 		keyString := os.Getenv("GOWAKU-NODEKEY")
 		if keyString != "" {
-			if prvKey, err = crypto.HexToECDSA(keyString); err != nil {
+			if prvKey, err = hexToECDSA(keyString); err != nil {
 				return nil, fmt.Errorf("error converting key into valid ecdsa key: %w", err)
 			}
 		} else {
@@ -447,4 +447,14 @@ func createDbOrFail(dsn string, waitForDB time.Duration) *sql.DB {
 		failOnErr(err, "timeout waiting for DB")
 	}
 	return db
+}
+
+func hexToECDSA(key string) (*ecdsa.PrivateKey, error) {
+	if len(key) == 60 {
+		key = "0000" + key
+	}
+	if len(key) == 62 {
+		key = "00" + key
+	}
+	return crypto.HexToECDSA(key)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,52 @@ func TestServer_StaticNodesReconnect(t *testing.T) {
 
 	// Expect reconnect to static nodes.
 	test.ExpectPeers(t, server.wakuNode, n1ID, n2ID)
+}
+
+func TestServer_hexToECDSA(t *testing.T) {
+	tcs := []struct {
+		name        string
+		key         string
+		expectedErr string
+	}{
+		{
+			name: "length 64 valid",
+			key:  "1df2b07b69f67be885148ef85ced1576048c7c33fb861f7cd8e9b62e13013330",
+		},
+		{
+			name: "length 62 valid",
+			key:  "f2b07b69f67be885148ef85ced1576048c7c33fb861f7cd8e9b62e13013330",
+		},
+		{
+			name: "length 60 valid",
+			key:  "b07b69f67be885148ef85ced1576048c7c33fb861f7cd8e9b62e13013330",
+		},
+		{
+			name:        "length 58 valid",
+			key:         "7b69f67be885148ef85ced1576048c7c33fb861f7cd8e9b62e13013330",
+			expectedErr: "invalid length, need 256 bits",
+		},
+		{
+			name:        "length 66 valid",
+			key:         "c7c33fb07b69f67be885148ef85ced1576048c7c33fb861f7cd8e9b62e13013330",
+			expectedErr: "invalid length, need 256 bits",
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			key, err := hexToECDSA(tc.key)
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				require.EqualError(t, err, tc.expectedErr)
+			} else {
+				keyHex := hex.EncodeToString(key.D.Bytes())
+				require.Equal(t, tc.key, keyHex)
+			}
+		})
+	}
 }
 
 func newTestServer(t *testing.T, staticNodes []string) (*Server, func()) {


### PR DESCRIPTION
This PR 0-pads the node key hex string if the length is 60 or 62 so that it can be decoded

See https://xmtp-labs.slack.com/archives/C02BABHFZG9/p1659028743218069 for more context

This is arguably worthy of a go-ethereum PR too, but we'll add our logic in here in the meantime