### PR TITLE
Revert back to go-libp2p-pubsub 0.6.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ipfs/go-log v1.0.5
 	github.com/jarcoal/httpmock v1.2.0
 	github.com/jessevdk/go-flags v1.4.0
-	github.com/libp2p/go-libp2p v0.20.3
+	github.com/libp2p/go-libp2p v0.20.2
 	github.com/libp2p/go-libp2p-core v0.16.1
 	github.com/libp2p/go-libp2p-pubsub v0.6.1
 	github.com/libp2p/go-msgio v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1227,8 +1227,8 @@ github.com/libp2p/go-eventbus v0.2.1/go.mod h1:jc2S4SoEVPP48H9Wpzm5aiGwUCBMfGhVh
 github.com/libp2p/go-flow-metrics v0.0.1/go.mod h1:Iv1GH0sG8DtYN3SVJ2eG221wMiNpZxBdp967ls1g+k8=
 github.com/libp2p/go-flow-metrics v0.0.3 h1:8tAs/hSdNvUiLgtlSy3mxwxWP4I9y/jlkPFT7epKdeM=
 github.com/libp2p/go-flow-metrics v0.0.3/go.mod h1:HeoSNUrOJVK1jEpDqVEiUOIXqhbnS27omG0uWU5slZs=
-github.com/libp2p/go-libp2p v0.20.3 h1:tjjDNfp7FqdI/7v1rXtB/BtELaPlAThL2uzlj18kcrw=
-github.com/libp2p/go-libp2p v0.20.3/go.mod h1:I+vndVanE/p/SjFbnA+BEmmfAUEpWxrdXZeyQ1Dus5c=
+github.com/libp2p/go-libp2p v0.20.2 h1:uPCbLjx1VIGt4noOoGsSQKsoUqd+WwOq0IeFbrAThXM=
+github.com/libp2p/go-libp2p v0.20.2/go.mod h1:heAEqZPMOagd26sado6/P4ifArxkUe9uV8PGrTn9K2k=
 github.com/libp2p/go-libp2p-asn-util v0.2.0 h1:rg3+Os8jbnO5DxkC7K/Utdi+DkY3q/d1/1q+8WeNAsw=
 github.com/libp2p/go-libp2p-asn-util v0.2.0/go.mod h1:WoaWxbHKBymSN41hWSq/lGKJEca7TNm58+gGJi2WsLI=
 github.com/libp2p/go-libp2p-blankhost v0.2.0/go.mod h1:eduNKXGTioTuQAUcZ5epXi9vMl+t4d8ugUBRQ4SqaNQ=


### PR DESCRIPTION
It seems that after https://github.com/xmtp/xmtp-node-go/pull/106 there's an issue with pubsub between the nodes. E2E tests were failing on the subscribe response check, not getting the other node messages. I'm not sure how these go-libp2p dependencies got updated in the original PR but this PR reverts them back to what they were before in an attempt to fix this issue. Note that the issue isn't showing on the local docker e2e test when using the same node code. If it doesn't work I'll PR another revert of the go-waku update and go back to trying to reproduce in an isolated env.