### PR TITLE
fix: start cleaner loop in Start func to avoid context race

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -119,10 +119,6 @@ func NewXmtpStore(opts ...Option) (*XmtpStore, error) {
 
 	s.MsgC = make(chan *protocol.Envelope, bufferSize)
 
-	if s.cleaner.Enable {
-		go s.cleanerLoop()
-	}
-
 	return s, nil
 }
 
@@ -141,6 +137,11 @@ func (s *XmtpStore) Start(ctx context.Context) {
 	tracing.GoPanicWrap(s.ctx, &s.wg, "store-incoming-messages", func(ctx context.Context) { s.storeIncomingMessages(ctx) })
 	tracing.GoPanicWrap(s.ctx, &s.wg, "store-status-metrics", func(ctx context.Context) { s.statusMetricsLoop(ctx) })
 	s.log.Info("Store protocol started")
+
+	// Start cleaner
+	if s.cleaner.Enable {
+		go s.cleanerLoop()
+	}
 }
 
 func (s *XmtpStore) Stop() {


### PR DESCRIPTION
**Goal**

Fix race where `s.cleanerLoop` is started in XMTP store creation and can potentially read `s.ctx` concurrently to it's recreation in `s.Start`.

**Changes**
- Start cleanerLoop in `s.Start` after ctx is set up

**Test**
Confirm no more data races in `store.go` in `go test -race ./...` report.

Race:
```
WARNING: DATA RACE
Read at 0x00c000198820 by goroutine 105:
  github.com/xmtp/xmtp-node-go/pkg/store.(*XmtpStore).cleanerLoop()
      /Users/michaelx/Code/xmtp-node-go/pkg/store/cleaner.go:25 +0x11c
  github.com/xmtp/xmtp-node-go/pkg/store.NewXmtpStore.func1()
      /Users/michaelx/Code/xmtp-node-go/pkg/store/store.go:123 +0x38

Previous write at 0x00c000198820 by goroutine 39:
  github.com/xmtp/xmtp-node-go/pkg/store.(*XmtpStore).Start()
      /Users/michaelx/Code/xmtp-node-go/pkg/store/store.go:138 +0x80
  github.com/xmtp/xmtp-node-go/pkg/store.newTestStore()
      /Users/michaelx/Code/xmtp-node-go/pkg/store/store_test.go:67 +0x530
  github.com/xmtp/xmtp-node-go/pkg/store.TestStore_Cleaner.func5()
      /Users/michaelx/Code/xmtp-node-go/pkg/store/cleaner_test.go:104 +0xe8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x18c
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x44

Goroutine 105 (running) created at:
  github.com/xmtp/xmtp-node-go/pkg/store.NewXmtpStore()
      /Users/michaelx/Code/xmtp-node-go/pkg/store/store.go:123 +0x3f0
  github.com/xmtp/xmtp-node-go/pkg/store.newTestStore()
      /Users/michaelx/Code/xmtp-node-go/pkg/store/store_test.go:52 +0x4e0
  github.com/xmtp/xmtp-node-go/pkg/store.TestStore_Cleaner.func5()
      /Users/michaelx/Code/xmtp-node-go/pkg/store/cleaner_test.go:104 +0xe8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x18c
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x44

Goroutine 39 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1486 +0x560
  github.com/xmtp/xmtp-node-go/pkg/store.TestStore_Cleaner()
      /Users/michaelx/Code/xmtp-node-go/pkg/store/cleaner_test.go:101 +0x1d60
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x18c
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x44
     ```