### PR TITLE
Emit api requests metric with client name tag too

### DIFF
--- a/pkg/api/telemetry.go
+++ b/pkg/api/telemetry.go
@@ -62,12 +62,18 @@ func (ti *TelemetryInterceptor) execute(ctx context.Context, fullMethod string) 
 	if len(vals) > 0 {
 		clientVersion = vals[0]
 	}
+	parts := strings.Split(clientVersion, "/")
+	var clientName string
+	if len(parts) > 0 {
+		clientName = parts[0]
+	}
 	ti.log.Info("api request",
 		zap.String("service", serviceName),
 		zap.String("method", methodName),
+		zap.String("client", clientName),
 		zap.String("client_version", clientVersion),
 	)
-	metrics.EmitAPIRequest(ctx, serviceName, methodName, clientVersion)
+	metrics.EmitAPIRequest(ctx, serviceName, methodName, clientName, clientVersion)
 	return nil
 }
 

--- a/pkg/metrics/api.go
+++ b/pkg/metrics/api.go
@@ -12,6 +12,7 @@ import (
 
 var serviceNameTag, _ = tag.NewKey("service")
 var methodNameTag, _ = tag.NewKey("method")
+var clientNameTag, _ = tag.NewKey("client")
 var clientVersionTag, _ = tag.NewKey("client-version")
 
 var apiRequestsMeasure = stats.Int64("api_requests", "Count api requests by client version", stats.UnitDimensionless)
@@ -24,12 +25,14 @@ var apiRequestsView = &view.View{
 	TagKeys: []tag.Key{
 		serviceNameTag,
 		methodNameTag,
+		clientNameTag,
 		clientVersionTag,
 	},
 }
 
-func EmitAPIRequest(ctx context.Context, serviceName, methodName, clientVersion string) {
+func EmitAPIRequest(ctx context.Context, serviceName, methodName, clientName, clientVersion string) {
 	mutators := []tag.Mutator{
+		tag.Insert(clientNameTag, clientName),
 		tag.Insert(clientVersionTag, clientVersion),
 		tag.Insert(serviceNameTag, serviceName),
 		tag.Insert(methodNameTag, methodName),
@@ -40,6 +43,7 @@ func EmitAPIRequest(ctx context.Context, serviceName, methodName, clientVersion 
 			zap.Error(err),
 			zap.String("service", serviceName),
 			zap.String("method", methodName),
+			zap.String("client", clientName),
 			zap.String("client_version", clientVersion),
 		)
 	}


### PR DESCRIPTION
We've got the api requests metric [in datadog](https://app.datadoghq.com/dashboard/2ui-pi7-dt2/waku-nodes?fullscreen_end_ts=1663860819489&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1663857219489&fullscreen_widget=7708936926128796&from_ts=1663857000972&to_ts=1663860600972&live=true), but after seeing it I realized we're going to need a way to segment the client name part of the client version in our views of it, so this PR adds that tag.

https://github.com/xmtp-labs/hq/issues/660