### PR TITLE
Send a header. Any header

### DIFF
--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -136,6 +136,8 @@ func (s *Service) Subscribe(req *proto.SubscribeRequest, stream proto.MessageApi
 	log := s.log.Named("subscribe").With(zap.Strings("content_topics", req.ContentTopics))
 	log.Debug("started")
 	defer log.Debug("stopped")
+	// Send a header (any header) to fix an issue with Tonic based GRPC clients.
+	// See: https://github.com/xmtp/libxmtp/pull/58
 	_ = stream.SendHeader(metadata.Pairs("subscribed", "true"))
 	subC := s.dispatcher.Register(nil, req.ContentTopics...)
 	defer s.dispatcher.Unregister(subC)


### PR DESCRIPTION
## Summary

After [banging my head against the wall for a day](https://github.com/xmtp/libxmtp/pull/58) trying to figure out why our Rust GRPC client would not start a stream until the first message has been received, I have found a hack to workaround the issue.

If we send a header, any header, down the GRPC stream Tonic will release control of the stream back to the caller.

I have tested this locally using `inbox-web` and confirm that the additional header doesn't break anything for web clients. I don't think these headers actually ever make it through GRPC gateway, since the HTTP headers have already been delivered and there is no support for trailers.

## Notes

I am going to make a reproducible test case in the Tonic repo, and open an issue for them to fix it on their end. Once that happens I think we can revert this PR (it appears to be a bug on Tonic's end and not a GRPC protocol expectation that a GRPC server send something at the start of a stream).