### PR TITLE
IP based rate limiting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy Nodes
 on:
   push:
     branches:
-      - main
+      - ip-rate-limits
 jobs:
   deploy:
     concurrency: main
@@ -43,12 +43,3 @@ jobs:
           variable-value: ${{ steps.push.outputs.docker_image }}
           variable-value-required-prefix: "xmtp/node-go@sha256:"
 
-      - name: Deploy (production)
-        uses: xmtp-labs/terraform-deployer@v1
-        with:
-          terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
-          terraform-org: xmtp
-          terraform-workspace: production
-          variable-name: xmtp_node_image
-          variable-value: ${{ steps.push.outputs.docker_image }}
-          variable-value-required-prefix: "xmtp/node-go@sha256:"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy Nodes
 on:
   push:
     branches:
-      - ip-rate-limits
+      - main
 jobs:
   deploy:
     concurrency: main
@@ -43,3 +43,12 @@ jobs:
           variable-value: ${{ steps.push.outputs.docker_image }}
           variable-value-required-prefix: "xmtp/node-go@sha256:"
 
+      - name: Deploy (production)
+        uses: xmtp-labs/terraform-deployer@v1
+        with:
+          terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
+          terraform-org: xmtp
+          terraform-workspace: production
+          variable-name: xmtp_node_image
+          variable-value: ${{ steps.push.outputs.docker_image }}
+          variable-value-required-prefix: "xmtp/node-go@sha256:"

--- a/cmd/xmtpd/main.go
+++ b/cmd/xmtpd/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jessevdk/go-flags"
 	"github.com/pkg/errors"
 	"github.com/status-im/go-waku/waku/v2/utils"
+	"github.com/xmtp/xmtp-node-go/pkg/logging"
 	"github.com/xmtp/xmtp-node-go/pkg/server"
 	"github.com/xmtp/xmtp-node-go/pkg/tracing"
 	"go.uber.org/zap"
@@ -149,6 +150,16 @@ func main() {
 		s.WaitForShutdown()
 		doneC <- true
 	})
