### PR TITLE
Rename xmtpd-e2e docker image to node-go-e2e

### DIFF
--- a/.github/workflows/deploy-e2e.yml
+++ b/.github/workflows/deploy-e2e.yml
@@ -43,7 +43,7 @@ jobs:
           terraform-workspace: dev
           variable-name: xmtpd_e2e_image
           variable-value: ${{ steps.push.outputs.docker_image }}
-          variable-value-required-prefix: "xmtp/xmtpd-e2e@sha256:"
+          variable-value-required-prefix: "xmtp/node-go-e2e@sha256:"
 
       - name: Deploy (production)
         uses: xmtp-labs/terraform-deployer@v1
@@ -53,4 +53,4 @@ jobs:
           terraform-workspace: production
           variable-name: xmtpd_e2e_image
           variable-value: ${{ steps.push.outputs.docker_image }}
-          variable-value-required-prefix: "xmtp/xmtpd-e2e@sha256:"
+          variable-value-required-prefix: "xmtp/node-go-e2e@sha256:"

--- a/dev/e2e/build
+++ b/dev/e2e/build
@@ -2,7 +2,7 @@
 set -e
 
 DOCKER_IMAGE_TAG="${DOCKER_IMAGE_TAG:-dev}"
-DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:-xmtp/xmtpd-e2e}"
+DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:-xmtp/node-go-e2e}"
 GIT_COMMIT="$(git rev-parse HEAD)"
 GO_VERSION="$(go list -f "{{.GoVersion}}" -m)"
 

--- a/dev/e2e/build-local
+++ b/dev/e2e/build-local
@@ -2,7 +2,7 @@
 set -e
 
 DOCKER_IMAGE_TAG="${DOCKER_IMAGE_TAG:-dev}"
-DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:-xmtp/xmtpd-e2e}"
+DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:-xmtp/node-go-e2e}"
 GIT_COMMIT="$(git rev-parse HEAD)"
 GO_VERSION="$(go list -f "{{.GoVersion}}" -m)"
 


### PR DESCRIPTION
Rename xmtpd-e2e docker image to node-go-e2e to avoid conflicts with e2e image from https://github.com/xmtp/xmtpd