### PR TITLE
Wait for node connection in dev/e2e/docker/up

### DIFF
--- a/dev/e2e/docker/up
+++ b/dev/e2e/docker/up
@@ -6,3 +6,7 @@ export GO_VERSION="$(go list -f "{{.GoVersion}}" -m)"
 
 docker_compose build
 docker_compose up -d
+
+while ! echo exit | nc localhost 16001 &>/dev/null; do sleep 1; done
+while ! echo exit | nc localhost 26001 &>/dev/null; do sleep 1; done
+while ! echo exit | nc localhost 36001 &>/dev/null; do sleep 1; done


### PR DESCRIPTION
We're seeing the e2e test fail sometimes in CI because it's racing startup of the docker nodes, so this PR updates `dev/e2e/docker/up` to wait for node connectivity via `nc`.

Example failure: https://github.com/xmtp/xmtp-node-go/runs/7880459226
> dial tcp 127.0.0.1:36001: connect: connection refused