### PR TITLE
Deploy nodes in 2 groups

### DIFF
--- a/scripts/deploy/nodes/main.go
+++ b/scripts/deploy/nodes/main.go
@@ -77,8 +77,15 @@ func main() {
 		msg = string(out)
 	}
 
-	err = deployer.Deploy("xmtp_node_image", options.ContainerImage, msg)
+	log.Info("deploying group1", zap.String("image", options.ContainerImage))
+	err = deployer.Deploy("xmtp_node_image_group1", options.ContainerImage, msg)
 	if err != nil {
-		log.Fatal("deploying", zap.Error(err))
+		log.Fatal("deploying group1", zap.Error(err))
+	}
+
+	log.Info("deploying group2", zap.String("image", options.ContainerImage))
+	err = deployer.Deploy("xmtp_node_image_group2", options.ContainerImage, msg)
+	if err != nil {
+		log.Fatal("deploying group2", zap.Error(err))
 	}
 }


### PR DESCRIPTION
This PR updates the deployer to deploy to 2 groups via the 2 TFC workspace vars

Will not be merged until after https://github.com/xmtp-labs/infrastructure/pull/114

https://github.com/xmtp-labs/hq/issues/668