### PR TITLE
Lock dispatcher map during Close

### DIFF
--- a/pkg/api/message/v1/dispatcher.go
+++ b/pkg/api/message/v1/dispatcher.go
@@ -71,6 +71,8 @@ func (d *dispatcher) Submit(topic string, obj interface{}) bool {
 }
 
 func (d *dispatcher) Close() error {
+	d.l.Lock()
+	defer d.l.Unlock()
 	for topic, bc := range d.bcs {
 		bc.Close()
 		delete(d.bcs, topic)


### PR DESCRIPTION
I haven't been able to reproduce https://github.com/xmtp/xmtp-node-go/issues/171 locally yet but the output from the failed GH run points to https://github.com/xmtp/xmtp-node-go/blob/main/pkg/api/message/v1/dispatcher.go#L49, and there's only 1 place that we access that map that isn't locked, so this PR adds that. 