### PR TITLE
Re-enable store metrics collector

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -125,7 +125,7 @@ func (s *XmtpStore) Start(ctx context.Context) {
 	s.host.SetStreamHandler(store.StoreID_v20beta4, s.onRequest)
 
 	tracing.GoPanicWrap(s.ctx, &s.wg, "store-incoming-messages", func(ctx context.Context) { s.storeIncomingMessages(ctx) })
-	// tracing.GoPanicWrap(s.ctx, &s.wg, "store-status-metrics", func(ctx context.Context) { s.statusMetricsLoop(ctx) })
+	tracing.GoPanicWrap(s.ctx, &s.wg, "store-status-metrics", func(ctx context.Context) { s.statusMetricsLoop(ctx) })
 	s.log.Info("Store protocol started")
 }
 


### PR DESCRIPTION
Re-enable the store metrics collector/emitter loop now that it's using the reader DB.