### PR TITLE
Log only client IP for realz

### DIFF
--- a/pkg/api/telemetry.go
+++ b/pkg/api/telemetry.go
@@ -67,7 +67,9 @@ func (ti *TelemetryInterceptor) record(ctx context.Context, fullMethod string, e
 		zap.String("app_version", appVersion),
 	}
 	if ips := md.Get("x-forwarded-for"); len(ips) > 0 {
-		fields = append(fields, zap.String("client_ip", ips[0]))
+		// There are potentially multiple comma separated IPs bundled in that first value
+		ips := strings.Split(ips[0], ",")
+		fields = append(fields, zap.String("client_ip", strings.TrimSpace(ips[0])))
 	}
 	if err != nil {
 		fields = append(fields, zap.Error(err))


### PR DESCRIPTION
#175 still doesn't do it, it seems the IPs are packed into a single string instead into multiple header values.

<img width="358" alt="Screen Shot 2022-11-04 at 15 34 28" src="https://user-images.githubusercontent.com/871693/200061439-4bf637fb-cc40-4f04-8ee5-0d9527c43cb0.png">
