### PR TITLE
Log grpc request errors

### DIFF
--- a/pkg/api/telemetry.go
+++ b/pkg/api/telemetry.go
@@ -67,13 +67,12 @@ func (ti *TelemetryInterceptor) record(ctx context.Context, fullMethod string, e
 		zap.String("app_version", appVersion),
 	}
 
-	var errCode string
 	if err != nil {
+		fields = append(fields, zap.Error(err))
 		grpcErr, _ := status.FromError(err)
 		if grpcErr != nil {
 			errCode := grpcErr.Code().String()
 			fields = append(fields, []zapcore.Field{
-				zap.Error(err),
 				zap.String("error_code", errCode),
 				zap.String("error_message", grpcErr.Message()),
 			}...)
@@ -81,7 +80,7 @@ func (ti *TelemetryInterceptor) record(ctx context.Context, fullMethod string, e
 	}
 
 	ti.log.Info("api request", fields...)
-	metrics.EmitAPIRequest(ctx, serviceName, methodName, clientName, clientVersion, appName, appVersion, errCode)
+	metrics.EmitAPIRequest(ctx, fields)
 }
 
 func splitMethodName(fullMethodName string) (serviceName string, methodName string) {


### PR DESCRIPTION
We're seeing a few requests erroring as unauthenticated, but we're returning that error code in a few places, so this PR updates the telemetry interceptor to log more context around errors, and includes the error code on our api request metric.

![Screen Shot 2022-11-03 at 4 10 04 PM](https://user-images.githubusercontent.com/182290/199824060-46b80159-8dd7-4733-a6be-c9e98301fa8a.png)