### PR TITLE
Remove future token timestamp check

### DIFF
--- a/pkg/api/authentication.go
+++ b/pkg/api/authentication.go
@@ -19,7 +19,6 @@ var (
 	TokenExpiration = time.Hour
 
 	ErrTokenExpired         = errors.New("token expired")
-	ErrFutureToken          = errors.New("token timestamp is in the future")
 	ErrInvalidSignature     = errors.New("invalid signature")
 	ErrWalletMismatch       = errors.New("wallet address mismatch")
 	ErrUnsignedKey          = errors.New("identity key is not signed")
@@ -49,12 +48,6 @@ func validateToken(ctx context.Context, log *zap.Logger, token *messagev1.Token,
 
 	// Check expiration
 	created := time.Unix(0, int64(data.CreatedNs))
-
-	// Add some time to the current time to mitigate skew between clients and servers.
-	if created.After(now.Add(20 * time.Minute)) {
-		log.Info("token timestamp is in the future", zap.Time("now", now), zap.Time("created", created))
-		return wallet, ErrFutureToken
-	}
 	if now.Sub(created) > TokenExpiration {
 		return wallet, ErrTokenExpired
 	}


### PR DESCRIPTION
We've been [seeing](https://app.datadoghq.com/logs?query=%22token%20timestamp%20is%20in%20the%20future%22&cols=env%2C%40now%2C%40created&index=%2A&messageDisplay=inline&saved-view-id=1310876&stream_sort=desc&viz=stream&from_ts=1667822987875&to_ts=1667837387875&live=true) some instances of tokens coming in with a timestamp that's 10s to 5m in the future so far. This PR increases our skew acceptance threshold from 5s to 20m.