### PR TITLE
Log app/client requester info with tracked queries

### DIFF
--- a/pkg/api/message/v1/context.go
+++ b/pkg/api/message/v1/context.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"context"
+	"strings"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	ClientVersionMetadataKey = "x-client-version"
+	AppVersionMetadataKey    = "x-app-version"
+)
+
+type requesterInfo struct {
+	ClientName    string
+	ClientVersion string
+
+	AppName    string
+	AppVersion string
+}
+
+func NewRequesterInfo(ctx context.Context) *requesterInfo {
+	ri := &requesterInfo{}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ri
+	}
+	ri.ClientName, _, ri.ClientVersion = parseVersionHeaderValue(md.Get(ClientVersionMetadataKey))
+	ri.AppName, _, ri.AppVersion = parseVersionHeaderValue(md.Get(AppVersionMetadataKey))
+	md.Append("X-User-Id", "real_user_id")
+	return ri
+}
+
+func (ri *requesterInfo) ZapFields() []zap.Field {
+	return []zap.Field{
+		zap.String("client", ri.ClientName),
+		zap.String("client_version", ri.ClientVersion),
+		zap.String("app", ri.AppName),
+		zap.String("app_version", ri.AppVersion),
+	}
+}
+
+func parseVersionHeaderValue(vals []string) (name string, version string, full string) {
+	if len(vals) == 0 {
+		return
+	}
+	full = vals[0]
+	parts := strings.Split(full, "/")
+	if len(parts) > 0 {
+		name = parts[0]
+		if len(parts) > 1 {
+			version = parts[1]
+		}
+	}
+	return
+}

--- a/pkg/api/message/v1/context_test.go
+++ b/pkg/api/message/v1/context_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAPI_Telemetry_parseVersionHeaderValue(t *testing.T) {
+func TestAPI_Context_parseVersionHeaderValue(t *testing.T) {
 	tcs := []struct {
 		name            string
 		value           []string

--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -175,11 +175,17 @@ func (s *Service) Query(ctx context.Context, req *proto.QueryRequest) (*proto.Qu
 	}
 
 	if req.StartTimeNs != 0 || req.EndTimeNs != 0 {
-		log.Info("query with time filters", zap.Uint64("start_time", req.StartTimeNs), zap.Uint64("end_time", req.EndTimeNs))
+		ri := NewRequesterInfo(ctx)
+		log.Info("query with time filters", append(
+			ri.ZapFields(),
+			zap.Uint64("start_time", req.StartTimeNs),
+			zap.Uint64("end_time", req.EndTimeNs),
+		)...)
 	}
 
 	if len(req.ContentTopics) > 1 {
-		log.Info("query with multiple topics")
+		ri := NewRequesterInfo(ctx)
+		log.Info("query with multiple topics", ri.ZapFields()...)
 	}
 
 	store, ok := s.waku.Store().(*store.XmtpStore)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -244,9 +244,9 @@ func allowCORS(h http.Handler) http.Handler {
 
 func incomingHeaderMatcher(key string) (string, bool) {
 	switch strings.ToLower(key) {
-	case clientVersionMetadataKey:
+	case messagev1.ClientVersionMetadataKey:
 		return key, true
-	case appVersionMetadataKey:
+	case messagev1.AppVersionMetadataKey:
 		return key, true
 	default:
 		return key, false


### PR DESCRIPTION
Include client/app version fields with logs for queries with multiple topics (https://github.com/xmtp/xmtp-node-go/pull/258) and time filters (https://github.com/xmtp/xmtp-node-go/pull/257), so we can see what clients/apps are making [the requests](https://app.datadoghq.com/dashboard/zau-bav-k8u/api-query-usage?from_ts=1677659329180&to_ts=1677662929180&live=true).