### PR TITLE
Fix server shutdown when store metrics enabled

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -202,8 +202,6 @@ func (server *Server) WaitForShutdown() {
 func (server *Server) Shutdown() {
 	server.logger.Info("shutting down...")
 
-	server.cancel()
-
 	// shut the node down
 	server.wakuNode.Stop()
 
@@ -225,8 +223,11 @@ func (server *Server) Shutdown() {
 		server.grpc.Close()
 	}
 
+	// Cancel outstanding goroutines
+	server.cancel()
 	server.wg.Wait()
 	server.logger.Info("shutdown complete")
+
 }
 
 func (server *Server) staticNodesConnectLoop(staticNodes []string) {


### PR DESCRIPTION
The server isn't cleanly shutting down when the store metrics/stats loop is running, and just hanging instead. This PR updates `TestServer_NewShutdown` to reproduce the issue, and fixes it by moving the context cancel earlier in `Shutdown`. Possibly a contributor to https://github.com/xmtp/xmtp-node-go/issues/88.