### PR TITLE
Update actions/setup-go@v2 to actions/setup-go@v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod

--- a/.github/workflows/deploy-e2e.yml
+++ b/.github/workflows/deploy-e2e.yml
@@ -18,7 +18,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Git Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - uses: actions/setup-go@v3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Git Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - uses: actions/setup-go@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: shellcheck
         run: |
           sudo apt-get -y install tree

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod


### PR DESCRIPTION
We're seeing this warning in GH actions because `go-version-file` is only available in `actions/setup-go@v3` (not v2):
> Unexpected input(s) 'go-version-file'

So this PR updates all v2 references to be v3, and also updates all `actions/checkout@v{1,2}` references to latest (v3) as well.