### PR TITLE
Avoid nil pointer dereference in http client retry policy

### DIFF
--- a/pkg/api/message/v1/client/http_client.go
+++ b/pkg/api/message/v1/client/http_client.go
@@ -207,7 +207,7 @@ func (c *httpClient) post(ctx context.Context, path string, req interface{}) (*h
 
 func retryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
 	// Avoid conflicting with grpc-gateway max message size error.
-	if resp.StatusCode == http.StatusTooManyRequests {
+	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
 		return false, err
 	}
 


### PR DESCRIPTION
This panic [has been happening](https://app.datadoghq.com/logs?query=service%3Axmtpd-e2e%20panic&cols=host%2Cservice&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1674391727886&to_ts=1674478127886&live=true) in the production e2e runner for the past few hours:

![Screenshot 2023-01-23 at 7 41 42 AM](https://user-images.githubusercontent.com/182290/214043643-4a4606fd-b6ef-49e5-bf4d-db269d93cb6f.png)