### PR TITLE
Limit concurrent deploys via GH workflow

### DIFF
--- a/.github/workflows/deploy-e2e.yml
+++ b/.github/workflows/deploy-e2e.yml
@@ -6,6 +6,7 @@ on:
     types: [completed]
 jobs:
   deploy:
+    concurrency: main
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
       - main
 jobs:
   deploy:
+    concurrency: main
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx


### PR DESCRIPTION
If I understand this config, it should limit/queue concurrent deployments triggered by merging rather then allowing them to overlap and usually timeout since the rollout in terraform is queued anyway https://docs.github.com/en/actions/using-jobs/using-concurrency#examples-using-concurrency-and-the-default-behavior