### PR TITLE
Revert "Emit e2e success/fail 0 metric count"

### DIFF
--- a/pkg/e2e/metrics.go
+++ b/pkg/e2e/metrics.go
@@ -62,18 +62,10 @@ func (r *Runner) withMetricsServer(fn func() error) error {
 }
 
 func recordSuccessfulRun(ctx context.Context, tags ...tag) error {
-	err := recordWithTags(ctx, tags, failedRuns.M(0))
-	if err != nil {
-		return err
-	}
 	return recordWithTags(ctx, tags, successfulRuns.M(1))
 }
 
 func recordFailedRun(ctx context.Context, tags ...tag) error {
-	err := recordWithTags(ctx, tags, successfulRuns.M(0))
-	if err != nil {
-		return err
-	}
 	return recordWithTags(ctx, tags, failedRuns.M(1))
 }
 


### PR DESCRIPTION
Reverts xmtp/xmtp-node-go#249 - this seems to default to 1 when given a 0 value:

![Screenshot 2023-02-17 at 8 49 46 AM](https://user-images.githubusercontent.com/182290/219672112-474d9560-6e41-4e92-8da1-db1b9b581d91.png)
