### PR TITLE
Add DB query index and simplify sorting clause

### DIFF
--- a/pkg/migrations/messages/20230613104852_add-topic-ts-id-index.down.sql
+++ b/pkg/migrations/messages/20230613104852_add-topic-ts-id-index.down.sql
@@ -1,0 +1,5 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+DROP INDEX message_ctopic_sts_id_idx;

--- a/pkg/migrations/messages/20230613104852_add-topic-ts-id-index.up.sql
+++ b/pkg/migrations/messages/20230613104852_add-topic-ts-id-index.up.sql
@@ -1,0 +1,5 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+CREATE INDEX CONCURRENTLY message_ctopic_sts_id_idx ON public.message (contentTopic, senderTimestamp, id);


### PR DESCRIPTION
https://github.com/xmtp/xmtp-node-go/issues/269#issuecomment-1589049880

The query pattern looks like this:
```sql
SELECT 
    id, receivertimestamp, sendertimestamp, contenttopic, pubsubtopic, payload, version 
FROM message 
WHERE 
    contentTopic IN ('/xmtp/0/invite-ADDRESS/proto') AND 
    (senderTimestamp > 1684147362154000000 OR 
    (senderTimestamp = 1684147362154000000 AND id > 'ID')) 
ORDER BY senderTimestamp asc, id asc, pubsubTopic asc, receiverTimestamp asc 
LIMIT 100  
```

With this EXPLAIN:

![Screenshot 2023-06-13 at 6 37 44 AM](https://github.com/xmtp/xmtp-node-go/assets/182290/f96abab3-5b59-44c2-958d-df6053b5d8f6)