### PR TITLE
register xmtp_published_envelope metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -55,6 +55,7 @@ func RegisterViews(logger *zap.Logger) {
 		BootstrapPeersView,
 		StoredMessageView,
 		apiRequestsView,
+		publishedEnvelopeView,
 	); err != nil {
 		logger.Fatal("registering metrics views", zap.Error(err))
 	}


### PR DESCRIPTION
In #165 I forgot to register the view, so the new metric doesn't show up in datadog.