### PR TITLE
Retry http client requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.0
+	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/hashicorp/go-tfe v1.2.0
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
 	github.com/huandu/go-sqlbuilder v1.13.0
@@ -91,7 +92,6 @@ require (
 	github.com/hashicorp/go-hclog v1.2.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.3 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/hashicorp/go-slug v0.8.0 // indirect
 	github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d // indirect
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect


### PR DESCRIPTION
There are times during deployments where a publish/subscribe/query request [can 500](https://app.datadoghq.com/dashboard/ask-2bf-idz/xmtpd-e2e?from_ts=1672582323603&to_ts=1672755123603&live=true), since we only allow 1 instance of an individual node to up at a time, which can result in an e2e failure. This PR updates the http client to retry when that happens, so that we can remove the noise from e2e alerts. This is consistent with [what we do in xmtp-js](https://github.com/xmtp/xmtp-js/blob/main/src/ApiClient.ts#L149) already as well.