### PR TITLE
fix: nil check auth data on token validation

### DIFF
--- a/pkg/api/authentication.go
+++ b/pkg/api/authentication.go
@@ -18,12 +18,14 @@ import (
 var (
 	TokenExpiration = time.Hour
 
-	ErrTokenExpired         = errors.New("token expired")
-	ErrInvalidSignature     = errors.New("invalid signature")
-	ErrWalletMismatch       = errors.New("wallet address mismatch")
-	ErrUnsignedKey          = errors.New("identity key is not signed")
-	ErrUnknownSignatureType = errors.New("unknown signature type")
-	ErrUnknownKeyType       = errors.New("unknown public key type")
+	ErrTokenExpired             = errors.New("token expired")
+	ErrMissingAuthData          = errors.New("missing auth data")
+	ErrMissingAuthDataSignature = errors.New("missing auth data signature")
+	ErrInvalidSignature         = errors.New("invalid signature")
+	ErrWalletMismatch           = errors.New("wallet address mismatch")
+	ErrUnsignedKey              = errors.New("identity key is not signed")
+	ErrUnknownSignatureType     = errors.New("unknown signature type")
+	ErrUnknownKeyType           = errors.New("unknown public key type")
 )
 
 func validateToken(ctx context.Context, log *zap.Logger, token *messagev1.Token, now time.Time) (wallet types.WalletAddr, err error) {
@@ -88,6 +90,12 @@ func recoverWalletAddress(ctx context.Context, identityKey *envelope.PublicKey) 
 }
 
 func verifyAuthSignature(ctx context.Context, pubKey *envelope.PublicKey, authDataBytes []byte, authSig *envelope.Signature) (data *messagev1.AuthData, err error) {
+	if authDataBytes == nil {
+		return nil, ErrMissingAuthData
+	}
+	if authSig == nil {
+		return nil, ErrMissingAuthDataSignature
+	}
 	switch key := pubKey.Union.(type) {
 	case *envelope.PublicKey_Secp256K1Uncompressed_:
 		pub, err := crypto.PublicKeyFromBytes(key.Secp256K1Uncompressed.Bytes)

--- a/pkg/api/authentication_test.go
+++ b/pkg/api/authentication_test.go
@@ -30,6 +30,15 @@ func Test_AuthnAllowedWithoutAuthn(t *testing.T) {
 	})
 }
 
+func Test_AuthnTokenMissingAuthData(t *testing.T) {
+	ctx := withMissingAuthData(t, context.Background())
+	testGRPCAndHTTP(t, ctx, func(t *testing.T, client messageclient.Client, server *Server) {
+		_, err := client.Publish(ctx, &messageV1.PublishRequest{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing auth data")
+	})
+}
+
 func Test_AuthnValidToken(t *testing.T) {
 	ctx := withAuth(t, context.Background())
 	testGRPCAndHTTP(t, ctx, func(t *testing.T, client messageclient.Client, server *Server) {

--- a/pkg/api/setup_test.go
+++ b/pkg/api/setup_test.go
@@ -132,6 +132,16 @@ func withExpiredAuth(t *testing.T, ctx context.Context) context.Context {
 	return ctx
 }
 
+func withMissingAuthData(t *testing.T, ctx context.Context) context.Context {
+	token, _, err := GenerateToken(time.Now())
+	require.NoError(t, err)
+	token.AuthDataBytes = nil
+	token.AuthDataSignature = nil
+	et, err := EncodeToken(token)
+	require.NoError(t, err)
+	return metadata.AppendToOutgoingContext(ctx, authorizationMetadataKey, "Bearer "+et)
+}
+
 func withAuthWithDetails(t *testing.T, ctx context.Context, when time.Time) (context.Context, *v1.AuthData) {
 	token, data, err := GenerateToken(when)
 	require.NoError(t, err)


### PR DESCRIPTION
This fixes a `SIGSEGV` when the auth token doesn't include an `.authDataSignature`.