### PR TITLE
Disable metrics messages count query

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -102,7 +102,7 @@ func (s *XmtpStore) Start(ctx context.Context) {
 	s.host.SetStreamHandler(store.StoreID_v20beta4, s.onRequest)
 
 	tracing.GoPanicWrap(s.ctx, &s.wg, "store-incoming-messages", func(ctx context.Context) { s.storeIncomingMessages(ctx) })
-	tracing.GoPanicWrap(s.ctx, &s.wg, "store-status-metrics", func(ctx context.Context) { s.statusMetricsLoop(ctx) })
+	// tracing.GoPanicWrap(s.ctx, &s.wg, "store-status-metrics", func(ctx context.Context) { s.statusMetricsLoop(ctx) })
 	s.log.Info("Store protocol started")
 }
 


### PR DESCRIPTION
Disables this query until https://github.com/xmtp/xmtp-node-go/pull/208 and https://github.com/xmtp-labs/infrastructure/pull/167 ship that switch it to use the DB reader. The queries seem to be timing out pretty consistently https://app.datadoghq.com/logs?query=status%3Aerror&cols=host%2Cservice&index=%2A&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1674043608869&to_ts=1674058008869&live=true with 25M messages in the DB and likely a contributor to the DB alerts we've seen.