### PR TITLE
Add counter metric for published envelopes

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -56,6 +56,7 @@ func RegisterViews(logger *zap.Logger) {
 		StoredMessageView,
 		apiRequestsView,
 		publishedEnvelopeView,
+		publishedEnvelopeCounterView,
 	); err != nil {
 		logger.Fatal("registering metrics views", zap.Error(err))
 	}


### PR DESCRIPTION
I've been trying to get a view of published envelopes over the past month using the `xmtp_published_envelope.count` part of the histogram metric, but it doesn't seem to be possible in the way we want to use it in a toplist (I even checked with DD support). So this PR adds a counter metric for `xmtp_published_envelopes` that we can use for https://github.com/xmtp/xmtp-node-go/issues/261