+
+	// Toggle debug level on SIGUSR1
+	sigToggleC := make(chan os.Signal, 1)
+	signal.Notify(sigToggleC, syscall.SIGUSR1)
+	go func() {
+		for range sigToggleC {
+			log.Info("toggling debug level")
+			logging.ToggleDebugLevel()
+		}
+	}()
 
 	sigC := make(chan os.Signal, 1)
 	signal.Notify(sigC,

--- a/dev/aws-shell
+++ b/dev/aws-shell
@@ -8,7 +8,7 @@
 
 region="${REGION:-us-east-2}"
 cluster="${ENV:-dev}"
-task="${TASK:-node-0}"
+task="${TASK:-group1-node-0}"
 container="${CONTAINER:-$task}"
 task=$(aws --region "$region" \
         --query 'taskArns[0]' \

--- a/pkg/api/interceptor.go
+++ b/pkg/api/interceptor.go
@@ -189,7 +189,7 @@ func (wa *WalletAuthorizer) applyLimits(ctx context.Context, fullMethod string, 
 	if err == nil {
 		return nil
 	}
-	wa.Log.Debug("rate limited",
+	wa.Log.Info("rate limited",
 		logging.String("client_ip", ip),
 		logging.WalletAddress(wallet.String()),
 		logging.Bool("priority", isPriority),

--- a/pkg/api/interceptor.go
+++ b/pkg/api/interceptor.go
@@ -189,6 +189,7 @@ func (wa *WalletAuthorizer) applyLimits(ctx context.Context, fullMethod string, 
 	if err == nil {
 		return nil
 	}
+
 	wa.Log.Info("rate limited",
 		logging.String("client_ip", ip),
 		logging.WalletAddress(wallet.String()),

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -14,6 +14,7 @@ import (
 	messageV1 "github.com/xmtp/proto/v3/go/message_api/v1"
 	messagev1api "github.com/xmtp/xmtp-node-go/pkg/api/message/v1"
 	messageclient "github.com/xmtp/xmtp-node-go/pkg/api/message/v1/client"
+	"github.com/xmtp/xmtp-node-go/pkg/ratelimiter"
 	test "github.com/xmtp/xmtp-node-go/pkg/testing"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -755,27 +756,70 @@ func Test_Publish_DenyListed(t *testing.T) {
 		require.NoError(t, err)
 
 		publishRes, err := client.Publish(ctx, &messageV1.PublishRequest{})
-		expectWalletDenied(t, err)
+		requireErrorEqual(t, err, codes.PermissionDenied, "wallet is deny listed")
 		require.Nil(t, publishRes)
 	})
 }
 
-func expectWalletDenied(t *testing.T, err error) {
-	grpcErr, ok := status.FromError(err)
-	if ok {
-		require.Equal(t, codes.PermissionDenied, grpcErr.Code())
-		require.Equal(t, "wallet is deny listed", grpcErr.Message())
-	} else {
-		parts := strings.SplitN(err.Error(), ": ", 2)
-		reason, msgJSON := parts[0], parts[1]
-		require.Equal(t, "403 Forbidden", reason)
-		var msg map[string]interface{}
-		err := json.Unmarshal([]byte(msgJSON), &msg)
+func Test_Ratelimits_Regular(t *testing.T) {
+	ctx := withAuth(t, context.Background())
+	testGRPCAndHTTP(t, ctx, func(t *testing.T, client messageclient.Client, server *Server) {
+		server.authorizer.Ratelimits = true
+		limiter, ok := server.authorizer.Limiter.(*ratelimiter.TokenBucketRateLimiter)
+		require.True(t, ok)
+		limiter.Limits[ratelimiter.PUBLISH] = &ratelimiter.Limit{MaxTokens: 1, RatePerMinute: 0}
+		envs := makeEnvelopes(2)
+		_, err := client.Publish(ctx, &messageV1.PublishRequest{Envelopes: envs[0:1]})
 		require.NoError(t, err)
-		require.Equal(t, map[string]interface{}{
-			"code":    float64(codes.PermissionDenied),
-			"message": "wallet is deny listed",
-			"details": []interface{}{},
-		}, msg)
+		_, err = client.Publish(ctx, &messageV1.PublishRequest{Envelopes: envs[1:2]})
+		requireErrorEqual(t, err, codes.ResourceExhausted, "rate limit exceeded")
+		// check that Query is not affected by publish quota
+		_, err = client.Query(ctx, &messageV1.QueryRequest{ContentTopics: []string{"topic"}})
+		require.NoError(t, err)
+	})
+}
+
+func Test_Ratelimits_Priority(t *testing.T) {
+	token, data, err := GenerateToken(time.Now(), false)
+	require.NoError(t, err)
+	et, err := EncodeToken(token)
+	require.NoError(t, err)
+	ctx := metadata.AppendToOutgoingContext(context.Background(), authorizationMetadataKey, "Bearer "+et)
+
+	testGRPCAndHTTP(t, ctx, func(t *testing.T, client messageclient.Client, server *Server) {
+		err := server.AllowLister.Allow(ctx, data.WalletAddr)
+		require.NoError(t, err)
+		server.authorizer.Ratelimits = true
+		limiter, ok := server.authorizer.Limiter.(*ratelimiter.TokenBucketRateLimiter)
+		require.True(t, ok)
+		limiter.Limits[ratelimiter.PUBLISH] = &ratelimiter.Limit{MaxTokens: 1, RatePerMinute: 0}
+		limiter.PriorityMultiplier = 2
+		envs := makeEnvelopes(3)
+		_, err = client.Publish(ctx, &messageV1.PublishRequest{Envelopes: envs[0:2]})
+		require.NoError(t, err)
+		_, err = client.Publish(ctx, &messageV1.PublishRequest{Envelopes: envs[2:3]})
+		requireErrorEqual(t, err, codes.ResourceExhausted, "rate limit exceeded")
+		// check that query is not affected by publish quota
+		_, err = client.Query(ctx, &messageV1.QueryRequest{ContentTopics: []string{"topic"}})
+		require.NoError(t, err)
+	})
+}
+
+func requireErrorEqual(t *testing.T, err error, code codes.Code, msg string, details ...interface{}) {
+	require.Error(t, err)
+	grpcErr, ok := status.FromError(err)
+	if ok { // GRPC
+		require.Equal(t, code, grpcErr.Code())
+		require.Equal(t, msg, grpcErr.Message())
+		require.ElementsMatch(t, details, grpcErr.Details())
+	} else { // HTTP
+		parts := strings.SplitN(err.Error(), ": ", 2)
+		_, errJSON := parts[0], parts[1]
+		var httpErr map[string]interface{}
+		err := json.Unmarshal([]byte(errJSON), &httpErr)
+		require.NoError(t, err)
+		require.Equal(t, float64(code), httpErr["code"])
+		require.Equal(t, msg, httpErr["message"])
+		require.ElementsMatch(t, details, httpErr["details"])
 	}
 }

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -789,9 +789,9 @@ func Test_Ratelimits_Regular(t *testing.T) {
 }
 
 func Test_Ratelimits_Priority(t *testing.T) {
-	token, data, err := GenerateToken(time.Now(), false)
+	token, data, err := generateV2AuthToken(time.Now())
 	require.NoError(t, err)
-	et, err := EncodeToken(token)
+	et, err := EncodeAuthToken(token)
 	require.NoError(t, err)
 	ctx := metadata.AppendToOutgoingContext(context.Background(), authorizationMetadataKey, "Bearer "+et)
 

--- a/pkg/api/setup_test.go
+++ b/pkg/api/setup_test.go
@@ -100,7 +100,7 @@ func testGRPCAndHTTP(t *testing.T, ctx context.Context, f func(*testing.T, messa
 	t.Run("grpc", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		server, cleanup := newTestServer(t)
 		defer cleanup()
@@ -127,7 +127,7 @@ func testGRPCAndHTTP(t *testing.T, ctx context.Context, f func(*testing.T, messa
 func testGRPC(t *testing.T, ctx context.Context, f func(*testing.T, messageclient.Client, *Server)) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	server, cleanup := newTestServer(t)
 	defer cleanup()

--- a/pkg/api/telemetry.go
+++ b/pkg/api/telemetry.go
@@ -10,7 +10,6 @@ import (
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -61,11 +60,8 @@ func (ti *TelemetryInterceptor) record(ctx context.Context, fullMethod string, e
 		ri.ZapFields()...,
 	)
 
-	md, _ := metadata.FromIncomingContext(ctx)
-	if ips := md.Get("x-forwarded-for"); len(ips) > 0 {
-		// There are potentially multiple comma separated IPs bundled in that first value
-		ips := strings.Split(ips[0], ",")
-		fields = append(fields, zap.String("client_ip", strings.TrimSpace(ips[0])))
+	if ip := clientIPFromContext(ctx); len(ip) > 0 {
+		fields = append(fields, zap.String("client_ip", ip))
 	}
 
 	logFn := ti.log.Debug

--- a/pkg/e2e/test_messagev1.go
+++ b/pkg/e2e/test_messagev1.go
@@ -36,7 +36,7 @@ func (s *Suite) testMessageV1PublishSubscribeQuery(log *zap.Logger) error {
 	defer cancel()
 	ctx, err := s.withAuth(ctx)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "adding auth token")
 	}
 
 	// Subscribe across nodes.
@@ -70,7 +70,7 @@ syncLoop:
 			},
 		})
 		if err != nil {
-			return errors.Wrap(err, "publishing")
+			return errors.Wrap(err, "publishing sync envelope")
 		}
 		syncEnvs = append(syncEnvs, syncEnv)
 
@@ -87,7 +87,7 @@ syncLoop:
 						prevSyncEnvs[string(syncEnv.Message)] = true
 						continue syncLoop
 					}
-					return err
+					return errors.Wrap(err, "reading sync envelope")
 				}
 				if prevSyncEnvs[string(env.Message)] {
 					s.log.Info("skipping previous sync envelope", zap.String("value", string(env.Message)))

--- a/pkg/logging/debug.go
+++ b/pkg/logging/debug.go
@@ -27,13 +27,13 @@ func IfDebug(field zap.Field) zap.Field {
 }
 
 // ToggleDebugLevel toggles the log level between DEBUG and INFO level.
-func ToggleDebugLevel() {
+func ToggleDebugLevel() error {
 	levelWaku := "DEBUG"
 	levelLibP2P := libp2p.LevelDebug
 	if IsDebugLevel() {
 		levelWaku = "INFO"
 		levelLibP2P = libp2p.LevelInfo
 	}
-	_ = waku.SetLogLevel(levelWaku)
 	libp2p.SetAllLoggers(levelLibP2P)
+	return waku.SetLogLevel(levelWaku)
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -27,6 +27,9 @@ var (
 	ENode      = logging.ENode
 	TCPAddr    = logging.TCPAddr
 	UDPAddr    = logging.UDPAddr
+	String     = zap.String
+	Bool       = zap.Bool
+	Int        = zap.Int
 )
 
 // WalletAddress creates a field for a wallet address.

--- a/pkg/metrics/api-limits.go
+++ b/pkg/metrics/api-limits.go
@@ -1,0 +1,37 @@
+package metrics
+
+import (
+	"context"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var bucketsNameKey = newTagKey("name")
+
+var ratelimiterBucketsGaugeMeasure = stats.Int64("ratelimiter_buckets", "size of ratelimiter buckets map", stats.UnitDimensionless)
+var ratelimiterBucketsGaugeView = &view.View{
+	Name:        "xmtp_ratelimiter_buckets",
+	Measure:     ratelimiterBucketsGaugeMeasure,
+	Description: "Size of rate-limiter buckets maps",
+	Aggregation: view.LastValue(),
+	TagKeys:     []tag.Key{bucketsNameKey},
+}
+
+func EmitRatelimiterBucketsSize(ctx context.Context, name string, size int) {
+	recordWithTags(ctx, []tag.Mutator{tag.Insert(topicCategoryTag, name)}, ratelimiterBucketsGaugeMeasure.M(int64(size)))
+}
+
+var ratelimiterBucketsDeletedCounterMeasure = stats.Int64("xmtp_ratelimiter_entries_deleted", "Count of deleted entries from ratelimiter buckets map", stats.UnitDimensionless)
+var ratelimiterBucketsDeletedCounterView = &view.View{
+	Name:        "xmtp_ratelimiter_entries_deleted",
+	Measure:     ratelimiterBucketsDeletedCounterMeasure,
+	Description: "Count of deleted entries from rate-limiter buckets maps",
+	Aggregation: view.Count(),
+	TagKeys:     []tag.Key{bucketsNameKey},
+}
+
+func EmitRatelimiterDeletedEntries(ctx context.Context, name string, count int) {
+	recordWithTags(ctx, []tag.Mutator{tag.Insert(topicCategoryTag, name)}, ratelimiterBucketsGaugeMeasure.M(int64(count)))
+}

--- a/pkg/metrics/api-limits.go
+++ b/pkg/metrics/api-limits.go
@@ -40,7 +40,7 @@ var ratelimiterBucketsDeletedCounterView = &view.View{
 }
 
 func EmitRatelimiterDeletedEntries(ctx context.Context, name string, count int) {
-	err := recordWithTags(ctx, []tag.Mutator{tag.Insert(bucketsNameKey, name)}, ratelimiterBucketsGaugeMeasure.M(int64(count)))
+	err := recordWithTags(ctx, []tag.Mutator{tag.Insert(bucketsNameKey, name)}, ratelimiterBucketsDeletedCounterMeasure.M(int64(count)))
 	if err != nil {
 		logging.From(ctx).Warn("recording metric",
 			zap.String("metric", ratelimiterBucketsDeletedCounterMeasure.Name()),

--- a/pkg/metrics/api-limits.go
+++ b/pkg/metrics/api-limits.go
@@ -22,7 +22,7 @@ var ratelimiterBucketsGaugeView = &view.View{
 }
 
 func EmitRatelimiterBucketsSize(ctx context.Context, name string, size int) {
-	err := recordWithTags(ctx, []tag.Mutator{tag.Insert(topicCategoryTag, name)}, ratelimiterBucketsGaugeMeasure.M(int64(size)))
+	err := recordWithTags(ctx, []tag.Mutator{tag.Insert(bucketsNameKey, name)}, ratelimiterBucketsGaugeMeasure.M(int64(size)))
 	if err != nil {
 		logging.From(ctx).Warn("recording metric",
 			zap.String("metric", ratelimiterBucketsGaugeMeasure.Name()),
@@ -40,7 +40,7 @@ var ratelimiterBucketsDeletedCounterView = &view.View{
 }
 
 func EmitRatelimiterDeletedEntries(ctx context.Context, name string, count int) {
-	err := recordWithTags(ctx, []tag.Mutator{tag.Insert(topicCategoryTag, name)}, ratelimiterBucketsGaugeMeasure.M(int64(count)))
+	err := recordWithTags(ctx, []tag.Mutator{tag.Insert(bucketsNameKey, name)}, ratelimiterBucketsGaugeMeasure.M(int64(count)))
 	if err != nil {
 		logging.From(ctx).Warn("recording metric",
 			zap.String("metric", ratelimiterBucketsDeletedCounterMeasure.Name()),

--- a/pkg/metrics/api-limits.go
+++ b/pkg/metrics/api-limits.go
@@ -3,9 +3,11 @@ package metrics
 import (
 	"context"
 
+	"github.com/xmtp/xmtp-node-go/pkg/logging"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	"go.uber.org/zap"
 )
 
 var bucketsNameKey = newTagKey("name")
@@ -20,7 +22,12 @@ var ratelimiterBucketsGaugeView = &view.View{
 }
 
 func EmitRatelimiterBucketsSize(ctx context.Context, name string, size int) {
-	recordWithTags(ctx, []tag.Mutator{tag.Insert(topicCategoryTag, name)}, ratelimiterBucketsGaugeMeasure.M(int64(size)))
+	err := recordWithTags(ctx, []tag.Mutator{tag.Insert(topicCategoryTag, name)}, ratelimiterBucketsGaugeMeasure.M(int64(size)))
+	if err != nil {
+		logging.From(ctx).Warn("recording metric",
+			zap.String("metric", ratelimiterBucketsGaugeMeasure.Name()),
+			zap.Error(err))
+	}
 }
 
 var ratelimiterBucketsDeletedCounterMeasure = stats.Int64("xmtp_ratelimiter_entries_deleted", "Count of deleted entries from ratelimiter buckets map", stats.UnitDimensionless)
@@ -33,5 +40,10 @@ var ratelimiterBucketsDeletedCounterView = &view.View{
 }
 
 func EmitRatelimiterDeletedEntries(ctx context.Context, name string, count int) {
-	recordWithTags(ctx, []tag.Mutator{tag.Insert(topicCategoryTag, name)}, ratelimiterBucketsGaugeMeasure.M(int64(count)))
+	err := recordWithTags(ctx, []tag.Mutator{tag.Insert(topicCategoryTag, name)}, ratelimiterBucketsGaugeMeasure.M(int64(count)))
+	if err != nil {
+		logging.From(ctx).Warn("recording metric",
+			zap.String("metric", ratelimiterBucketsDeletedCounterMeasure.Name()),
+			zap.Error(err))
+	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -59,6 +59,8 @@ func RegisterViews(logger *zap.Logger) {
 		publishedEnvelopeCounterView,
 		queryDurationView,
 		queryResultView,
+		ratelimiterBucketsGaugeView,
+		ratelimiterBucketsDeletedCounterView,
 	); err != nil {
 		logger.Fatal("registering metrics views", zap.Error(err))
 	}

--- a/pkg/ratelimiter/buckets.go
+++ b/pkg/ratelimiter/buckets.go
@@ -1,0 +1,83 @@
+package ratelimiter
+
+import (
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type Buckets struct {
+	name    string
+	log     *zap.Logger
+	mutex   sync.RWMutex
+	buckets map[string]*Entry
+}
+
+func NewBuckets(log *zap.Logger, name string) *Buckets {
+	return &Buckets{
+		name:    name,
+		log:     log.Named(name),
+		buckets: make(map[string]*Entry),
+		mutex:   sync.RWMutex{},
+	}
+}
+
+func (b *Buckets) getAndRefill(bucket string, limit *Limit, multiplier uint16, createIfMissing bool) *Entry {
+	// The locking strategy is adapted from the following blog post: https://misfra.me/optimizing-concurrent-map-access-in-go/
+	b.mutex.RLock()
+	currentVal, exists := b.buckets[bucket]
+	b.mutex.RUnlock()
+	if !exists {
+		if !createIfMissing {
+			return nil
+		}
+		b.mutex.Lock()
+		currentVal, exists = b.buckets[bucket]
+		if !exists {
+			currentVal = &Entry{
+				tokens:   uint16(limit.MaxTokens * multiplier),
+				lastSeen: time.Now(),
+				mutex:    sync.Mutex{},
+			}
+			b.buckets[bucket] = currentVal
+			b.mutex.Unlock()
+
+			return currentVal
+		}
+		b.mutex.Unlock()
+	}
+
+	limit.Refill(currentVal, multiplier)
+	return currentVal
+}
+
+func (b *Buckets) deleteExpired(expiresAfter time.Duration) (deleted int) {
+	// Use RLock to iterate over the map
+	// to allow concurrent reads
+	b.mutex.RLock()
+	var expired []string
+	for bucket, entry := range b.buckets {
+		if time.Since(entry.lastSeen) > expiresAfter {
+			expired = append(expired, bucket)
+		}
+	}
+	b.mutex.RUnlock()
+	if len(expired) == 0 {
+		return deleted
+	}
+	b.log.Info("found expired buckets", zap.Int("count", len(expired)))
+	// Use Lock for individual deletes to avoid prolonged
+	// lockout for readers.
+	for _, bucket := range expired {
+		b.mutex.Lock()
+		// check lastSeen again in case it was updated in the meantime.
+		if entry, exists := b.buckets[bucket]; exists && time.Since(entry.lastSeen) > expiresAfter {
+			delete(b.buckets, bucket)
+			deleted++
+		}
+		b.mutex.Unlock()
+	}
+	b.log.Info("deleted expired buckets", zap.Int("count", deleted))
+	return deleted
+}

--- a/pkg/ratelimiter/rate_limiter_test.go
+++ b/pkg/ratelimiter/rate_limiter_test.go
@@ -1,6 +1,7 @@
 package ratelimiter
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -13,18 +14,14 @@ const walletAddress = "0x1234"
 
 func TestSpend(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
-	rl := NewTokenBucketRateLimiter(logger)
-	rl.wallets[walletAddress] = &Entry{
-		lastSeen: time.Now(),
-		tokens:   uint16(1),
-		mutex:    sync.Mutex{},
-	}
+	rl := NewTokenBucketRateLimiter(context.Background(), logger)
+	rl.newBuckets.getAndRefill(walletAddress, &Limit{1, 0}, 1, true)
 
-	err1 := rl.Spend(walletAddress, false)
+	err1 := rl.Spend(DEFAULT, walletAddress, 1, false)
 	require.NoError(t, err1)
-	err2 := rl.Spend(walletAddress, false)
+	err2 := rl.Spend(DEFAULT, walletAddress, 1, false)
 	require.Error(t, err2)
-	if err2.Error() != "rate_limit_exceeded" {
+	if err2.Error() != "rate limit exceeded" {
 		t.Error("Incorrect error")
 	}
 }
@@ -32,84 +29,136 @@ func TestSpend(t *testing.T) {
 // Ensure that new entries are created for previously unseen wallets
 func TestSpendInitialize(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
-	rl := NewTokenBucketRateLimiter(logger)
-	entry := rl.fillAndReturnEntry(walletAddress, false)
-	require.Equal(t, entry.tokens, REGULAR_MAX_TOKENS)
+	rl := NewTokenBucketRateLimiter(context.Background(), logger)
+	entry := rl.fillAndReturnEntry(DEFAULT, walletAddress, false)
+	require.Equal(t, entry.tokens, DEFAULT_MAX_TOKENS)
 }
 
 // Set the clock back 1 minute and ensure that 1 item has been added to the bucket
 func TestSpendWithTime(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
-	rl := NewTokenBucketRateLimiter(logger)
-	rl.wallets[walletAddress] = &Entry{
-		// Set the last seen to 1 minute ago
-		lastSeen: time.Now().Add(-1 * time.Minute),
-		tokens:   uint16(0),
-		mutex:    sync.Mutex{},
-	}
-	err1 := rl.Spend(walletAddress, false)
+	rl := NewTokenBucketRateLimiter(context.Background(), logger)
+	rl.Limits[DEFAULT] = &Limit{100, 1}
+	entry := rl.newBuckets.getAndRefill(walletAddress, &Limit{0, 0}, 1, true)
+	// Set the last seen to 1 minute ago
+	entry.lastSeen = time.Now().Add(-1 * time.Minute)
+	err1 := rl.Spend(DEFAULT, walletAddress, 1, false)
 	require.NoError(t, err1)
-	err2 := rl.Spend(walletAddress, false)
+	err2 := rl.Spend(DEFAULT, walletAddress, 1, false)
 	require.Error(t, err2)
 }
 
 // Ensure that the token balance cannot go above the max bucket size
 func TestSpendMaxBucket(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
-	rl := NewTokenBucketRateLimiter(logger)
-	rl.wallets[walletAddress] = &Entry{
-		// Set last seen to 500 minutes ago
-		lastSeen: time.Now().Add(-500 * time.Minute),
-		tokens:   uint16(0),
-		mutex:    sync.Mutex{},
-	}
-	entry := rl.fillAndReturnEntry(walletAddress, false)
-	require.Equal(t, entry.tokens, REGULAR_MAX_TOKENS)
+	rl := NewTokenBucketRateLimiter(context.Background(), logger)
+	entry := rl.newBuckets.getAndRefill(walletAddress, &Limit{0, 0}, 1, true)
+	// Set last seen to 500 minutes ago
+	entry.lastSeen = time.Now().Add(-500 * time.Minute)
+	entry = rl.fillAndReturnEntry(DEFAULT, walletAddress, false)
+	require.Equal(t, entry.tokens, DEFAULT_MAX_TOKENS)
 }
 
 // Ensure that the allow list is being correctly applied
 func TestSpendAllowListed(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
-	rl := NewTokenBucketRateLimiter(logger)
-	rl.wallets[walletAddress] = &Entry{
-		// Set last seen to 500 minutes ago
-		lastSeen: time.Now().Add(-500 * time.Minute),
-		tokens:   uint16(0),
-		mutex:    sync.Mutex{},
-	}
-	entry := rl.fillAndReturnEntry(walletAddress, true)
-	require.Equal(t, entry.tokens, uint16(500*ALLOW_LISTED_RATE_PER_MINUTE))
+	rl := NewTokenBucketRateLimiter(context.Background(), logger)
+	entry := rl.newBuckets.getAndRefill(walletAddress, &Limit{0, 0}, 1, true)
+	// Set last seen to 5 minutes ago
+	entry.lastSeen = time.Now().Add(-5 * time.Minute)
+	entry = rl.fillAndReturnEntry(DEFAULT, walletAddress, true)
+	require.Equal(t, entry.tokens, uint16(5*DEFAULT_RATE_PER_MINUTE*PRIORITY_MULTIPLIER))
 }
 
 func TestMaxUint16(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
-	rl := NewTokenBucketRateLimiter(logger)
-	rl.wallets[walletAddress] = &Entry{
-		// Set last seen to 1 million minutes ago
-		lastSeen: time.Now().Add(-1000000 * time.Minute),
-		tokens:   uint16(0),
-		mutex:    sync.Mutex{},
-	}
-
-	entry := rl.fillAndReturnEntry(walletAddress, true)
-	require.Equal(t, entry.tokens, uint16(ALLOW_LISTED_MAX_TOKENS))
+	rl := NewTokenBucketRateLimiter(context.Background(), logger)
+	entry := rl.newBuckets.getAndRefill(walletAddress, &Limit{0, 0}, 1, true)
+	// Set last seen to 1 million minutes ago
+	entry.lastSeen = time.Now().Add(-1000000 * time.Minute)
+	entry = rl.fillAndReturnEntry(DEFAULT, walletAddress, true)
+	require.Equal(t, entry.tokens, DEFAULT_MAX_TOKENS*PRIORITY_MULTIPLIER)
 }
 
 // Ensures that the map can be accessed concurrently
 func TestSpendConcurrent(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
-	rl := NewTokenBucketRateLimiter(logger)
+	rl := NewTokenBucketRateLimiter(context.Background(), logger)
 	wg := sync.WaitGroup{}
-	for i := 0; i < 100; i++ {
+	for i := 0; i < int(PUBLISH_MAX_TOKENS); i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = rl.Spend(walletAddress, false)
+			_ = rl.Spend(PUBLISH, walletAddress, 1, false)
 		}()
 	}
 
 	wg.Wait()
 
-	entry := rl.fillAndReturnEntry(walletAddress, false)
+	entry := rl.fillAndReturnEntry(PUBLISH, walletAddress, false)
 	require.Equal(t, entry.tokens, uint16(0))
+}
+
+func TestBucketExpiration(t *testing.T) {
+	// Set things up so that entries are expired after two sweep intervals
+	expiresAfter := 100 * time.Millisecond
+	sweepInterval := 60 * time.Millisecond
+
+	logger, _ := zap.NewDevelopment()
+	rl := NewTokenBucketRateLimiter(context.Background(), logger)
+	rl.Limits[DEFAULT] = &Limit{2, 0} // 2 tokens, no refill
+
+	require.NoError(t, rl.Spend(DEFAULT, "ip1", 1, false)) // bucket1 add
+	require.NoError(t, rl.Spend(DEFAULT, "ip2", 1, false)) // bucket1 add
+
+	time.Sleep(sweepInterval)
+	require.Equal(t, 0, rl.sweepAndSwap(expiresAfter)) // sweep bucket2 and swap
+
+	require.NoError(t, rl.Spend(DEFAULT, "ip2", 1, false)) // bucket1 refresh
+	require.NoError(t, rl.Spend(DEFAULT, "ip3", 1, false)) // bucket2 add
+
+	time.Sleep(sweepInterval)
+	require.Equal(t, 1, rl.sweepAndSwap(expiresAfter)) // sweep bucket1 and swap, delete ip1
+
+	// ip2 has been refreshed every 60ms so it should still be out of tokens
+	require.Error(t, rl.Spend(DEFAULT, "ip2", 1, false)) // bucket1 refresh
+	// ip1 entry should have expired by now, so we should have 2 tokens again
+	require.NoError(t, rl.Spend(DEFAULT, "ip1", 1, false)) // bucket1 add
+	require.NoError(t, rl.Spend(DEFAULT, "ip1", 1, false)) // bucket1 refresh
+	require.Error(t, rl.Spend(DEFAULT, "ip1", 1, false))   // bucket1 refresh
+
+	time.Sleep(sweepInterval)
+	require.Equal(t, 1, rl.sweepAndSwap(expiresAfter)) // sweep bucket2 and swap, delete ip3
+
+	// ip2 should still be out of tokens
+	require.Error(t, rl.Spend(DEFAULT, "ip2", 1, false)) // bucket1 refresh
+	// ip3 should have expired now and we should have 2 tokens again
+	require.NoError(t, rl.Spend(DEFAULT, "ip3", 1, false)) // bucket2 add
+	require.NoError(t, rl.Spend(DEFAULT, "ip3", 1, false)) // bucket2 refresh
+	require.Error(t, rl.Spend(DEFAULT, "ip3", 1, false))   // bucket2 refresh
+}
+
+func TestBucketExpirationIntegrity(t *testing.T) {
+	expiresAfter := 10 * time.Millisecond
+	logger, _ := zap.NewDevelopment()
+	rl := NewTokenBucketRateLimiter(context.Background(), logger)
+	rl.Limits[DEFAULT] = &Limit{2, 0} // 2 tokens, no refill
+
+	require.NoError(t, rl.Spend(DEFAULT, "ip1", 1, false)) // bucket1 add
+
+	require.Equal(t, 0, rl.sweepAndSwap(expiresAfter)) // sweep bucket2 and swap
+
+	require.NoError(t, rl.Spend(DEFAULT, "ip1", 1, false)) // bucket1 refresh
+	require.Error(t, rl.Spend(DEFAULT, "ip1", 1, false))   // should be out of tokens now
+
+	require.Equal(t, 0, rl.sweepAndSwap(expiresAfter)) // sweep bucket1 and swap
+
+	require.Error(t, rl.Spend(DEFAULT, "ip1", 1, false)) // should still be out of tokens
+
+	require.Equal(t, 0, rl.sweepAndSwap(expiresAfter)) // sweep bucket2 and swap
+
+	time.Sleep(2 * expiresAfter)                       // wait until ip1 expires
+	require.Equal(t, 1, rl.sweepAndSwap(expiresAfter)) // sweep bucket1 and swap, delete ip1
+
+	require.NoError(t, rl.Spend(DEFAULT, "ip1", 1, false)) // bucket1 add
 }

--- a/pkg/ratelimiter/rate_limiter_test.go
+++ b/pkg/ratelimiter/rate_limiter_test.go
@@ -21,9 +21,7 @@ func TestSpend(t *testing.T) {
 	require.NoError(t, err1)
 	err2 := rl.Spend(DEFAULT, walletAddress, 1, false)
 	require.Error(t, err2)
-	if err2.Error() != "rate limit exceeded" {
-		t.Error("Incorrect error")
-	}
+	require.Equal(t, "1 exceeds rate limit 0x1234", err2.Error())
 }
 
 // Ensure that new entries are created for previously unseen wallets


### PR DESCRIPTION
I think this is the smallest change to achieve what we agreed on in https://github.com/xmtp-labs/hq/issues/1101. Here is the summary of the rules with the new changes in place (I can summarize the old rules, but I'm not sure that's really relevant at this point). None of this applies unless `--api.authn.enable` is set:

## `--api.authn.ratelimits`

All requests are subject to rate limits. Requests are bucketed by client IP address (there is one bucket for all requests without IPs). Each bucket is allocated a number of tokens that are refilled at a fixed rate per minute up to a given maximum number of tokens. Requests cost 1 token by default, except Publish requests cost the number of Envelopes carried and BatchQuery requests cost the number of queries carried. If `--api.authn.allowlists` is also set then requests with Bearer tokens from wallets explicitly `Allowed` get priority, i.e. higher bucket token max and refill rate. Priority wallets get separate IP buckets from regular wallets.

## `--api.authn.allowlists`

All requests that require authentication (currently Publish only) will be rejected for wallets that are explicitly `Denied`. Normally they will be permitted according to the rules of the request type, i.e. you can't publish into other wallets' contact and private topics (this applies regardless of this option).

Wallets that are explicitly `Allowed` will get priority rate limits if `--api.authn.ratelimits` is set.

## Notes

* The authorization flow is rewired a fair bit, I tried to disentangle the authorization and rate limiting bits, hopefully it's a bit clearer now.
* The rate limiter changes are 
  * adding a notion of cost to the spend logic
  * reifying Limit handling to make overriding the defaults easier for testing
  * also tried to clean up the terminology, calling things priority instead of allow listed, since that's a bit confusing in the rate limiting context, also purging the term wallet
* Added `Allow, Apply` to the AllowLister to be able to test priority rate limiting
* It may make sense to have completely different limits for stream requests given that they are long lasting and tax the system differently.
* ~~Also to replicate what we have at the edge we should have different limits for publishes and for the other requests.~~