### PR TITLE
Emit e2e success/fail 0 metric count

### DIFF
--- a/pkg/e2e/metrics.go
+++ b/pkg/e2e/metrics.go
@@ -62,10 +62,18 @@ func (r *Runner) withMetricsServer(fn func() error) error {
 }
 
 func recordSuccessfulRun(ctx context.Context, tags ...tag) error {
+	err := recordWithTags(ctx, tags, failedRuns.M(0))
+	if err != nil {
+		return err
+	}
 	return recordWithTags(ctx, tags, successfulRuns.M(1))
 }
 
 func recordFailedRun(ctx context.Context, tags ...tag) error {
+	err := recordWithTags(ctx, tags, successfulRuns.M(0))
+	if err != nil {
+		return err
+	}
 	return recordWithTags(ctx, tags, failedRuns.M(1))
 }
 


### PR DESCRIPTION
After the e2e failure alert is triggered and then recovers, the monitor in DD continues to be 🔴 since the metric it's waiting for to decrease below the threshold isn't emitted again. This PR updates the success/fail alerts to also emit a 0-value for the opposite (success vs fail) metric being emitted so that the monitor will recover.

![Screenshot 2023-02-17 at 7 45 11 AM](https://user-images.githubusercontent.com/182290/219656828-4700e898-5437-4b6d-a225-db44fd7660b7.png)

Follow-up from [incident-5](https://www.notion.so/xmtplabs/Incident-5-5c37e3e4bc4f4d009bb6f06be9e1791e)