### PR TITLE
Add message.id db index

### DIFF
--- a/pkg/migrations/messages/20230119205834_add-id-index.down.sql
+++ b/pkg/migrations/messages/20230119205834_add-id-index.down.sql
@@ -1,0 +1,5 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+DROP INDEX message_id_idx;

--- a/pkg/migrations/messages/20230119205834_add-id-index.up.sql
+++ b/pkg/migrations/messages/20230119205834_add-id-index.up.sql
@@ -1,0 +1,5 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+CREATE INDEX CONCURRENTLY message_id_idx ON public.message (id);


### PR DESCRIPTION
The cleaner has been timing out and pushing CPU usage near 100% while running the delete queries. I had to cancel a few that went out earlier today before the revert. I've also noticed in retool that even a 1-batch delete query on `id` takes about 15 seconds to run. It turns out we don't have an index on `id`:
```
Indexes:
    "messageindex" PRIMARY KEY, btree (sendertimestamp, id, pubsubtopic)
    "message_contenttopic_idx" btree (contenttopic)
    "message_pubsubtopic_idx" btree (pubsubtopic)
    "message_sendertimestamp_idx" btree (sendertimestamp)
    "message_sort_idx" btree (sendertimestamp, id)
```

So this PR adds an index migration for `message.id`.