### PR TITLE
Fix api requests metric measure

### DIFF
--- a/pkg/metrics/api.go
+++ b/pkg/metrics/api.go
@@ -34,7 +34,7 @@ func EmitAPIRequest(ctx context.Context, serviceName, methodName, clientVersion 
 		tag.Insert(serviceNameTag, serviceName),
 		tag.Insert(methodNameTag, methodName),
 	}
-	err := stats.RecordWithTags(ctx, mutators, apiRequestsMeasure.M(1))
+	err := recordWithTags(ctx, mutators, apiRequestsMeasure.M(1))
 	if err != nil {
 		logging.From(ctx).Warn("recording metric",
 			zap.Error(err),

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -9,7 +9,9 @@ import (
 	v2metrics "github.com/status-im/go-waku/waku/v2/metrics"
 	"github.com/xmtp/xmtp-node-go/pkg/logging"
 	"github.com/xmtp/xmtp-node-go/pkg/tracing"
+	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 	"go.uber.org/zap"
 )
 
@@ -56,4 +58,12 @@ func RegisterViews(logger *zap.Logger) {
 	); err != nil {
 		logger.Fatal("registering metrics views", zap.Error(err))
 	}
+}
+
+func record(ctx context.Context, measurement stats.Measurement) {
+	stats.Record(ctx, measurement)
+}
+
+func recordWithTags(ctx context.Context, mutators []tag.Mutator, measurement stats.Measurement) error {
+	return stats.RecordWithTags(ctx, mutators, measurement)
 }

--- a/pkg/metrics/peers.go
+++ b/pkg/metrics/peers.go
@@ -44,7 +44,9 @@ func EmitPeersByProtocol(ctx context.Context, host host.Host) {
 		}
 	}
 	for proto, count := range byProtocol {
-		if err := stats.RecordWithTags(ctx, []tag.Mutator{tag.Insert(TagProto, proto)}, PeersByProto.M(count)); err != nil {
+		mutators := []tag.Mutator{tag.Insert(TagProto, proto)}
+		err := recordWithTags(ctx, mutators, PeersByProto.M(count))
+		if err != nil {
 			logging.From(ctx).Warn("recording metric", zap.String("metric", PeersByProto.Name()), zap.String("proto", proto), zap.Error(err))
 		}
 	}
@@ -57,5 +59,5 @@ func EmitBootstrapPeersConnected(ctx context.Context, host host.Host, bootstrapP
 			bootstrapPeersFound++
 		}
 	}
-	stats.Record(ctx, BootstrapPeers.M(float64(bootstrapPeersFound)/float64(len(bootstrapPeers))))
+	record(ctx, BootstrapPeers.M(float64(bootstrapPeersFound)/float64(len(bootstrapPeers))))
 }


### PR DESCRIPTION
`RecordWithTags` was missing the measurement argument, which is optional and silently doesn't work if not included.