### PR TITLE
Deflake e2e random topics

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"math/rand"
 	"time"
 
 	"github.com/xmtp/xmtp-node-go/pkg/api"
@@ -12,8 +13,9 @@ import (
 )
 
 type Suite struct {
-	ctx context.Context
-	log *zap.Logger
+	ctx  context.Context
+	log  *zap.Logger
+	rand *rand.Rand
 
 	config *Config
 }
@@ -39,6 +41,7 @@ func NewSuite(ctx context.Context, log *zap.Logger, config *Config) *Suite {
 	e := &Suite{
 		ctx:    ctx,
 		log:    log,
+		rand:   rand.New(rand.NewSource(time.Now().UTC().UnixNano())),
 		config: config,
 	}
 	return e
@@ -57,6 +60,16 @@ func (s *Suite) newTest(name string, runFn testRunFunc) *Test {
 		Run:  runFn,
 	}
 }
+
+func (s *Suite) randomStringLower(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[s.rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz1234567890")
 
 func withAuth(ctx context.Context) (context.Context, error) {
 	token, _, err := api.GenerateToken(time.Now())

--- a/pkg/e2e/test_messagev1.go
+++ b/pkg/e2e/test_messagev1.go
@@ -28,7 +28,7 @@ func (s *Suite) testMessageV1PublishSubscribeQuery(log *zap.Logger) error {
 		defer clients[i].Close()
 	}
 
-	contentTopic := "test-" + randomStringLower(12)
+	contentTopic := "test-" + s.randomStringLower(12)
 
 	ctx, err := withAuth(ctx)
 	if err != nil {

--- a/pkg/e2e/test_waku.go
+++ b/pkg/e2e/test_waku.go
@@ -51,7 +51,7 @@ func (s *Suite) testWakuPublishSubscribeQuery(log *zap.Logger) error {
 	time.Sleep(500 * time.Millisecond)
 
 	// Subscribe to a topic on each client, connected to each node.
-	contentTopic := "test-" + randomStringLower(12)
+	contentTopic := "test-" + s.randomStringLower(12)
 	envCs := make([]chan *wakuprotocol.Envelope, len(clients))
 	for i, c := range clients {
 		var err error

--- a/pkg/e2e/waku.go
+++ b/pkg/e2e/waku.go
@@ -6,7 +6,6 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"net"
 	"net/http"
 	"time"
@@ -107,16 +106,6 @@ func wakuConnectWithAddr(ctx context.Context, n *wakunode.WakuNode, addr string)
 	time.Sleep(100 * time.Millisecond)
 
 	return nil
-}
-
-var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz1234567890")
-
-func randomStringLower(n int) string {
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
-	}
-	return string(b)
 }
 
 func wakuSubscribeTo(ctx context.Context, n *wakunode.WakuNode, contentTopics []string) (chan *wakuprotocol.Envelope, error) {


### PR DESCRIPTION
We're [seeing](https://app.datadoghq.com/dashboard/ask-2bf-idz/xmtpd-e2e?fullscreen_end_ts=1662580691463&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1662577091463&fullscreen_widget=694164414171040&from_ts=1662569821830&to_ts=1662573421830&live=true) sporadic e2e test failures in dev/prod, and I'm able to reproduce locally. 

Sometimes it looks like [this](https://app.datadoghq.com/logs?query=service%3Axmtpd-e2e%20status%3Aerror&cols=host%2Cservice&event=AQAAAYMZAl4L6uvBHwAAAABBWU1aQWwtYUFBQWNHZXFScDIzRkdBQUE&index=%2A&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1662571125044&to_ts=1662572025044&live=true) (from messagev1 tests):
```
expected equal, diff:   []*v1.Envelope(Inverse(cmpopts.SortSlices, []*v1.Envelope{
- 	s`content_topic:"test-tsmjv" timestamp_ns:1 message:"msg1"`,
  	s`content_topic:"test-tsmjv" timestamp_ns:1 message:"msg1-1"`,
  	s`content_topic:"test-tsmjv" timestamp_ns:1 message:"msg2-1"`,
  	... // 2 identical elements
  	s`content_topic:"test-tsmjv" timestamp_ns:1 message:"msg5-1"`,
  	s`content_topic:"test-tsmjv" timestamp_ns:2 message:"msg1-2"`,
- 	s`content_topic:"test-tsmjv" timestamp_ns:2 message:"msg2"`,
  	s`content_topic:"test-tsmjv" timestamp_ns:2 message:"msg2-2"`,
  	s`content_topic:"test-tsmjv" timestamp_ns:2 message:"msg3-2"`,
  	... // 2 identical elements
  	s`content_topic:"test-tsmjv" timestamp_ns:3 message:"msg1-3"`,
  	s`content_topic:"test-tsmjv" timestamp_ns:3 message:"msg2-3"`,
- 	s`content_topic:"test-tsmjv" timestamp_ns:3 message:"msg3"`,
  	s`content_topic:"test-tsmjv" timestamp_ns:3 message:"msg3-3"`,
  	s`content_topic:"test-tsmjv" timestamp_ns:3 message:"msg4-3"`,
  	s`content_topic:"test-tsmjv" timestamp_ns:3 message:"msg5-3"`,
  }))
```

And sometimes like this (from waku tests):
```
timeout waiting for query expectation, diff:   []*pb.WakuMessage(Inverse(cmpopts.SortSlices, []*pb.WakuMessage{
  	&{Payload: "msg1", ContentTopic: "test-diwpe", Timestamp: 1},
- 	s`payload:"msg1-1" contentTopic:"test-diwpe" timestamp:1 `,
- 	s`payload:"msg2-1" contentTopic:"test-diwpe" timestamp:1 `,
- 	s`payload:"msg3-1" contentTopic:"test-diwpe" timestamp:1 `,
- 	s`payload:"msg4-1" contentTopic:"test-diwpe" timestamp:1 `,
- 	s`payload:"msg5-1" contentTopic:"test-diwpe" timestamp:1 `,
- 	s`payload:"msg1-2" contentTopic:"test-diwpe" timestamp:2 `,
  	&{Payload: "msg2", ContentTopic: "test-diwpe", Timestamp: 2},
- 	s`payload:"msg2-2" contentTopic:"test-diwpe" timestamp:2 `,
- 	s`payload:"msg3-2" contentTopic:"test-diwpe" timestamp:2 `,
- 	s`payload:"msg4-2" contentTopic:"test-diwpe" timestamp:2 `,
- 	s`payload:"msg5-2" contentTopic:"test-diwpe" timestamp:2 `,
- 	s`payload:"msg1-3" contentTopic:"test-diwpe" timestamp:3 `,
- 	s`payload:"msg2-3" contentTopic:"test-diwpe" timestamp:3 `,
  	&{Payload: "msg3", ContentTopic: "test-diwpe", Timestamp: 3},
- 	s`payload:"msg3-3" contentTopic:"test-diwpe" timestamp:3 `,
- 	s`payload:"msg4-3" contentTopic:"test-diwpe" timestamp:3 `,
- 	s`payload:"msg5-3" contentTopic:"test-diwpe" timestamp:3 `,
  }))
```

Notice that different message payload/content value formats in the diffs. One (`msg1-1`) is from messagev1 tests, and the other (`msg1`) is from waku tests. They seem to be using the same topics sometimes.

https://github.com/xmtp-labs/hq/issues/663