### PR TITLE
Disable high-volume query metrics

### DIFF
--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -209,10 +209,8 @@ func (s *Service) Query(ctx context.Context, req *proto.QueryRequest) (*proto.Qu
 	res, err := store.FindMessages(buildWakuQuery(req))
 	duration := time.Since(start)
 	if err != nil {
-		metrics.EmitQuery(ctx, req, 0, err, duration)
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
-	metrics.EmitQuery(ctx, req, len(res.Messages), nil, duration)
 	if duration > 10*time.Millisecond {
 		log.With(zap.Duration("duration", duration), zap.Int("results", len(res.Messages))).Info("slow query")
 	}


### PR DESCRIPTION
These metrics are very high-volume and currently taking out the rest of our node-specific metrics in DD. It's also not clear that they're adding much signal/value, since we already have RDS query monitoring directly in AWS, and we log slow queries in the nodes on top of that. This PR disables them so we're not flying blind. If at some point we want to add them back then we should make sure they don't take out the rest of the DD metrics first; we really can't operate reliably/safely with telemetry blackouts for extended periods of time.

![Screenshot 2023-06-15 at 8 19 52 AM](https://github.com/xmtp/xmtp-node-go/assets/182290/794cce9d-0b9c-4916-b793-7d09dacaef9b)

https://github.com/xmtp/xmtp-node-go/issues/269