### PR TITLE
Add mutex lock around e2e rand source usage

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/xmtp/xmtp-node-go/pkg/api"
@@ -11,9 +12,10 @@ import (
 )
 
 type Suite struct {
-	ctx  context.Context
-	log  *zap.Logger
-	rand *rand.Rand
+	ctx    context.Context
+	log    *zap.Logger
+	rand   *rand.Rand
+	randMu sync.Mutex
 
 	config *Config
 }
@@ -61,6 +63,8 @@ func (s *Suite) newTest(name string, runFn testRunFunc) *Test {
 }
 
 func (s *Suite) randomStringLower(n int) string {
+	s.randMu.Lock()
+	defer s.randMu.Unlock()
 	b := make([]rune, n)
 	for i := range b {
 		b[i] = letterRunes[s.rand.Intn(len(letterRunes))]


### PR DESCRIPTION
We started seeing some [index out of range panics](https://app.datadoghq.com/logs?query=service%3Axmtpd-e2e%20panic&cols=host%2Cservice&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1670589756511&to_ts=1673181756511&live=true) from e2e since adding a second test case last week.

![Screenshot 2023-01-08 at 7 52 12 AM](https://user-images.githubusercontent.com/182290/211197080-6c86df98-bb90-49e9-a1d7-7c9f694c8f55.png)

It seems to be because [rand.Source](https://pkg.go.dev/math/rand#NewSource) isn't thread/concurrency-safe, so this PR adds a lock around the usage of it.

https://github.com/xmtp/xmtp-node-go/pull/202#issuecomment-1374830256