### PR TITLE
Hash topic for nats subject

### DIFF
--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -203,6 +203,7 @@ func (s *Service) Subscribe(req *proto.SubscribeRequest, stream proto.MessageApi
 			}()
 		})
 		if err != nil {
+			log.Error("error subscribing", zap.Error(err))
 			return err
 		}
 		defer func() {

--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -2,8 +2,8 @@ package api
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
+	"fmt"
+	"hash/fnv"
 	"io"
 	"strings"
 	"sync"
@@ -509,6 +509,7 @@ func toWakuTimestamp(ts uint64) int64 {
 }
 
 func buildNatsSubject(topic string) string {
-	hash := sha256.Sum256([]byte(topic))
-	return hex.EncodeToString(hash[:])
+	hasher := fnv.New64a()
+	hasher.Write([]byte(topic))
+	return fmt.Sprintf("%x", hasher.Sum64())
 }


### PR DESCRIPTION
We're seeing some `nats: invalid subject` errors from the subscribe handler, so this PR fixes that by hashing the topic to ensure [valid nats subject](https://docs.nats.io/nats-concepts/subjects#characters-allowed-for-subject-names).