### PR TITLE
Use ctid for cleaner batch deletes

### DIFF
--- a/pkg/store/cleaner.go
+++ b/pkg/store/cleaner.go
@@ -34,6 +34,7 @@ func (s *XmtpStore) deleteNonXMTPMessagesBatch(log *zap.Logger) error {
 	// reader for the non-indexed NOT LIKE query first, because ctid can change
 	// during a full vacuum of the DB, so we want to avoid conflicting with
 	// that scenario and deleting the wrong data.
+	started := time.Now().UTC()
 	stmt, err := s.db.Prepare(`
 		WITH msg AS (
 			SELECT ctid
@@ -58,7 +59,7 @@ func (s *XmtpStore) deleteNonXMTPMessagesBatch(log *zap.Logger) error {
 		return err
 	}
 
-	log.Info("deleted non-xmtp messages", zap.Int64("deleted", count))
+	log.Info("deleted non-xmtp messages", zap.Int64("deleted", count), zap.Duration("duration", time.Since(started)))
 
 	return nil
 }


### PR DESCRIPTION
Use postgres's `ctid` field for batch deletes instead of the not-guaranteed-to-be-unique `message.id` field as discussed in https://github.com/xmtp/xmtp-node-go/pull/213#issuecomment-1398491037, and also increase the batch size to 10k. I confirmed in retool that running the batch delete (with the NOT LIKE subquery) runs in sub-second, so we could go higher than even 10k if we wanted, but it seems like a reasonably large batch size already.