### PR TITLE
Use short git sha for e2e app version

### DIFF
--- a/pkg/e2e/test_messagev1.go
+++ b/pkg/e2e/test_messagev1.go
@@ -22,7 +22,11 @@ func (s *Suite) testMessageV1PublishSubscribeQuery(log *zap.Logger) error {
 	msgsPerClientCount := 3
 	clients := make([]messageclient.Client, clientCount)
 	for i := 0; i < clientCount; i++ {
-		clients[i] = messageclient.NewHTTPClient(s.log, s.config.APIURL, s.config.GitCommit, "e2e/"+s.config.GitCommit[:7])
+		appVersion := "xmtp-e2e/"
+		if len(s.config.GitCommit) > 0 {
+			appVersion += s.config.GitCommit[:7]
+		}
+		clients[i] = messageclient.NewHTTPClient(s.log, s.config.APIURL, s.config.GitCommit, appVersion)
 		defer clients[i].Close()
 	}
 


### PR DESCRIPTION
We have app version telemetry now but the e2e app version contains the full git sha instead of just the [:7] version

![Screen Shot 2022-11-04 at 4 43 47 PM](https://user-images.githubusercontent.com/182290/200071524-9c13695c-87bc-4cbc-ab42-7e93507b95b4.png)
