### PR TITLE
Increase e2e query expectation timeout

### DIFF
--- a/pkg/e2e/test_messagev1.go
+++ b/pkg/e2e/test_messagev1.go
@@ -173,7 +173,7 @@ func isErrClosedConnection(err error) bool {
 }
 
 func expectQueryMessagesEventually(ctx context.Context, client messageclient.Client, contentTopics []string, expectedEnvs []*messagev1.Envelope) error {
-	timeout := 3 * time.Second
+	timeout := 10 * time.Second
 	delay := 500 * time.Millisecond
 	started := time.Now()
 	for {


### PR DESCRIPTION
This PR increase the e2e query expectation timeout as an attempt to mitigate https://github.com/xmtp/xmtp-node-go/issues/134