### PR TITLE
Fix app version header passthrough

### DIFF
--- a/pkg/api/message/v1/client/http_client.go
+++ b/pkg/api/message/v1/client/http_client.go
@@ -149,7 +149,7 @@ func (c *httpClient) post(ctx context.Context, path string, req interface{}) (*h
 	if clientVersion == "" {
 		post.Header.Set(clientVersionHeaderKey, c.version)
 	}
-	appVersion := post.Header.Get(clientVersionHeaderKey)
+	appVersion := post.Header.Get(appVersionHeaderKey)
 	if appVersion == "" {
 		post.Header.Set(appVersionHeaderKey, c.appVersion)
 	}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -241,6 +241,8 @@ func incomingHeaderMatcher(key string) (string, bool) {
 	switch strings.ToLower(key) {
 	case clientVersionMetadataKey:
 		return key, true
+	case appVersionMetadataKey:
+		return key, true
 	default:
 		return key, false
 	}


### PR DESCRIPTION
- Add to incoming header matcher for the gateway
- Fix header access reference in the go client