### PR TITLE
Reintroduce the query metrics with less cardinality

### DIFF
--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -216,8 +216,10 @@ func (s *Service) Query(ctx context.Context, req *proto.QueryRequest) (*proto.Qu
 	res, err := store.FindMessages(buildWakuQuery(req))
 	duration := time.Since(start)
 	if err != nil {
+		metrics.EmitQuery(ctx, req, 0, err, duration)
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
+	metrics.EmitQuery(ctx, req, len(res.Messages), nil, duration)
 	if duration > 10*time.Millisecond {
 		log.With(zap.Duration("duration", duration), zap.Int("results", len(res.Messages))).Info("slow query")
 	}

--- a/pkg/metrics/api.go
+++ b/pkg/metrics/api.go
@@ -148,7 +148,7 @@ var queryResultView = &view.View{
 }
 
 func EmitQuery(ctx context.Context, req *proto.QueryRequest, results int, err error, duration time.Duration) {
-	mutators := contextMutators(ctx)
+	mutators := []tag.Mutator{}
 	if len(req.ContentTopics) > 0 {
 		topicCategory := topic.Category(req.ContentTopics[0])
 		mutators = append(mutators, tag.Insert(topicCategoryTag, topicCategory))


### PR DESCRIPTION
See https://github.com/xmtp/xmtp-node-go/pull/281#issuecomment-1598935997 for the analysis. This reintroduces the metrics removed by #281 with the highest cardinality tags removed.

One thing to note as well is that the individual tag cardinalities are somewhat misleading, because what matters is which combinations of those actually occur. The api_request_metric has a theoretical cardinality of tens of thousands, but it seems to be clocking at about a 1000 metrics.

As far as utility of these metrics go, I think they are quite helpful in understanding the query patterns. They were quite useful in identifying what was going on with #269. We can't get these from logs either as we only log what qualifies as "slow queries" with these parameters, so most of the query volume is not visible (at the info level).

If we decide to go ahead with this, caution and observation after deployment is certainly warranted.