### PR TITLE
fix: expand lock around current val in ratelimiter

### DIFF
--- a/pkg/ratelimiter/rate_limiter.go
+++ b/pkg/ratelimiter/rate_limiter.go
@@ -78,10 +78,11 @@ func (rl *TokenBucketRateLimiter) fillAndReturnEntry(walletAddress string, isAll
 		return currentVal
 	}
 
+	currentVal.mutex.Lock()
+	defer currentVal.mutex.Unlock()
 	now := time.Now()
 	minutesSinceLastSeen := now.Sub(currentVal.lastSeen).Minutes()
 	if minutesSinceLastSeen > 0 {
-		currentVal.mutex.Lock()
 		// Only update the lastSeen if it has been >= 1 minute
 		// This allows for continuously sending nodes to still get credits
 		currentVal.lastSeen = now
@@ -92,7 +93,6 @@ func (rl *TokenBucketRateLimiter) fillAndReturnEntry(walletAddress string, isAll
 			additionalTokens = MAX_UINT_16 - int(currentVal.tokens)
 		}
 		currentVal.tokens = minUint16(currentVal.tokens+uint16(additionalTokens), maxTokens)
-		currentVal.mutex.Unlock()
 	}
 
 	return currentVal


### PR DESCRIPTION
**Goal**

Latest in a series of data race fixes #240 #241 . This change expands a lock very slightly to cover a read on `currentVal.lastSeen`.

**Changes**
- Increase lock scope by one line and use defer

**Testing**
- e2e tests pass, and subsequent `go test -race ./...` does not show any races in ratelimiter

race:
```
WARNING: DATA RACE
Read at 0x00c000184000 by goroutine 17:
  github.com/xmtp/xmtp-node-go/pkg/ratelimiter.(*TokenBucketRateLimiter).fillAndReturnEntry()
      /Users/michaelx/Code/xmtp-node-go/pkg/ratelimiter/rate_limiter.go:82 +0xd8
  github.com/xmtp/xmtp-node-go/pkg/ratelimiter.(*TokenBucketRateLimiter).Spend()
      /Users/michaelx/Code/xmtp-node-go/pkg/ratelimiter/rate_limiter.go:103 +0x50
  github.com/xmtp/xmtp-node-go/pkg/ratelimiter.TestSpendConcurrent.func1()
      /Users/michaelx/Code/xmtp-node-go/pkg/ratelimiter/rate_limiter_test.go:107 +0x78

Previous write at 0x00c000184000 by goroutine 16:
  github.com/xmtp/xmtp-node-go/pkg/ratelimiter.(*TokenBucketRateLimiter).fillAndReturnEntry()
      /Users/michaelx/Code/xmtp-node-go/pkg/ratelimiter/rate_limiter.go:87 +0x168
  github.com/xmtp/xmtp-node-go/pkg/ratelimiter.(*TokenBucketRateLimiter).Spend()
      /Users/michaelx/Code/xmtp-node-go/pkg/ratelimiter/rate_limiter.go:103 +0x50
  github.com/xmtp/xmtp-node-go/pkg/ratelimiter.TestSpendConcurrent.func1()
      /Users/michaelx/Code/xmtp-node-go/pkg/ratelimiter/rate_limiter_test.go:107 +0x78

Goroutine 17 (running) created at:
  github.com/xmtp/xmtp-node-go/pkg/ratelimiter.TestSpendConcurrent()
      /Users/michaelx/Code/xmtp-node-go/pkg/ratelimiter/rate_limiter_test.go:105 +0x6c
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x18c
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x44

Goroutine 16 (running) created at:
  github.com/xmtp/xmtp-node-go/pkg/ratelimiter.TestSpendConcurrent()
      /Users/michaelx/Code/xmtp-node-go/pkg/ratelimiter/rate_limiter_test.go:105 +0x6c
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x18c
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x44
      ```