### PR TITLE
Store messages then forward to relay

### DIFF
--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -93,7 +93,17 @@ func (s *Service) Publish(ctx context.Context, req *proto.PublishRequest) (*prot
 			Timestamp:    toWakuTimestamp(env.TimestampNs),
 			Payload:      env.Message,
 		}
-		_, err := s.waku.Relay().Publish(ctx, wakuMsg)
+
+		store, ok := s.waku.Store().(*store.XmtpStore)
+		if !ok {
+			return nil, status.Errorf(codes.Internal, "waku store not xmtp store")
+		}
+		_, err := store.InsertMessage(wakuMsg)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, err.Error())
+		}
+
+		_, err = s.waku.Relay().Publish(ctx, wakuMsg)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}

--- a/pkg/api/setup_test.go
+++ b/pkg/api/setup_test.go
@@ -56,7 +56,7 @@ func newTestNode(t *testing.T, storeNodes []*wakunode.WakuNode, opts ...wakunode
 	n, nodeCleanup := test.NewNode(t, storeNodes,
 		append(
 			opts,
-			wakunode.WithWakuStore(true, false),
+			wakunode.WithWakuStore(false, false),
 			wakunode.WithWakuStoreFactory(func(w *wakunode.WakuNode) wakustore.Store {
 				// Note that the node calls store.Stop() during it's cleanup,
 				// but it that doesn't clean up the given DB, so we make sure

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -147,7 +147,7 @@ func New(ctx context.Context, log *zap.Logger, options Options) (*Server, error)
 	}
 
 	if options.Store.Enable {
-		nodeOpts = append(nodeOpts, node.WithWakuStoreAndRetentionPolicy(options.Store.ShouldResume, options.Store.RetentionMaxDaysDuration(), options.Store.RetentionMaxMessages))
+		nodeOpts = append(nodeOpts, node.WithWakuStore(false, options.Store.ShouldResume))
 		dbStore, err := xmtpstore.NewDBStore(s.log, xmtpstore.WithDBStoreDB(s.db))
 		if err != nil {
 			return nil, errors.Wrap(err, "creating db store")


### PR DESCRIPTION
Store messages on `Publish`, then forward to waku relay, rather than forwarding to relay and waiting for consumers to store. This allows our clients to assume that after a Publish request returns with non-error, the published message will be available via Query. Note that in the case of duplicate key error from the DB, no error is returned to the user, this was the case before, and hasn't changed. In the case of other DB errors, an error may be returned on the public request, which is a change in behaviour vs before this.

The intention of this PR is to demonstrate the store-then-forward change for https://github.com/xmtp-labs/hq/issues/925