### PR TITLE
Add missing api requests metric tag keys

### DIFF
--- a/pkg/metrics/api.go
+++ b/pkg/metrics/api.go
@@ -17,9 +17,9 @@ var clientVersionTag, _ = tag.NewKey("client-version")
 var apiRequestsMeasure = stats.Int64("api_requests", "Count api requests by client version", stats.UnitDimensionless)
 
 var apiRequestsView = &view.View{
-	Name:        "xmtp_api_requests_by_client_version",
+	Name:        "xmtp_api_requests",
 	Measure:     apiRequestsMeasure,
-	Description: "Count of api requests by client version",
+	Description: "Count of api requests",
 	Aggregation: view.Count(),
 	TagKeys: []tag.Key{
 		serviceNameTag,


### PR DESCRIPTION
Following up on https://github.com/xmtp/xmtp-node-go/pull/136, this PR adds the missing tag keys in the `apiRequestsView` view definition