### PR TITLE
Clean up e2e query expectation failure logging

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -273,7 +272,8 @@ func expectQueryMessagesEventually(log *zap.Logger, n *wakunode.WakuNode, peerAd
 			break
 		}
 		if time.Since(started) > timeout {
-			return errors.New("timeout")
+			diff := cmp.Diff(msgs, expectedMsgs, cmpopts.SortSlices(wakuMessagesLessFn))
+			return fmt.Errorf("timeout waiting for query expectation, diff: %s", diff)
 		}
 		time.Sleep(delay)
 	}


### PR DESCRIPTION
Update this failure logging to be a little more verbose/helpful, and match the logging we do for the subscribe expectation failure.

https://github.com/xmtp/xmtp-node-go/issues/88