### PR TITLE
log samples of request metadata at regular interval

### DIFF
--- a/pkg/api/telemetry.go
+++ b/pkg/api/telemetry.go
@@ -17,6 +17,10 @@ const (
 	appVersionMetadataKey    = "x-app-version"
 )
 
+var sensitiveHeaders = map[string]bool{
+	authorizationMetadataKey: true,
+}
+
 type TelemetryInterceptor struct {
 	log *zap.Logger
 
@@ -87,7 +91,9 @@ func (ti *TelemetryInterceptor) execute(ctx context.Context, fullMethod string) 
 func (ti *TelemetryInterceptor) logSample(fullMethod string, md metadata.MD) {
 	fields := []zapcore.Field{zap.String("method", fullMethod)}
 	for key, data := range md {
-		fields = append(fields, zap.Strings(key, data))
+		if !sensitiveHeaders[key] {
+			fields = append(fields, zap.Strings(key, data))
+		}
 	}
 	ti.log.Info("request metadata sample", fields...)
 }


### PR DESCRIPTION
Before shipping #170 I want to confirm what is actually coming in the metadata. This PR samples the metadata at 1 minute interval, which should be pretty harmless, so we could just leave it in, or rip it out when we don't care anymore.