### PR TITLE
Don't return grpc error on subscribe context cancelled during send

### DIFF
--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -150,6 +150,9 @@ func (s *Service) Subscribe(req *proto.SubscribeRequest, stream proto.MessageApi
 			}
 			err := stream.Send(env)
 			if err != nil {
+				if err == context.Canceled {
+					return nil
+				}
 				log.Error("sending envelope to subscriber", zap.Error(err))
 			}
 		}


### PR DESCRIPTION
Don't return grpc error that results in HTTP 500 when context is cancelled during stream.Send https://github.com/xmtp/xmtp-node-go/issues/251