### PR TITLE
Use test- topic prefix for e2e batch test case

### DIFF
--- a/pkg/e2e/test_messagev1.go
+++ b/pkg/e2e/test_messagev1.go
@@ -167,7 +167,7 @@ func (s *Suite) testMessageV1PublishBatchQuery(log *zap.Logger) error {
 
 	contentTopics := make([]string, 0)
 	for i := 0; i < numTopics; i++ {
-		contentTopic := "testbatch-" + s.randomStringLower(12)
+		contentTopic := "test-" + s.randomStringLower(12)
 		contentTopics = append(contentTopics, contentTopic)
 	}
 


### PR DESCRIPTION
Use the `test-` prefix for the batch message topics instead of `testbatch-` so that we can leverage the existing 1. topic categorization for metrics, and 2. summary/cleanup tooling in retool. 

![Screenshot 2023-01-09 at 11 49 52 AM](https://user-images.githubusercontent.com/182290/211362488-ed48acfb-924e-4a64-8bc9-49c46f7229c1.png)