### PR TITLE
Make waku e2e test support max 1 instance deployments

### DIFF
--- a/pkg/api/setup_test.go
+++ b/pkg/api/setup_test.go
@@ -107,7 +107,8 @@ func testGRPCAndHTTP(t *testing.T, ctx context.Context, f func(*testing.T, messa
 		server, cleanup := newTestServer(t)
 		defer cleanup()
 
-		client := messageclient.NewHTTPClient(server.httpListenAddr(), "")
+		log := test.NewLog(t)
+		client := messageclient.NewHTTPClient(log, server.httpListenAddr(), "")
 		defer client.Close()
 		f(t, client, server)
 	})

--- a/pkg/e2e/test_messagev1.go
+++ b/pkg/e2e/test_messagev1.go
@@ -22,7 +22,7 @@ func (s *Suite) testMessageV1PublishSubscribeQuery(log *zap.Logger) error {
 	msgsPerClientCount := 3
 	clients := make([]messageclient.Client, clientCount)
 	for i := 0; i < clientCount; i++ {
-		clients[i] = messageclient.NewHTTPClient(s.config.APIURL, s.config.GitCommit)
+		clients[i] = messageclient.NewHTTPClient(s.log, s.config.APIURL, s.config.GitCommit)
 		defer clients[i].Close()
 	}
 

--- a/pkg/e2e/test_waku.go
+++ b/pkg/e2e/test_waku.go
@@ -96,8 +96,8 @@ func (s *Suite) testWakuPublishSubscribeQuery(log *zap.Logger) error {
 	}
 
 	// Expect that they've all been stored on each node.
-	for i, c := range clients {
-		err := wakuExpectQueryMessagesEventually(log, c.node, bootstrapAddrs[i], []string{contentTopic}, msgs)
+	for _, c := range clients {
+		err := wakuExpectQueryMessagesEventually(log, c.node, c.addr, []string{contentTopic}, msgs)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR updates the waku e2e test to support deployments where a node can have maximum of 1 instance running, for https://github.com/xmtp-labs/hq/issues/668 and https://github.com/xmtp-labs/infrastructure/pull/129

It also updates the api client http stream to not panic with "sending to closed channel" when a node is down, which seems to have been happening sometimes while testing it