### PR TITLE
Move telemetry interceptor before auth

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -77,6 +77,10 @@ func (s *Server) startGRPC() error {
 	unary := []grpc.UnaryServerInterceptor{prometheus.UnaryServerInterceptor}
 	stream := []grpc.StreamServerInterceptor{prometheus.StreamServerInterceptor}
 
+	telemetryInterceptor := NewTelemetryInterceptor(s.Log)
+	unary = append(unary, telemetryInterceptor.Unary())
+	stream = append(stream, telemetryInterceptor.Stream())
+
 	if s.Config.Authn.Enable {
 		s.authorizer = NewWalletAuthorizer(&AuthnConfig{
 			AuthnOptions: s.Config.Authn,
@@ -87,10 +91,6 @@ func (s *Server) startGRPC() error {
 		unary = append(unary, s.authorizer.Unary())
 		stream = append(stream, s.authorizer.Stream())
 	}
-
-	telemetryInterceptor := NewTelemetryInterceptor(s.Log)
-	unary = append(unary, telemetryInterceptor.Unary())
-	stream = append(stream, telemetryInterceptor.Stream())
 
 	options := []grpc.ServerOption{
 		grpc.Creds(insecure.NewCredentials()),


### PR DESCRIPTION
We're seeing a few `unauthenticated` grpc errors being reported but the logging of it that happens in the telemetry interceptor isn't happening because the auth interceptor is executed before it. So this PR moves the telemetry interceptor to be added before the the auth interceptor.