### PR TITLE
Sweep expired rate limiter buckets

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -91,6 +91,8 @@ func (s *Server) startGRPC() error {
 		limiter := ratelimiter.NewTokenBucketRateLimiter(s.Log)
 		// Expire buckets after 6 hours of inactivity,
 		// sweep for expired buckets every hour.
+		// Note: entry expiration should be at least some multiple of
+		// maximum limit max / limit rate minutes.
 		go limiter.Janitor(s.ctx, time.Hour, 6*time.Hour)
 		s.authorizer = NewWalletAuthorizer(&AuthnConfig{
 			AuthnOptions: s.Config.Authn,

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -89,11 +89,11 @@ func (s *Server) startGRPC() error {
 
 	if s.Config.Authn.Enable {
 		limiter := ratelimiter.NewTokenBucketRateLimiter(s.Log)
-		// Expire buckets after 6 hours of inactivity,
-		// sweep for expired buckets every hour.
+		// Expire buckets after 1 hour of inactivity,
+		// sweep for expired buckets every 10 minutes.
 		// Note: entry expiration should be at least some multiple of
-		// maximum limit max / limit rate minutes.
-		go limiter.Janitor(s.ctx, time.Hour, 6*time.Hour)
+		// maximum (limit max / limit rate) minutes.
+		go limiter.Janitor(s.ctx, 10*time.Minute, 1*time.Hour)
 		s.authorizer = NewWalletAuthorizer(&AuthnConfig{
 			AuthnOptions: s.Config.Authn,
 			Limiter:      limiter,

--- a/pkg/ratelimiter/buckets.go
+++ b/pkg/ratelimiter/buckets.go
@@ -53,13 +53,13 @@ func (b *Buckets) deleteExpired(expiresAfter time.Duration) {
 	// Use RLock to iterate over the map
 	// to allow concurrent reads
 	b.mutex.RLock()
-	defer b.mutex.RUnlock()
 	var expired []string
 	for bucket, entry := range b.buckets {
 		if time.Since(entry.lastSeen) > expiresAfter {
 			expired = append(expired, bucket)
 		}
 	}
+	b.mutex.RUnlock()
 	if len(expired) == 0 {
 		return
 	}

--- a/pkg/ratelimiter/buckets.go
+++ b/pkg/ratelimiter/buckets.go
@@ -21,13 +21,13 @@ func NewBuckets(log *zap.Logger) *Buckets {
 	}
 }
 
-func (b *Buckets) getAndRefill(bucket string, limit *Limit, multiplier uint16, create bool) *Entry {
+func (b *Buckets) getAndRefill(bucket string, limit *Limit, multiplier uint16, createIfMissing bool) *Entry {
 	// The locking strategy is adapted from the following blog post: https://misfra.me/optimizing-concurrent-map-access-in-go/
 	b.mutex.RLock()
 	currentVal, exists := b.buckets[bucket]
 	b.mutex.RUnlock()
 	if !exists {
-		if !create {
+		if !createIfMissing {
 			return nil
 		}
 		b.mutex.Lock()
@@ -43,6 +43,7 @@ func (b *Buckets) getAndRefill(bucket string, limit *Limit, multiplier uint16, c
 
 			return currentVal
 		}
+		b.mutex.Unlock()
 	}
 
 	limit.Refill(currentVal, multiplier)

--- a/pkg/ratelimiter/buckets.go
+++ b/pkg/ratelimiter/buckets.go
@@ -62,7 +62,7 @@ func (b *Buckets) deleteExpired(expiresAfter time.Duration) (deleted int) {
 	}
 	b.mutex.RUnlock()
 	if len(expired) == 0 {
-		return
+		return deleted
 	}
 	b.log.Info("found expired buckets", zap.Int("count", len(expired)))
 	// Use Lock for individual deletes to avoid prolonged

--- a/pkg/ratelimiter/buckets.go
+++ b/pkg/ratelimiter/buckets.go
@@ -1,0 +1,80 @@
+package ratelimiter
+
+import (
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type Buckets struct {
+	log     *zap.Logger
+	mutex   sync.RWMutex
+	buckets map[string]*Entry
+}
+
+func NewBuckets(log *zap.Logger) *Buckets {
+	return &Buckets{
+		log:     log,
+		buckets: make(map[string]*Entry),
+		mutex:   sync.RWMutex{},
+	}
+}
+
+func (b *Buckets) getAndRefill(bucket string, limit *Limit, multiplier uint16, create bool) *Entry {
+	// The locking strategy is adapted from the following blog post: https://misfra.me/optimizing-concurrent-map-access-in-go/
+	b.mutex.RLock()
+	currentVal, exists := b.buckets[bucket]
+	b.mutex.RUnlock()
+	if !exists {
+		if !create {
+			return nil
+		}
+		b.mutex.Lock()
+		currentVal, exists = b.buckets[bucket]
+		if !exists {
+			currentVal = &Entry{
+				tokens:   uint16(limit.MaxTokens * multiplier),
+				lastSeen: time.Now(),
+				mutex:    sync.Mutex{},
+			}
+			b.buckets[bucket] = currentVal
+			b.mutex.Unlock()
+
+			return currentVal
+		}
+	}
+
+	limit.Refill(currentVal, multiplier)
+	return currentVal
+}
+
+func (b *Buckets) deleteExpired(expiresAfter time.Duration) {
+	// Use RLock to iterate over the map
+	// to allow concurrent reads
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+	var expired []string
+	for bucket, entry := range b.buckets {
+		if time.Since(entry.lastSeen) > expiresAfter {
+			expired = append(expired, bucket)
+		}
+	}
+	if len(expired) == 0 {
+		return
+	}
+	b.log.Info("found expired buckets", zap.Int("count", len(expired)))
+	// Use Lock for individual deletes to avoid prolonged
+	// lockout for readers.
+	count := 0
+	for _, bucket := range expired {
+		b.mutex.Lock()
+		// check lastSeen again in case it was updated in the meantime.
+		if entry, exists := b.buckets[bucket]; exists && time.Since(entry.lastSeen) > expiresAfter {
+			delete(b.buckets, bucket)
+			count++
+		}
+		b.mutex.Unlock()
+	}
+	b.log.Info("deleted expired buckets", zap.Int("count", count))
+}

--- a/pkg/ratelimiter/rate_limiter.go
+++ b/pkg/ratelimiter/rate_limiter.go
@@ -136,11 +136,16 @@ func (rl *TokenBucketRateLimiter) Janitor(ctx context.Context, sweepInterval, ex
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			rl.buckets2.deleteExpired(expiresAfter)
-			rl.buckets1, rl.buckets2 = rl.buckets2, rl.buckets1
-			rl.log.Info("swapped buckets")
+			rl.sweep(expiresAfter)
 		}
 	}
+}
+
+func (rl *TokenBucketRateLimiter) sweep(expiresAfter time.Duration) int {
+	deleted := rl.buckets2.deleteExpired(expiresAfter)
+	rl.buckets1, rl.buckets2 = rl.buckets2, rl.buckets1
+	rl.log.Info("swapped buckets")
+	return deleted
 }
 
 func minUint16(x, y uint16) uint16 {

--- a/pkg/ratelimiter/rate_limiter_test.go
+++ b/pkg/ratelimiter/rate_limiter_test.go
@@ -156,7 +156,7 @@ func TestBucketExpirationIntegrity(t *testing.T) {
 
 	require.Equal(t, 0, rl.sweepAndSwap(expiresAfter)) // sweep bucket2 and swap
 
-	time.Sleep(2 * expiresAfter)
+	time.Sleep(2 * expiresAfter)                       // wait until ip1 expires
 	require.Equal(t, 1, rl.sweepAndSwap(expiresAfter)) // sweep bucket1 and swap, delete ip1
 
 	require.NoError(t, rl.Spend(DEFAULT, "ip1", 1, false)) // bucket1 add


### PR DESCRIPTION
This adds a janitor process to the rate limiter to prevent unbounded growth of the bucket map. My main concern was locking out request flow while iterating over the potentially large bucket map looking for expired entries.

We can definitely do the search under the read lock, and do the removal separately under a write lock. However that is still potentially blocking requests from new IPs. Moreover as soon as a new IP queues up a write lock request, any following read lock requests will be blocked as well (I'm not 100% sure about this but I don't see how else you can prevent write lock requests being preempted by read locks forever).

To address the write lock blocking I split the bucket maps into two. One will be subject to creating new IP entries, and the other will be subject to the expiration sweep. That way the writes and sweeps should not collide. The cost is having to read 2 maps to check for entry presence (and consequently 2 read locks) on every read access, but I think it's worth it to avoid unpredictable sweep pauses. The maps' roles are swapped after every sweep.

## Notes

* We could try to be more clever about keeping the two maps roughly the same size, but maybe let's collect some metrics first to see whether it's worth it

## Update

Also added another mutex at the Limiter level, to protect the swap of the two buffer maps. Otherwise a goroutine that is in the middle of `fillAndReturnEntry` could end up getting the same map in the second check. Consequently we have two layers of mutexes now so we need to be careful about locking them in a fixed order so that we don't deadlock.