### PR TITLE
Increase cleaner batch size

### DIFF
--- a/pkg/store/cleaner.go
+++ b/pkg/store/cleaner.go
@@ -8,7 +8,7 @@ import (
 
 type CleanerOptions struct {
 	Enable        bool          `long:"enable" description:"Enable DB cleaner"`
-	ActivePeriod  time.Duration `long:"active-period" description:"Time between successive runs of the cleaner when the last run was a full batch" default:"2s"`
+	ActivePeriod  time.Duration `long:"active-period" description:"Time between successive runs of the cleaner when the last run was a full batch" default:"5s"`
 	PassivePeriod time.Duration `long:"passive-period" description:"Time between successive runs of the cleaner when the last run was not a full batch" default:"5m"`
 	RetentionDays int           `long:"retention-days" description:"Number of days in the past that messages must be before being deleted" default:"1"`
 	BatchSize     int           `long:"batch-size" description:"Batch size of messages to be deleted in one iteration" default:"50000"`


### PR DESCRIPTION
The cleaner query is relatively expensive for the DB, or at least it has to scan a bunch of rows for it, so it's doing work. The batch size doesn't meaningfully change the number of rows it needs to scan when it gets down to not having many matching rows left, in that it's scanning almost the whole set anyway. And when there are many matching rows having a larger batch size, of even 100k or 500k doesn't meaningfully affect the time the operation takes to run. So this seems like a reasonable way to decrease the work the DB has to do by not rerunning the same relatively expensive query in small batches over and over again, and just run it with a larger batch instead.

This won't be merged until after https://github.com/xmtp/xmtp-node-go/pull/235 is out and settled