### PR TITLE
Deploy using single xmtp_node_image tf var

### DIFF
--- a/scripts/deploy/nodes/main.go
+++ b/scripts/deploy/nodes/main.go
@@ -77,15 +77,9 @@ func main() {
 		msg = string(out)
 	}
 
-	log.Info("deploying group1", zap.String("image", options.ContainerImage))
-	err = deployer.Deploy("xmtp_node_image_group1", options.ContainerImage, msg)
+	log.Info("deploying", zap.String("image", options.ContainerImage))
+	err = deployer.Deploy("xmtp_node_image", options.ContainerImage, msg)
 	if err != nil {
-		log.Fatal("deploying group1", zap.Error(err))
-	}
-
-	log.Info("deploying group2", zap.String("image", options.ContainerImage))
-	err = deployer.Deploy("xmtp_node_image_group2", options.ContainerImage, msg)
-	if err != nil {
-		log.Fatal("deploying group2", zap.Error(err))
+		log.Fatal("deploying", zap.Error(err))
 	}
 }


### PR DESCRIPTION
We switched to using a single `xmtp_node_image` tf variable in https://github.com/xmtp-labs/infrastructure/pull/155, so this PR updates the deploy script to use that variable instead of the 2 grouped variables.

https://github.com/xmtp-labs/infrastructure/issues/138