### PR TITLE
feat: permit identity signature of either ecdsa type

### DIFF
--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -385,7 +385,7 @@ func Test_QueryPaging(t *testing.T) {
 }
 
 func Test_Publish_DenyListed(t *testing.T) {
-	token, data, err := GenerateToken(time.Now())
+	token, data, err := GenerateToken(time.Now(), false)
 	require.NoError(t, err)
 	et, err := EncodeToken(token)
 	require.NoError(t, err)

--- a/pkg/api/setup_test.go
+++ b/pkg/api/setup_test.go
@@ -133,7 +133,7 @@ func withExpiredAuth(t *testing.T, ctx context.Context) context.Context {
 }
 
 func withMissingAuthData(t *testing.T, ctx context.Context) context.Context {
-	token, _, err := GenerateToken(time.Now())
+	token, _, err := GenerateToken(time.Now(), false)
 	require.NoError(t, err)
 	token.AuthDataBytes = nil
 	token.AuthDataSignature = nil
@@ -143,7 +143,7 @@ func withMissingAuthData(t *testing.T, ctx context.Context) context.Context {
 }
 
 func withAuthWithDetails(t *testing.T, ctx context.Context, when time.Time) (context.Context, *v1.AuthData) {
-	token, data, err := GenerateToken(when)
+	token, data, err := GenerateToken(when, false)
 	require.NoError(t, err)
 	et, err := EncodeToken(token)
 	require.NoError(t, err)

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -70,7 +70,7 @@ func (s *Suite) randomStringLower(n int) string {
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz1234567890")
 
 func withAuth(ctx context.Context) (context.Context, error) {
-	token, _, err := api.GenerateToken(time.Now())
+	token, _, err := api.GenerateToken(time.Now(), false)
 	if err != nil {
 		return ctx, err
 	}


### PR DESCRIPTION
This makes the auth token verification handle _either_ `.WalletEcdsaCompact` or `.EcdsaCompact` signatures on the signed identity key.

This allows the published contacts to have the same shape as the auth token signature.