### PR TITLE
Mitigate subscribe-publish race

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/yoheimuta/protolint v0.39.0
 	go.opencensus.io v0.23.0
 	go.uber.org/zap v1.21.0
+	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29
 	google.golang.org/grpc v1.48.0
 	google.golang.org/protobuf v1.28.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.40.1
@@ -176,7 +177,6 @@ require (
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57 // indirect
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
-	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 // indirect
 	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65 // indirect

--- a/pkg/api/message/v1/client/grpc_client.go
+++ b/pkg/api/message/v1/client/grpc_client.go
@@ -2,9 +2,13 @@ package client
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	"github.com/pkg/errors"
 	messagev1 "github.com/xmtp/proto/go/message_api/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 )
 
 type grpcClient struct {
@@ -27,15 +31,28 @@ func (c *grpcClient) Close() error {
 
 func (c *grpcClient) Subscribe(ctx context.Context, r *messagev1.SubscribeRequest) (Stream, error) {
 	ctx, cancel := context.WithCancel(ctx)
-	stream, err := c.grpc.Subscribe(ctx, r)
+	sub, err := c.grpc.Subscribe(ctx, r)
 	if err != nil {
 		cancel()
 		return nil, err
 	}
-	return &grpcStream{
+	stream := &grpcStream{
 		cancel: cancel,
-		stream: stream,
-	}, nil
+		stream: sub,
+	}
+
+	// Wait for confirmation of the subscription.
+	ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
+	env, err := stream.Next(ctx)
+	cancel()
+	if err != nil {
+		return nil, errors.Wrap(err, "waiting for subscribe confirmation")
+	}
+	if !proto.Equal(env, &messagev1.Envelope{}) {
+		return nil, fmt.Errorf("expected empty env as subscribe confirmation, got: %s", env)
+	}
+
+	return stream, nil
 }
 
 func (c *grpcClient) Publish(ctx context.Context, r *messagev1.PublishRequest) (*messagev1.PublishResponse, error) {

--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -99,6 +99,12 @@ func (s *Service) Subscribe(req *proto.SubscribeRequest, stream proto.MessageApi
 	subC := s.dispatcher.Register(req.ContentTopics...)
 	defer s.dispatcher.Unregister(subC, req.ContentTopics...)
 
+	// Send confirmation of the subscription.
+	err := stream.Send(&proto.Envelope{})
+	if err != nil {
+		return err
+	}
+
 	for {
 		select {
 		case <-stream.Context().Done():

--- a/pkg/e2e/test_messagev1.go
+++ b/pkg/e2e/test_messagev1.go
@@ -49,7 +49,6 @@ func (s *Suite) testMessageV1PublishSubscribeQuery(log *zap.Logger) error {
 		streams[i] = stream
 		defer stream.Close()
 	}
-	time.Sleep(500 * time.Millisecond)
 
 	// Publish messages.
 	envs := make([]*messagev1.Envelope, 0, clientCount*1)


### PR DESCRIPTION
We're [seeing](https://app.datadoghq.com/logs?query=service%3Axmtpd-e2e%20status%3Aerror&cols=host%2Cservice&event=AQAAAYMhu-68wQGfSAAAAABBWU1odV9DakFBRElqVE9tZG1FVnhBQUE&index=%2A&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1662634272787&to_ts=1662720672787&live=true) a few more sporadic e2e test failures. They seem to look like this (from the subscribe expectation check):
```
expected equal, diff:   []*v1.Envelope(Inverse(cmpopts.SortSlices, []*v1.Envelope{
- 	s`content_topic:"test-yy1f8nf4bko5" timestamp_ns:1 message:"msg1-1"`,
- 	s`content_topic:"test-yy1f8nf4bko5" timestamp_ns:1 message:"msg2-1"`,
  	s`content_topic:"test-yy1f8nf4bko5" timestamp_ns:1 message:"msg3-1"`,
  	s`content_topic:"test-yy1f8nf4bko5" timestamp_ns:1 message:"msg4-1"`,
  	s`content_topic:"test-yy1f8nf4bko5" timestamp_ns:1 message:"msg5-1"`,
- 	s`content_topic:"test-yy1f8nf4bko5" timestamp_ns:2 message:"msg1-2"`,
- 	s`content_topic:"test-yy1f8nf4bko5" timestamp_ns:2 message:"msg2-2"`,
  	s`content_topic:"test-yy1f8nf4bko5" timestamp_ns:2 message:"msg3-2"`,
  	s`content_topic:"test-yy1f8nf4bko5" timestamp_ns:2 message:"msg4-2"`,
  	s`content_topic:"test-yy1f8nf4bko5" timestamp_ns:2 message:"msg5-2"`,
- 	s`content_topic:"test-yy1f8nf4bko5" timestamp_ns:3 message:"msg1-3"`,
- 	s`content_topic:"test-yy1f8nf4bko5" timestamp_ns:3 message:"msg2-3"`,
  	s`content_topic:"test-yy1f8nf4bko5" timestamp_ns:3 message:"msg3-3"`,
  	s`content_topic:"test-yy1f8nf4bko5" timestamp_ns:3 message:"msg4-3"`,
  	s`content_topic:"test-yy1f8nf4bko5" timestamp_ns:3 message:"msg5-3"`,
  }))
```

I'm able to reproduce similar behaviour locally by removing/reducing the `time.Sleep` delay that happens after subscribing via the set of clients, before publishing messages. It looks like what's happening is that the subscription on the node-side isn't fully set up before the client starts publishing messages. I can see this in the logs too.

This PR mitigates it by having the node send an initial empty env as confirmation of the subscription, and having the client wait for that confirmation before moving on and publishing. I'm not a huge fan of overloading the purpose of `Envelope` for this, but I wanted to demonstrate the approach before doing something more significant. A proper solution would be to change the subscribe streaming response type from `Envelope` to something like `SubscribeResponse` that can encapsulate both purposes. Both approaches will need a xmtp-js update to expect the confirmation. Alternatively, we could just increase the `time.Sleep` delay in the e2e test and be ok with this race existing for users if they publish too soon after subscribing, which is arguably fine and unlikely to be noticed outside of code like we have in our tests. LMK if you have opinions, this PR is up for demonstration and discussion purposes only at this point.

https://github.com/xmtp/xmtp-node-go/issues/88