### PR TITLE
info logs for tests, unless -debug specified

### DIFF
--- a/pkg/testing/log.go
+++ b/pkg/testing/log.go
@@ -1,14 +1,25 @@
 package testing
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
+var debug bool
+
+func init() {
+	flag.BoolVar(&debug, "debug", false, "debug level logging in tests")
+}
+
 func NewLog(t *testing.T) *zap.Logger {
-	log, err := zap.NewDevelopment()
+	cfg := zap.NewDevelopmentConfig()
+	if !debug {
+		cfg.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
+	}
+	log, err := cfg.Build()
 	require.NoError(t, err)
 	return log
 }


### PR DESCRIPTION
Looks like some tests run with debug level logging on atm, which can be expensive and slow for some. This changes the default to INFO level, and adds a `-debug` testing flag that sets it to DEBUG level.