### PR TITLE
Run e2e tests against local docker nodes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 README.md
 dev/docker/*
+dev/e2e/docker/*
 dev/e2e/Dockerfile
 dev/e2e/build
 dev/e2e/run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           go-version-file: go.mod
       - run: dev/docker/up
+      - run: dev/e2e/docker/up
       - name: Run Tests
         run: |
           export GOPATH="${HOME}/go/"

--- a/dev/e2e/docker/compose
+++ b/dev/e2e/docker/compose
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+. dev/e2e/docker/env
+
+docker_compose "$@"

--- a/dev/e2e/docker/docker-compose.yml
+++ b/dev/e2e/docker/docker-compose.yml
@@ -1,0 +1,92 @@
+services:
+  nodes:
+    image: nginx
+    ports:
+      - 8000:80
+    volumes:
+      - ./nodes:/usr/share/nginx/html
+  db:
+    image: postgres:13
+    environment:
+      POSTGRES_PASSWORD: xmtp
+  node1:
+    build:
+      context: ../../../
+      dockerfile: dev/docker/Dockerfile
+      args:
+        - GO_VERSION=${GO_VERSION}
+    ports:
+      - 16001:6001
+    command:
+    - --store
+    - --metrics
+    - --metrics-address=0.0.0.0
+    - --ws
+    - --ws-port=6001
+    - --port=6000
+    - --lightpush
+    - --filter
+    - --log-encoding=json
+    - --wait-for-db=10s
+    - --static-node=/dns4/node2/tcp/6000/p2p/16Uiu2HAmPexvM9XDgoac3i3V4PHGHpk11ZoYpNjG5TsuGfeQy79R
+    - --static-node=/dns4/node3/tcp/6000/p2p/16Uiu2HAmRFvBjrt91Xcyi9QVz9mH7G2D1wrDifa3Z2C8azGr3edr
+    environment:
+      ENV: dev
+      GOLOG_LOG_FMT: json
+      MESSAGE_DB_CONNECTION_STRING: postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
+      AUTHZ_DB_CONNECTION_STRING: postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
+      GOWAKU-NODEKEY: 8a30dcb604b0b53627a5adc054dbf434b446628d4bd1eccc681d223f0550ce67
+  node2:
+    build:
+      context: ../../../
+      dockerfile: dev/docker/Dockerfile
+      args:
+        - GO_VERSION=${GO_VERSION}
+    ports:
+      - 26001:6001
+    command:
+    - --store
+    - --metrics
+    - --metrics-address=0.0.0.0
+    - --ws
+    - --ws-port=6001
+    - --port=6000
+    - --lightpush
+    - --filter
+    - --log-encoding=json
+    - --wait-for-db=10s
+    - --static-node=/dns4/node1/tcp/6000/p2p/16Uiu2HAmNCxLZCkXNbpVPBpSSnHj9iq4HZQj7fxRzw2kj1kKSHHA
+    - --static-node=/dns4/node3/tcp/6000/p2p/16Uiu2HAmRFvBjrt91Xcyi9QVz9mH7G2D1wrDifa3Z2C8azGr3edr
+    environment:
+      ENV: dev
+      GOLOG_LOG_FMT: json
+      MESSAGE_DB_CONNECTION_STRING: postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
+      AUTHZ_DB_CONNECTION_STRING: postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
+      GOWAKU-NODEKEY: 5757057f3daac3fa80e43a06d24edf15fcaba11eb16ede5fd53b78ba68ef1436
+  node3:
+    build:
+      context: ../../../
+      dockerfile: dev/docker/Dockerfile
+      args:
+        - GO_VERSION=${GO_VERSION}
+    ports:
+      - 36001:6001
+    command:
+    - --store
+    - --metrics
+    - --metrics-address=0.0.0.0
+    - --ws
+    - --ws-port=6001
+    - --port=6000
+    - --lightpush
+    - --filter
+    - --log-encoding=json
+    - --wait-for-db=10s
+    - --static-node=/dns4/node1/tcp/6000/p2p/16Uiu2HAmNCxLZCkXNbpVPBpSSnHj9iq4HZQj7fxRzw2kj1kKSHHA
+    - --static-node=/dns4/node2/tcp/6000/p2p/16Uiu2HAmPexvM9XDgoac3i3V4PHGHpk11ZoYpNjG5TsuGfeQy79R
+    environment:
+      ENV: dev
+      GOLOG_LOG_FMT: json
+      MESSAGE_DB_CONNECTION_STRING: postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
+      AUTHZ_DB_CONNECTION_STRING: postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
+      GOWAKU-NODEKEY: f643b771ad9e1bc9519d4dc754370c4ff32dd7a9f76f6026b5a6448289212fd7

--- a/dev/e2e/docker/down
+++ b/dev/e2e/docker/down
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -e
+. dev/e2e/docker/env
+
+docker_compose down

--- a/dev/e2e/docker/env
+++ b/dev/e2e/docker/env
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+function docker_compose() {
+  docker-compose -f dev/e2e/docker/docker-compose.yml -p xmtpd-e2e "$@"
+}

--- a/dev/e2e/docker/nodes/index.html
+++ b/dev/e2e/docker/nodes/index.html
@@ -1,0 +1,7 @@
+{
+    "local": {
+        "node1": "/ip4/127.0.0.1/tcp/16001/ws/p2p/16Uiu2HAmNCxLZCkXNbpVPBpSSnHj9iq4HZQj7fxRzw2kj1kKSHHA",
+        "node2": "/ip4/127.0.0.1/tcp/26001/ws/p2p/16Uiu2HAmPexvM9XDgoac3i3V4PHGHpk11ZoYpNjG5TsuGfeQy79R",
+        "node3": "/ip4/127.0.0.1/tcp/36001/ws/p2p/16Uiu2HAmRFvBjrt91Xcyi9QVz9mH7G2D1wrDifa3Z2C8azGr3edr"
+    }
+}

--- a/dev/e2e/docker/up
+++ b/dev/e2e/docker/up
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+. dev/e2e/docker/env
+
+export GO_VERSION="$(go list -f "{{.GoVersion}}" -m)"
+
+docker_compose build
+docker_compose up -d

--- a/dev/e2e/run
+++ b/dev/e2e/run
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -e
 
-export XMTPD_E2E_ENV="$1"
+export XMTPD_E2E_ENV="${1:-local}"
 export E2E="yes"
 
 go clean -testcache

--- a/dev/up
+++ b/dev/up
@@ -24,3 +24,4 @@ if ! which protolint &>/dev/null; then go install github.com/yoheimuta/protolint
 
 dev/generate
 dev/docker/up
+dev/e2e/docker/up

--- a/go.mod
+++ b/go.mod
@@ -12,13 +12,11 @@ require (
 	github.com/hashicorp/go-tfe v1.2.0
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
 	github.com/huandu/go-sqlbuilder v1.13.0
-	github.com/ipfs/go-ds-leveldb v0.5.0
 	github.com/ipfs/go-log v1.0.5
 	github.com/jarcoal/httpmock v1.2.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/libp2p/go-libp2p v0.20.3
 	github.com/libp2p/go-libp2p-core v0.16.1
-	github.com/libp2p/go-libp2p-peerstore v0.6.0
 	github.com/libp2p/go-libp2p-pubsub v0.7.1
 	github.com/libp2p/go-msgio v0.2.0
 	github.com/mattn/go-sqlite3 v1.14.13
@@ -96,12 +94,10 @@ require (
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/huin/goupnp v1.0.3 // indirect
 	github.com/ipfs/go-cid v0.1.0 // indirect
-	github.com/ipfs/go-datastore v0.5.1 // indirect
 	github.com/ipfs/go-ipfs-util v0.0.2 // indirect
 	github.com/ipfs/go-log/v2 v2.5.1 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
-	github.com/jbenet/goprocess v0.1.4 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.15.1 // indirect
@@ -113,6 +109,7 @@ require (
 	github.com/libp2p/go-flow-metrics v0.0.3 // indirect
 	github.com/libp2p/go-libp2p-asn-util v0.2.0 // indirect
 	github.com/libp2p/go-libp2p-discovery v0.6.0 // indirect
+	github.com/libp2p/go-libp2p-peerstore v0.6.0 // indirect
 	github.com/libp2p/go-libp2p-resource-manager v0.3.0 // indirect
 	github.com/libp2p/go-mplex v0.7.0 // indirect
 	github.com/libp2p/go-nat v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,7 +66,6 @@ dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=
-github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 h1:cTp8I5+VIoKjsnZuH8vjyaysT/ses3EvZeaV/1UkF2M=
 github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2/go.mod h1:4rQ/NZncSvGqNkkOsNpOU1tgoNuIlp9AfUH5G1tvCHc=
@@ -497,7 +496,6 @@ github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc/go.mod h1:xb
 github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/denisenkom/go-mssqldb v0.11.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
-github.com/dgraph-io/badger v1.6.2 h1:mNw0qs90GVgGGWylh0umH5iag1j6n/PeJtNvL6KY/x8=
 github.com/dgraph-io/badger v1.6.2/go.mod h1:JW2yswe3V058sS0kZ2h/AXeDSqFjxnZcRrVH//y2UQE=
 github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=
@@ -1015,13 +1013,9 @@ github.com/ipfs/go-cid v0.0.7/go.mod h1:6Ux9z5e+HpkQdckYoX1PG/6xqKspzlEIR5SDmgqg
 github.com/ipfs/go-cid v0.1.0 h1:YN33LQulcRHjfom/i25yoOZR4Telp1Hr/2RU3d0PnC0=
 github.com/ipfs/go-cid v0.1.0/go.mod h1:rH5/Xv83Rfy8Rw6xG+id3DYAMUVmem1MowoKwdXmN2o=
 github.com/ipfs/go-datastore v0.5.0/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh73hakZ90Bk=
-github.com/ipfs/go-datastore v0.5.1 h1:WkRhLuISI+XPD0uk3OskB0fYFSyqK8Ob5ZYew9Qa1nQ=
-github.com/ipfs/go-datastore v0.5.1/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh73hakZ90Bk=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
 github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46UU0LZ723meps=
-github.com/ipfs/go-ds-badger v0.3.0 h1:xREL3V0EH9S219kFFueOYJJTcjgNSZ2HY1iSvN7U1Ro=
 github.com/ipfs/go-ds-badger v0.3.0/go.mod h1:1ke6mXNqeV8K3y5Ak2bAA0osoTfmxUdupVCGm4QUIek=
-github.com/ipfs/go-ds-leveldb v0.5.0 h1:s++MEBbD3ZKc9/8/njrn4flZLnCuY9I79v94gBUNumo=
 github.com/ipfs/go-ds-leveldb v0.5.0/go.mod h1:d3XG9RUDzQ6V4SHi8+Xgj9j1XuEk1z82lquxrVbml/Q=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-ipfs-util v0.0.2 h1:59Sswnk1MFaiq+VcaknX7aYEyGyGDAA73ilhEK2POp8=
@@ -1106,7 +1100,6 @@ github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5D
 github.com/jbenet/go-temp-err-catcher v0.1.0 h1:zpb3ZH6wIE8Shj2sKS+khgRvf7T7RABoLk/+KKHggpk=
 github.com/jbenet/go-temp-err-catcher v0.1.0/go.mod h1:0kJRvmDZXNMIiJirNPEYfhpPwbGVtZVWC34vc5WLsDk=
 github.com/jbenet/goprocess v0.1.3/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZlqdZVfqY4=
-github.com/jbenet/goprocess v0.1.4 h1:DRGOFReOMqqDNXwW70QkacFW0YN9QnwLV0Vqk+3oU0o=
 github.com/jbenet/goprocess v0.1.4/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZlqdZVfqY4=
 github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e/go.mod h1:G1CVv03EnqU1wYL2dFwXxW2An0az9JTl/ZsqXQeBlkU=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=

--- a/pkg/e2e/e2e_test.go
+++ b/pkg/e2e/e2e_test.go
@@ -22,9 +22,14 @@ import (
 	_ "net/http/pprof"
 )
 
+const (
+	localNetworkEnv = "local"
+	localNodesURL   = "http://localhost:8000"
+)
+
 var (
 	envShouldRunE2ETestsContinuously = envVarBool("E2E_CONTINUOUS")
-	envNetworkEnv                    = envVar("XMTPD_E2E_ENV", "dev")
+	envNetworkEnv                    = envVar("XMTPD_E2E_ENV", localNetworkEnv)
 	envBootstrapAddrs                = envVarStrings("XMTPD_E2E_BOOTSTRAP_ADDRS")
 	envNodesURL                      = envVar("XMTPD_E2E_NODES_URL", "https://nodes.xmtp.com")
 	envDelayBetweenRunsSeconds       = envVarInt("XMTPD_E2E_DELAY", 5)
@@ -36,6 +41,9 @@ func TestE2E(t *testing.T) {
 		go func() {
 			log.Println(http.ListenAndServe("localhost:6060", nil))
 		}()
+	}
+	if envNetworkEnv == localNetworkEnv {
+		envNodesURL = localNodesURL
 	}
 	withMetricsServer(t, ctx, func(t *testing.T) {
 		for {


### PR DESCRIPTION
This PR updates e2e tests to run against 3 local docker-based nodes in CI and as the default if no env is given, with the intention being to catch failures against this more prod-like setup before merges. 

It also reverts https://github.com/xmtp/xmtp-node-go/pull/107

The local docker-based e2e tests are 🟢 on this branch, so it's still not clear why we saw e2e failures against dev/prod when it was deployed yesterday, but at this point I think I need to deploy it again to figure out if it's still an issue or if it was just an issue with the way that specific deploy went out, because I haven't been able to reproduce it. Alternatively I could spin up a new cluster/env via tf for testing/debugging this, but I'm not sure we have to go that far just yet. Other suggestions welcome.

https://github.com/xmtp/xmtp-node-go/issues/83