### PR TITLE
Enable GRPC handling time histogram

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -68,6 +68,7 @@ func (s *Server) startGRPC() error {
 		return errors.Wrap(err, "creating grpc listener")
 	}
 
+	prometheus.EnableHandlingTimeHistogram()
 	unary := []grpc.UnaryServerInterceptor{prometheus.UnaryServerInterceptor}
 	stream := []grpc.StreamServerInterceptor{prometheus.StreamServerInterceptor}
 	if s.Config.Authn.Enable {


### PR DESCRIPTION
The default metric setup has just counters, which is a bit anemic. [The docs](https://github.com/grpc-ecosystem/go-grpc-prometheus#histograms) warn that histogram can be expensive, but I don't think we want to make do without histograms altogether. So let's give it a try and see.