### PR TITLE
Support group invites

### DIFF
--- a/pkg/api/interceptor.go
+++ b/pkg/api/interceptor.go
@@ -150,7 +150,7 @@ var TopicCategoryPermissions = map[string]int{
 	"dmE":          TopicCategoryPermissionNoAuthRequired,
 	"intro":        TopicCategoryPermissionNoAuthRequired,
 	"invite":       TopicCategoryPermissionNoAuthRequired,
-	"group-invite": TopicCategoryPermissionNoAuthRequired,
+	"groupInvite":  TopicCategoryPermissionNoAuthRequired,
 }
 
 func allowedToPublish(topic string, wallet types.WalletAddr) bool {

--- a/pkg/metrics/api_test.go
+++ b/pkg/metrics/api_test.go
@@ -20,7 +20,7 @@ func TestCategoryFromTopic(t *testing.T) {
 		"/xmtp/0/contact-0x43A3bD1a8a4cfF0aC27bFeda477774542f2B6A2b/proto":                                       "contact",
 		"/xmtp/0/privatestore-0x5AD7052d32880a11B654Eb7749429248db42958A/key_bundle/proto":                       "private",
 		"/xmtp/0/invite-0xC141028c42eb7871a4FF6BbC22E6AE8d05e2810c/proto":                                        "v2-invite",
-		"/xmtp/0/group-invite-0xC141028c42eb7871a4FF6BbC22E6AE8d05e2810c/proto":                                  "v2-group-invite",
+		"/xmtp/0/groupInvite-0xC141028c42eb7871a4FF6BbC22E6AE8d05e2810c/proto":                                   "v2-group-invite",
 		"/xmtp/0/dm-0xAa5CF238A4e000e0A28e6d6Ac2767DD428Bf030B-0xAa5CF238A4e000e0A28e6d6Ac2767DD428Bf030B/proto": "v1-conversation",
 		"/xmtp/0/m-TRA9YXFCT8oCx6iRAGkBfA6komD9FLv555w0hJcGIuI/proto":                                            "v2-conversation",
 		"/xmtp/0/intro-0xAa5CF238A4e000e0A28e6d6Ac2767DD428Bf030B/proto":                                         "v1-intro",

--- a/pkg/topic/topic.go
+++ b/pkg/topic/topic.go
@@ -9,7 +9,7 @@ var topicCategoryByPrefix = map[string]string{
 	"dm":           "v1-conversation",
 	"dmE":          "v1-conversation-ephemeral",
 	"invite":       "v2-invite",
-	"group-invite": "v2-group-invite",
+	"groupInvite":  "v2-group-invite",
 	"m":            "v2-conversation",
 	"mE":           "v2-conversation-ephemeral",
 	"privatestore": "private",


### PR DESCRIPTION
This lets the server know about group invites since they have a different topic string format.

See https://github.com/xmtp/xmtp-js/pull/381#issuecomment-1563644625 for the motivation behind adding a separate topic for group conversations.