### PR TITLE
go test -v for junit test reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           export GOPATH="${HOME}/go/"
           export PATH="${PATH}:${GOPATH}/bin"
           go install github.com/jstemmer/go-junit-report/v2@latest
-          go test ./... | go-junit-report -set-exit-code -iocopy -out report.xml
+          go test -v ./... | go-junit-report -set-exit-code -iocopy -out report.xml
       - uses: datadog/junit-upload-github-action@v1
         with:
             api-key: ${{ secrets.DD_API_KEY }}


### PR DESCRIPTION
I think this is why we're not seeing test runs for this repo in datadog https://github.com/jstemmer/go-junit-report
> go-junit-report reads go test -v output

I originally had `-v` included but removed it before merging the PR so that's why we see some older tests there, and nothing since then.