### PR TITLE
Fix logger reference in signal handler

### DIFF
--- a/cmd/xmtpd/main.go
+++ b/cmd/xmtpd/main.go
@@ -142,7 +142,7 @@ func main() {
 	)
 	select {
 	case sig := <-sigC:
-		utils.Logger().Info("ending on signal", zap.String("signal", sig.String()))
+		log.Info("ending on signal", zap.String("signal", sig.String()))
 	case <-doneC:
 	}
 


### PR DESCRIPTION
This didn't get updated properly in a rebase, and was still using the waku logger.