### PR TITLE
Add query marginalia as a SQL comment take 2

### DIFF
--- a/pkg/store/query_test.go
+++ b/pkg/store/query_test.go
@@ -2,7 +2,9 @@ package store
 
 import (
 	"database/sql"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3" // Blank import to register the sqlite3 driver
@@ -355,5 +357,69 @@ func TestPageSizeOne(t *testing.T) {
 			break
 		}
 		loops++
+	}
+}
+
+func TestMarginalia(t *testing.T) {
+	type tc struct {
+		query      *pb.HistoryQuery
+		marginalia string
+	}
+	for i, c := range []tc{
+		{
+			marginalia: "/* ",
+			query: &pb.HistoryQuery{
+				ContentFilters: []*pb.ContentFilter{
+					{
+						ContentTopic: "topic",
+					},
+				},
+			},
+		},
+		{
+			marginalia: "/* START END",
+			query: &pb.HistoryQuery{
+				ContentFilters: []*pb.ContentFilter{
+					{
+						ContentTopic: "topic",
+					},
+				},
+				StartTime: int64(1),
+				EndTime:   int64(2),
+			},
+		},
+		{
+			marginalia: "/* ASC LIMIT CURSOR SENDER_TIME DIGEST",
+			query: &pb.HistoryQuery{
+				ContentFilters: []*pb.ContentFilter{
+					{
+						ContentTopic: "topic",
+					},
+				},
+				PagingInfo: &pb.PagingInfo{
+					PageSize: 1,
+					Cursor: &pb.Index{
+						SenderTime: int64(2),
+						Digest:     []byte("digest"),
+					},
+					Direction: pb.PagingInfo_FORWARD,
+				},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			require.Equal(t, c.marginalia, strings.Split(marginalia(c.query), "\n")[0])
+		})
+	}
+}
+
+func TestMarginaliaSanitization(t *testing.T) {
+	for i, tc := range [][]string{
+		{"\n\tA4$\x88", "??A4$?"},
+		{"hello */ world\n", "hello ?? world?"},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			require.Equal(t, tc[1], sanitize(tc[0]))
+		})
 	}
 }


### PR DESCRIPTION
I have a suspicion that the reason why the first attempt #270 failed during rollout was https://github.com/xmtp/xmtp-js/pull/385. It seems we've been generating convo topic names with random bytes in them, which could conceivable throw off the SQL parser in postgres, since the topics were printed into the marginalia without any sanitization, which I'm going to add in this attempt.