### PR TITLE
Remove metrics count query

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -125,7 +125,6 @@ func (s *XmtpStore) Start(ctx context.Context) {
 	s.host.SetStreamHandler(store.StoreID_v20beta4, s.onRequest)
 
 	tracing.GoPanicWrap(s.ctx, &s.wg, "store-incoming-messages", func(ctx context.Context) { s.storeIncomingMessages(ctx) })
-	tracing.GoPanicWrap(s.ctx, &s.wg, "store-status-metrics", func(ctx context.Context) { s.statusMetricsLoop(ctx) })
 	s.log.Info("Store protocol started")
 }
 
@@ -385,23 +384,6 @@ func (s *XmtpStore) storeIncomingMessages(ctx context.Context) {
 				return
 			}
 			_, _ = s.storeMessage(envelope)
-		}
-	}
-}
-
-func (s *XmtpStore) statusMetricsLoop(ctx context.Context) {
-	if s.statsPeriod == 0 {
-		s.log.Info("statsPeriod is 0 indicating no metrics loop")
-		return
-	}
-	ticker := time.NewTicker(s.statsPeriod)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			metrics.EmitStoredMessages(ctx, s.readerDB, s.log)
 		}
 	}
 }


### PR DESCRIPTION
This query is just [timing out most of the time](https://app.datadoghq.com/logs?query=service%3A%28group2-node-1%20OR%20group2-node-0%20OR%20group1-node-0%20OR%20group1-node-1%29%20status%3Aerror%20NOT%20message%3A%22dialing%20static%20node%22&cols=host%2Cservice&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1674144113571&to_ts=1674145013571&live=true) at this point, even against the reader, since it needs to scan the whole table. So this PR removes it. If we find that we need a full-DB count metrics in DD, then we can figure out a better way to get it, maybe materialize it at write-time or something.