### PR TITLE
Simplify cleaner query index

### DIFF
--- a/pkg/migrations/messages/20230124214407_add-ts-shouldexpire-index.down.sql
+++ b/pkg/migrations/messages/20230124214407_add-ts-shouldexpire-index.down.sql
@@ -1,0 +1,9 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+CREATE INDEX CONCURRENTLY message_recvts_shouldexpire_idx ON public.message (receiverTimestamp, should_expire);
+
+--bun:split
+
+DROP INDEX message_recvts_shouldexpiretrue_idx;

--- a/pkg/migrations/messages/20230124214407_add-ts-shouldexpire-index.up.sql
+++ b/pkg/migrations/messages/20230124214407_add-ts-shouldexpire-index.up.sql
@@ -1,0 +1,9 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+CREATE INDEX CONCURRENTLY message_recvts_shouldexpiretrue_idx ON public.message (receiverTimestamp) WHERE should_expire IS TRUE;
+
+--bun:split
+
+DROP INDEX message_recvts_shouldexpire_idx;


### PR DESCRIPTION
The way this index was defined on `(receiverTimestamp, should_expire)` is pretty suboptimal for the query of 
```sql
SELECT ctid
FROM message
WHERE receivertimestamp < $1 AND should_expire IS TRUE
LIMIT $2
```

Starting the index tuple with the `receiverTimestamp` results in the need to scan over a bunch of should_expire=FALSE rows in the query, as opposed to starting it with the finite-valued `should_expire`, or even just making it a partial index on just `should_expire IS TRUE`. This makes for a smaller index and one that's better optimized for the query being used.