### PR TITLE
Set app version in go client

### DIFF
--- a/pkg/api/message/v1/client/http_client.go
+++ b/pkg/api/message/v1/client/http_client.go
@@ -35,10 +35,11 @@ func NewHTTPClient(log *zap.Logger, serverAddr string, gitCommit string, appVers
 		version += gitCommit[:7]
 	}
 	return &httpClient{
-		log:     log,
-		http:    &http.Client{Transport: transport},
-		url:     serverAddr,
-		version: version,
+		log:        log,
+		http:       &http.Client{Transport: transport},
+		url:        serverAddr,
+		version:    version,
+		appVersion: appVersion,
 	}
 }
 


### PR DESCRIPTION
The client constructor isn't setting the `appVersion`, so this PR fixes that.

There's no rush to merge this today, it can wait until after the lens DMs launch, both lenster and our chat app aren't passing through this header yet anyway