### PR TITLE
Close DB query rows in FindMessages

### DIFF
--- a/pkg/store/query.go
+++ b/pkg/store/query.go
@@ -25,6 +25,7 @@ func FindMessages(db *sql.DB, query *pb.HistoryQuery) (res *pb.HistoryResponse, 
 	if err != nil {
 		return
 	}
+	defer rows.Close()
 
 	res, err = buildResponse(rows, query)
 


### PR DESCRIPTION
This might be why we're seeing DB connection spikes during https://github.com/xmtp/xmtp-node-go/issues/269 - and possibly even the cause of the degradation getting so out of hand during those periods.