### PR TITLE
Increase cleaner timeout

### DIFF
--- a/pkg/store/cleaner.go
+++ b/pkg/store/cleaner.go
@@ -20,13 +20,14 @@ func (s *XmtpStore) cleanerLoop() {
 	log := s.log.Named("cleaner")
 
 	for {
+		started := time.Now().UTC()
 		select {
 		case <-s.ctx.Done():
 			return
 		default:
 			count, err := s.deleteNonXMTPMessagesBatch(log)
 			if err != nil {
-				log.Error("error deleting non-xmtp messages", zap.Error(err))
+				log.Error("error deleting non-xmtp messages", zap.Error(err), zap.Duration("duration", time.Since(started)))
 			}
 			if count >= int64(s.cleaner.BatchSize-10) {
 				time.Sleep(s.cleaner.ActivePeriod)


### PR DESCRIPTION
When there aren't many matching rows, the cleaner query can take > 30s to run, and so we're seeing timeouts from it in dev and prod. We can see that they usually complete in 20s in retool but sometimes longer if given the time. This PR increases the timeout to 60s so the cleaner can complete and stop constantly failing+retrying. The PR also logs duration when there's a cleaner timeout too.

Another thing we can do is increase the batch size from 1k to 10k or 100k. I was using 100k in testing and it was just fine, completed on avg in 20s, sometimes longer. But then it was done and it didn't have to run the heavy query on the DB any more until there's another full batch, so there's less constant pressure. But I'll do that in a follow-up PR to make the changes in isolation.