### PR TITLE
Stop using prepared statement for message insert

### DIFF
--- a/pkg/store/db_store.go
+++ b/pkg/store/db_store.go
@@ -86,17 +86,9 @@ func (d *DBStore) Put(env *protocol.Envelope) error {
 	pubsubTopic := env.PubsubTopic()
 	message := env.Message()
 	shouldExpire := !isXMTP(message)
-	stmt, err := d.db.Prepare("INSERT INTO message (id, receiverTimestamp, senderTimestamp, contentTopic, pubsubTopic, payload, version, should_expire) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)")
-	if err != nil {
-		return err
-	}
-	defer stmt.Close()
-	_, err = stmt.Exec(cursor.Digest, cursor.ReceiverTime, message.Timestamp, message.ContentTopic, pubsubTopic, message.Payload, message.Version, shouldExpire)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	sql := "INSERT INTO message (id, receiverTimestamp, senderTimestamp, contentTopic, pubsubTopic, payload, version, should_expire) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)"
+	_, err := d.db.Exec(sql, cursor.Digest, cursor.ReceiverTime, message.Timestamp, message.ContentTopic, pubsubTopic, message.Payload, message.Version, shouldExpire)
+	return err
 }
 
 func isXMTP(msg *pb.WakuMessage) bool {


### PR DESCRIPTION
We're not really making use of prepared statements in an effective way during message inserts, because we're just creating a new one for every insert. It's also possible that there are issues with prepared statements in pgdriver after seeing such a significant improvement from removing them in the cleaner (https://github.com/xmtp/xmtp-node-go/issues/237). So this PR removes the use of a prepared statement for inserting messages too.