### PR TITLE
Log client IP with requests

### DIFF
--- a/pkg/api/telemetry.go
+++ b/pkg/api/telemetry.go
@@ -59,6 +59,7 @@ func (ti *TelemetryInterceptor) record(ctx context.Context, fullMethod string, e
 	clientName, _, clientVersion := parseVersionHeaderValue(md.Get(clientVersionMetadataKey))
 	appName, _, appVersion := parseVersionHeaderValue(md.Get(appVersionMetadataKey))
 	fields := []zapcore.Field{
+		zap.Strings("x-forwarded-for", md.Get("x-forwarded-for")),
 		zap.String("service", serviceName),
 		zap.String("method", methodName),
 		zap.String("client", clientName),


### PR DESCRIPTION
Looking at https://github.com/grpc-ecosystem/grpc-gateway/pull/174, the gateway should be passing "X-Forwarded-For" in request metadata 🤞 

We may need to enable the header on the lb https://docs.aws.amazon.com/global-accelerator/latest/dg/preserve-client-ip-address.headers.html