### PR TITLE
feat: authn - privileged addresses

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -34,9 +34,10 @@ type Config struct {
 
 // Options bundle command line options associated with the authn package.
 type AuthnOptions struct {
-	Enable     bool `long:"enable" description:"require client authentication via wallet tokens"`
-	Ratelimits bool `long:"ratelimits" description:"apply rate limits per wallet"`
-	AllowLists bool `long:"allowlists" description:"apply higher limits for allow listed wallets (requires authz and ratelimits)"`
+	Enable              bool     `long:"enable" description:"require client authentication via wallet tokens"`
+	Ratelimits          bool     `long:"ratelimits" description:"apply rate limits per wallet"`
+	AllowLists          bool     `long:"allowlists" description:"apply higher limits for allow listed wallets (requires authz and ratelimits)"`
+	PrivilegedAddresses []string `long:"privileged-address" description:"allow this address to publish into other user's topics"`
 }
 
 // Config bundles Options and other parameters needed to set up an authorizer.


### PR DESCRIPTION
This is somewhat forward looking, but.I expect we will need a way to bypass authentication requirements for some of our maintenance tasks, e.g. converting contacts from V1 to V2. This PR adds an option to allow giving some specific wallets the ability:
```
      --api.authn.privileged-address= allow this address to publish into other user's topics
```
The option can be used multiple times to allow configuring multiple addresses for privileged access, this should work well in our TF infra configs.