### PR TITLE
Add query marginalia as a SQL comment

### DIFF
--- a/pkg/store/query.go
+++ b/pkg/store/query.go
@@ -2,6 +2,9 @@ package store
 
 import (
 	"database/sql"
+	"fmt"
+	"strings"
+	"time"
 
 	sqlBuilder "github.com/huandu/go-sqlbuilder"
 	"github.com/status-im/go-waku/waku/persistence"
@@ -68,6 +71,7 @@ func buildSqlQuery(query *pb.HistoryQuery) (querySql string, args []interface{},
 	addSort(sb, direction)
 
 	querySql, args = sb.Build()
+	querySql = marginalia(query) + querySql
 
 	return querySql, args, err
 }
@@ -284,4 +288,51 @@ func minOf(vars ...int) int {
 	}
 
 	return min
+}
+
+func marginalia(query *pb.HistoryQuery) string {
+	var shape []string
+	var params strings.Builder
+	params.WriteString(fmt.Sprintf("TOPICS: %s\n", getContentTopics(query.ContentFilters)))
+	if query.StartTime != 0 {
+		shape = append(shape, "START")
+		params.WriteString(fmt.Sprintf("START: %v\n", toTime(query.StartTime)))
+	}
+	if query.EndTime != 0 {
+		shape = append(shape, "END")
+		params.WriteString(fmt.Sprintf("END: %v\n", toTime(query.EndTime)))
+	}
+	if query.PubsubTopic != "" {
+		shape = append(shape, "PUBSUB")
+		params.WriteString(fmt.Sprintf("PUBSUB: %s\n", query.PubsubTopic))
+	}
+	if pagingInfo := query.PagingInfo; pagingInfo != nil {
+		if pagingInfo.Direction == pb.PagingInfo_BACKWARD {
+			shape = append(shape, "DESC")
+			params.WriteString("DIRECTION: DESC\n")
+		} else {
+			shape = append(shape, "ASC")
+			params.WriteString("DIRECTION: ASC\n")
+		}
+		if pagingInfo.PageSize != 0 {
+			shape = append(shape, "LIMIT")
+			params.WriteString(fmt.Sprintf("LIMIT: %d\n", pagingInfo.PageSize))
+		}
+		if cursor := pagingInfo.Cursor; cursor != nil {
+			shape = append(shape, "CURSOR")
+			if cursor.SenderTime != 0 {
+				shape = append(shape, "SENDER_TIME")
+				params.WriteString(fmt.Sprintf("SENDER TIME: %v\n", toTime(cursor.SenderTime)))
+			}
+			if cursor.Digest != nil {
+				shape = append(shape, "DIGEST")
+				params.WriteString(fmt.Sprintf("DIGEST: %X\n", cursor.Digest))
+			}
+		}
+	}
+	return fmt.Sprintf("/* %s\n%s*/\n", strings.Join(shape, " "), params.String())
+}
+
+func toTime(nanos int64) time.Time {
+	return time.Unix(0, nanos).UTC()
 }

--- a/pkg/store/query_test.go
+++ b/pkg/store/query_test.go
@@ -2,7 +2,9 @@ package store
 
 import (
 	"database/sql"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3" // Blank import to register the sqlite3 driver
@@ -355,5 +357,58 @@ func TestPageSizeOne(t *testing.T) {
 			break
 		}
 		loops++
+	}
+}
+
+func TestMarginalia(t *testing.T) {
+	type tc struct {
+		query      *pb.HistoryQuery
+		marginalia string
+	}
+	for i, c := range []tc{
+		{
+			marginalia: "/* ",
+			query: &pb.HistoryQuery{
+				ContentFilters: []*pb.ContentFilter{
+					{
+						ContentTopic: "topic",
+					},
+				},
+			},
+		},
+		{
+			marginalia: "/* START END",
+			query: &pb.HistoryQuery{
+				ContentFilters: []*pb.ContentFilter{
+					{
+						ContentTopic: "topic",
+					},
+				},
+				StartTime: int64(1),
+				EndTime:   int64(2),
+			},
+		},
+		{
+			marginalia: "/* ASC LIMIT CURSOR SENDER_TIME DIGEST",
+			query: &pb.HistoryQuery{
+				ContentFilters: []*pb.ContentFilter{
+					{
+						ContentTopic: "topic",
+					},
+				},
+				PagingInfo: &pb.PagingInfo{
+					PageSize: 1,
+					Cursor: &pb.Index{
+						SenderTime: int64(2),
+						Digest:     []byte("digest"),
+					},
+					Direction: pb.PagingInfo_FORWARD,
+				},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			require.Equal(t, c.marginalia, strings.Split(marginalia(c.query), "\n")[0])
+		})
 	}
 }


### PR DESCRIPTION
This should prefix all SQL queries with a [comment](https://www.techonthenet.com/postgresql/comments.php) including marginalia describing the query that generated it, example query and marginalia: 
```
&pb.HistoryQuery{
ContentFilters: []*pb.ContentFilter{
	{
		ContentTopic: "topic",
	},
},
PagingInfo: &pb.PagingInfo{
	PageSize: 1,
	Cursor: &pb.Index{
		SenderTime: int64(2),
		Digest:     []byte("digest"),
	},
	Direction: pb.PagingInfo_FORWARD,
},

 /* ASC LIMIT CURSOR SENDER_TIME DIGEST
TOPICS: [topic]
DIRECTION: ASC
LIMIT: 1
SENDER TIME: 1970-01-01 00:00:00.000000002 +0000 UTC
DIGEST: 646967657374
*/
```

I'm hoping this will make it into the query logs and help debugging slow queries, e.g for #269 . First line is a terse summary of the query parameters, which should help distinguishing different types of queries. The rest are the actual parameter values. Note that it purposely doesn't show defaults that get inserted into the SQL (e.g. default descending order, or page size 100), the goal is to show what was specified in the query.

