### PR TITLE
Add query duration and result metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -57,6 +57,8 @@ func RegisterViews(logger *zap.Logger) {
 		apiRequestsView,
 		publishedEnvelopeView,
 		publishedEnvelopeCounterView,
+		queryDurationView,
+		queryResultView,
 	); err != nil {
 		logger.Fatal("registering metrics views", zap.Error(err))
 	}


### PR DESCRIPTION
that will show the various query durations and result sizes across the various query shapes. Besides the usual API tags, the `parameters` tag has a form of a 7 character string indicating which query parameters were specified `SE[AD]LCDT`, a dash `-` indicates absence. The meaning is as follows
```
1 [S] Start Time
2 [E] End Time
3 [AD] Sort Direction Asc/Desc
4 [L] Limit
5 [C] Cursor
6 [D] Cursor.Digest
7 [T] Cursor.SenderTime
```
The theoretical cardinality is 2^^6 * 3 = 192, but I expect we'll only see a handful of the combinations in practice.

The `error` tag is currently either absent for successful queries or has value `internal` for failing query. That leaves room for possibly refining it later.

https://github.com/xmtp/xmtp-node-go/issues/269