### PR TITLE
Increase api max message size

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -22,6 +22,7 @@ type Options struct {
 	HTTPAddress string       `long:"http-address" description:"API HTTP listening address" default:"0.0.0.0"`
 	HTTPPort    uint         `long:"http-port" description:"API HTTP listening port" default:"5555"`
 	Authn       AuthnOptions `group:"API Authentication Options" namespace:"authn"`
+	MaxMsgSize  int          `long:"max-msg-size" description:"Max message size in bytes (default 50MB)" default:"52428800"`
 }
 
 type Config struct {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -89,6 +89,7 @@ func (s *Server) startGRPC() error {
 		grpc.Creds(insecure.NewCredentials()),
 		grpc.UnaryInterceptor(middleware.ChainUnaryServer(unary...)),
 		grpc.StreamInterceptor(middleware.ChainStreamServer(stream...)),
+		grpc.MaxRecvMsgSize(s.Config.Options.MaxMsgSize),
 	}
 	grpcServer := grpc.NewServer(options...)
 
@@ -111,7 +112,6 @@ func (s *Server) startGRPC() error {
 }
 
 func (s *Server) startHTTP() error {
-
 	mux := http.NewServeMux()
 	gwmux := runtime.NewServeMux(
 		runtime.WithErrorHandler(runtime.DefaultHTTPErrorHandler),
@@ -184,6 +184,9 @@ func (s *Server) dialGRPC(ctx context.Context) (*grpc.ClientConn, error) {
 		ctx,
 		dialAddr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(s.Config.Options.MaxMsgSize),
+		),
 	)
 }
 

--- a/pkg/api/setup_test.go
+++ b/pkg/api/setup_test.go
@@ -16,6 +16,10 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+const (
+	testMaxMsgSize = 2 * 1024 * 1024
+)
+
 func newTestServer(t *testing.T) (*Server, func()) {
 	waku, wakuCleanup := newTestNode(t, nil)
 	s, err := New(&Config{
@@ -27,6 +31,7 @@ func newTestServer(t *testing.T) (*Server, func()) {
 			Authn: AuthnOptions{
 				Enable: true,
 			},
+			MaxMsgSize: testMaxMsgSize,
 		},
 		Waku: waku,
 		Log:  test.NewLog(t),


### PR DESCRIPTION
This PR increases grpc max message size default from 4MB to 50MB, for https://github.com/xmtp-labs/hq/issues/684