### PR TITLE
Fix grpc error logging for streaming requests

### DIFF
--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -135,7 +135,7 @@ func (s *Service) Close() {
 func (s *Service) Publish(ctx context.Context, req *proto.PublishRequest) (*proto.PublishResponse, error) {
 	for _, env := range req.Envelopes {
 		log := s.log.Named("publish").With(zap.String("content_topic", env.ContentTopic))
-		log.Info("received message")
+		log.Debug("received message")
 
 		if len(env.ContentTopic) > MaxContentTopicNameSize {
 			return nil, status.Errorf(codes.InvalidArgument, "topic length too big")

--- a/pkg/api/telemetry.go
+++ b/pkg/api/telemetry.go
@@ -44,9 +44,9 @@ func (ti *TelemetryInterceptor) Stream() grpc.StreamServerInterceptor {
 		info *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,
 	) error {
-		res := handler(srv, stream)
-		ti.record(stream.Context(), info.FullMethod, nil)
-		return res
+		err := handler(srv, stream)
+		ti.record(stream.Context(), info.FullMethod, err)
+		return err
 	}
 }
 

--- a/pkg/api/telemetry.go
+++ b/pkg/api/telemetry.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
@@ -78,6 +79,11 @@ func (ti *TelemetryInterceptor) record(ctx context.Context, fullMethod string, e
 			fields = append(fields, []zapcore.Field{
 				zap.String("error_code", errCode),
 				zap.String("error_message", grpcErr.Message()),
+			}...)
+		} else {
+			fields = append(fields, []zapcore.Field{
+				zap.String("error_code", codes.Internal.String()),
+				zap.String("error_message", err.Error()),
 			}...)
 		}
 	}


### PR DESCRIPTION
We're seeing some grpc errors reported from the grpc_server_handled metric on the subscribe endpoint, but our request logger isn't recording them, so this PR fixes that.