### PR TITLE
Close db prepared statement in cleaner when finished

### DIFF
--- a/pkg/store/cleaner.go
+++ b/pkg/store/cleaner.go
@@ -54,6 +54,7 @@ func (s *XmtpStore) deleteNonXMTPMessagesBatch(log *zap.Logger) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
+	defer stmt.Close()
 	timestampThreshold := time.Now().UTC().Add(time.Duration(s.cleaner.RetentionDays) * -1 * 24 * time.Hour).UnixNano()
 	res, err := stmt.Exec(timestampThreshold, s.cleaner.BatchSize)
 	if err != nil {


### PR DESCRIPTION
This should be closed after using it, and is possibly a contributor to the errors ([1](https://app.datadoghq.com/logs?query=service%3A%28group1-node-1%20OR%20group2-node-0%20OR%20group2-node-1%20OR%20group1-node-0%29%20message%3A%22error%20deleting%20non-xmtp%20messages%22&cols=env%2Cservice%2Cdeleted%2Cduration&event=AgAAAYXpJpJT8ixobwAAAAAAAAAYAAAAAEFZWHBKcFBJQUFCRHU2b3BqeEMtVXdBQQAAACQAAAAAMDE4NWU5MjYtZmFhZS00ZTA2LWIyNzQtYTQ5ZWE0YWUyYTUw&index=&messageDisplay=inline&saved-view-id=1494278&stream_sort=time%2Cdesc&viz=stream&from_ts=1674588227703&to_ts=1674602627703&live=true)) ([2](https://app.datadoghq.com/logs?query=service%3A%28group2-node-1%20OR%20group2-node-0%20OR%20group1-node-0%20OR%20group1-node-1%29%20status%3Aerror%20NOT%20message%3A%22dialing%20static%20node%22&cols=host%2Cservice%2Cenv&index=%2A&messageDisplay=inline&saved-view-id=1494282&stream_sort=time%2Cdesc&viz=stream&from_ts=1674639741599&to_ts=1674654141599&live=true)) we've been seeing in the logs.