### PR TITLE
Active/passive periods for cleaner

### DIFF
--- a/pkg/store/cleaner.go
+++ b/pkg/store/cleaner.go
@@ -8,8 +8,10 @@ import (
 
 type CleanerOptions struct {
 	Enable        bool          `long:"enable" description:"Enable DB cleaner"`
-	Period        time.Duration `long:"period" description:"Time between successive runs of the cleaner" default:"5s"`
+	ActivePeriod  time.Duration `long:"active-period" description:"Time between successive runs of the cleaner when the last run was a full batch" default:"2s"`
+	PassivePeriod time.Duration `long:"passive-period" description:"Time between successive runs of the cleaner when the last run was not a full batch" default:"5m"`
 	RetentionDays int           `long:"retention-days" description:"Number of days in the past that messages must be before being deleted" default:"3"`
+	BatchSize     int           `long:"batch-size" description:"Batch size of messages to be deleted in one iteration" default:"1000"`
 }
 
 func (s *XmtpStore) cleanerLoop() {
@@ -20,16 +22,20 @@ func (s *XmtpStore) cleanerLoop() {
 		case <-s.ctx.Done():
 			return
 		default:
-			err := s.deleteNonXMTPMessagesBatch(log)
+			count, err := s.deleteNonXMTPMessagesBatch(log)
 			if err != nil {
 				log.Error("error deleting non-xmtp messages", zap.Error(err))
 			}
-			time.Sleep(s.cleaner.Period)
+			if count >= int64(s.cleaner.BatchSize-10) {
+				time.Sleep(s.cleaner.ActivePeriod)
+			} else {
+				time.Sleep(s.cleaner.PassivePeriod)
+			}
 		}
 	}
 }
 
-func (s *XmtpStore) deleteNonXMTPMessagesBatch(log *zap.Logger) error {
+func (s *XmtpStore) deleteNonXMTPMessagesBatch(log *zap.Logger) (int64, error) {
 	// We use a single atomic query here instead of breaking it up to hit the
 	// reader for the non-indexed NOT LIKE query first, because ctid can change
 	// during a full vacuum of the DB, so we want to avoid conflicting with
@@ -40,26 +46,26 @@ func (s *XmtpStore) deleteNonXMTPMessagesBatch(log *zap.Logger) error {
 			SELECT ctid
 			FROM message
 			WHERE receivertimestamp < $1 AND contenttopic NOT LIKE '/xmtp/%'
-			LIMIT 1000
+			LIMIT $2
 			FOR UPDATE SKIP LOCKED
 		)
 		DELETE FROM message WHERE ctid IN (TABLE msg);
 	`)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	timestampThreshold := time.Now().UTC().Add(time.Duration(s.cleaner.RetentionDays) * -1 * 24 * time.Hour).UnixNano()
-	res, err := stmt.Exec(timestampThreshold)
+	res, err := stmt.Exec(timestampThreshold, s.cleaner.BatchSize)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	count, err := res.RowsAffected()
 	if err != nil {
-		return err
+		return 0, err
 	}
 
-	log.Info("deleted non-xmtp messages", zap.Int64("deleted", count), zap.Duration("duration", time.Since(started)))
+	log.Info("non-xmtp messages cleaner", zap.Int64("deleted", count), zap.Duration("duration", time.Since(started)))
 
-	return nil
+	return count, nil
 }

--- a/pkg/store/cleaner_test.go
+++ b/pkg/store/cleaner_test.go
@@ -13,8 +13,10 @@ func TestStore_Cleaner_DeletesNonXMTPMessages(t *testing.T) {
 
 	s, cleanup := newTestStore(t, WithCleaner(CleanerOptions{
 		Enable:        true,
-		Period:        1 * time.Second,
+		ActivePeriod:  time.Second,
+		PassivePeriod: time.Second,
 		RetentionDays: 3,
+		BatchSize:     10,
 	}))
 	defer cleanup()
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -34,7 +34,9 @@ var (
 	ErrMissingDBOption              = errors.New("missing db option")
 	ErrMissingMessageProviderOption = errors.New("missing message provider option")
 	ErrMissingStatsPeriodOption     = errors.New("missing stats period option")
-	ErrMissingCleanerPeriod         = errors.New("missing cleaner period option")
+	ErrMissingCleanerActivePeriod   = errors.New("missing cleaner active period option")
+	ErrMissingCleanerPassivePeriod  = errors.New("missing cleaner passive period option")
+	ErrMissingCleanerBatchSize      = errors.New("missing cleaner batch size option")
 	ErrMissingCleanerRetentionDays  = errors.New("missing cleaner retention days option")
 )
 
@@ -95,8 +97,14 @@ func NewXmtpStore(opts ...Option) (*XmtpStore, error) {
 
 	// Required cleaner options.
 	if s.cleaner.Enable {
-		if s.cleaner.Period == 0 {
-			return nil, ErrMissingCleanerPeriod
+		if s.cleaner.ActivePeriod == 0 {
+			return nil, ErrMissingCleanerActivePeriod
+		}
+		if s.cleaner.PassivePeriod == 0 {
+			return nil, ErrMissingCleanerPassivePeriod
+		}
+		if s.cleaner.BatchSize == 0 {
+			return nil, ErrMissingCleanerBatchSize
 		}
 		if s.cleaner.RetentionDays == 0 {
 			return nil, ErrMissingCleanerRetentionDays


### PR DESCRIPTION
When the previous number of deleted messages isn't a full batch, drop the delay/period between runs down to a "passive period" config (default 5m), vs when it was a full batch then use the "active period" config (default 2s). Since the query being run is pretty inefficient, it'd be great not to run it every few seconds non-stop if there's not much to be deleted.