### PR TITLE
Trigger e2e deploy only when node deploy is successful

### DIFF
--- a/.github/workflows/deploy-e2e.yml
+++ b/.github/workflows/deploy-e2e.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Set up Docker Buildx
         id: buildx


### PR DESCRIPTION
I noticed that the `Deploy E2E` GH workflow is running even after failure of the dependent `Deploy Nodes` workflow, but we only want it to run on success of it, so this PR fixes that.