### PR TITLE
Consistent e2e auth identity

### DIFF
--- a/cmd/xmtpd-e2e/main.go
+++ b/cmd/xmtpd-e2e/main.go
@@ -41,17 +41,17 @@ func main() {
 
 	apiURL := envVar("XMTPD_E2E_API_URL", remoteAPIURLByEnv[networkEnv])
 
-	walletKeyHex := envVar("XMTPD_E2E_AUTH_WALLET_KEY", "")
-	var walletKey *ecdsa.PrivateKey
-	if walletKeyHex != "" {
-		walletKey, err = crypto.HexToECDSA(walletKeyHex)
+	v2WalletKeyHex := envVar("XMTPD_E2E_V2_AUTH_WALLET_KEY", "")
+	var v2WalletKey *ecdsa.PrivateKey
+	if v2WalletKeyHex != "" {
+		v2WalletKey, err = crypto.HexToECDSA(v2WalletKeyHex)
 		requireNoError(err)
 	}
 
-	installationKeyHex := envVar("XMTPD_E2E_AUTH_INSTALLATION_KEY", "")
-	var installationKey *ecdsa.PrivateKey
-	if installationKeyHex != "" {
-		installationKey, err = crypto.HexToECDSA(installationKeyHex)
+	v2IdentityKeyHex := envVar("XMTPD_E2E_V2_AUTH_IDENTITY_KEY", "")
+	var v2IdentityKey *ecdsa.PrivateKey
+	if v2IdentityKeyHex != "" {
+		v2IdentityKey, err = crypto.HexToECDSA(v2IdentityKeyHex)
 		requireNoError(err)
 	}
 
@@ -64,8 +64,8 @@ func main() {
 		APIURL:                  apiURL,
 		DelayBetweenRunsSeconds: envVarInt("XMTPD_E2E_DELAY", 5),
 		GitCommit:               GitCommit,
-		WalletKey:               walletKey,
-		InstallationKey:         installationKey,
+		V2WalletKey:             v2WalletKey,
+		V2InstallationKey:       v2IdentityKey,
 	})
 
 	err = runner.Start()

--- a/pkg/api/interceptor.go
+++ b/pkg/api/interceptor.go
@@ -104,7 +104,7 @@ func (wa *WalletAuthorizer) authorize(ctx context.Context, req interface{}) erro
 	if scheme := strings.TrimSpace(words[0]); scheme != "Bearer" {
 		return status.Errorf(codes.Unauthenticated, "unrecognized authorization scheme %s", scheme)
 	}
-	token, err := decodeToken(strings.TrimSpace(words[1]))
+	token, err := decodeAuthToken(strings.TrimSpace(words[1]))
 	if err != nil {
 		return status.Errorf(codes.Unauthenticated, "extracting token: %s", err)
 	}

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -744,7 +744,7 @@ func Test_BatchQueryOverLimitError(t *testing.T) {
 }
 
 func Test_Publish_DenyListed(t *testing.T) {
-	token, data, err := generateAuthToken(time.Now(), false)
+	token, data, err := generateV2AuthToken(time.Now())
 	require.NoError(t, err)
 	et, err := EncodeAuthToken(token)
 	require.NoError(t, err)

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -744,9 +744,9 @@ func Test_BatchQueryOverLimitError(t *testing.T) {
 }
 
 func Test_Publish_DenyListed(t *testing.T) {
-	token, data, err := GenerateToken(time.Now(), false)
+	token, data, err := generateAuthToken(time.Now(), false)
 	require.NoError(t, err)
-	et, err := EncodeToken(token)
+	et, err := EncodeAuthToken(token)
 	require.NoError(t, err)
 	ctx := metadata.AppendToOutgoingContext(context.Background(), authorizationMetadataKey, "Bearer "+et)
 

--- a/pkg/api/setup_test.go
+++ b/pkg/api/setup_test.go
@@ -149,29 +149,29 @@ func withExpiredAuth(t *testing.T, ctx context.Context) context.Context {
 }
 
 func withMissingAuthData(t *testing.T, ctx context.Context) context.Context {
-	token, _, err := GenerateToken(time.Now(), false)
+	token, _, err := generateAuthToken(time.Now(), false)
 	require.NoError(t, err)
 	token.AuthDataBytes = nil
 	token.AuthDataSignature = nil
-	et, err := EncodeToken(token)
+	et, err := EncodeAuthToken(token)
 	require.NoError(t, err)
 	return metadata.AppendToOutgoingContext(ctx, authorizationMetadataKey, "Bearer "+et)
 }
 
 // Test possible malicious behavior of the client.
 func withMissingIdentityKey(t *testing.T, ctx context.Context) context.Context {
-	token, _, err := GenerateToken(time.Now(), false)
+	token, _, err := generateAuthToken(time.Now(), false)
 	require.NoError(t, err)
 	token.IdentityKey = nil
-	et, err := EncodeToken(token)
+	et, err := EncodeAuthToken(token)
 	require.NoError(t, err)
 	return metadata.AppendToOutgoingContext(ctx, authorizationMetadataKey, "Bearer "+et)
 }
 
 func withAuthWithDetails(t *testing.T, ctx context.Context, when time.Time) (context.Context, *v1.AuthData) {
-	token, data, err := GenerateToken(when, false)
+	token, data, err := generateAuthToken(when, false)
 	require.NoError(t, err)
-	et, err := EncodeToken(token)
+	et, err := EncodeAuthToken(token)
 	require.NoError(t, err)
 	return metadata.AppendToOutgoingContext(ctx, authorizationMetadataKey, "Bearer "+et), data
 }

--- a/pkg/api/setup_test.go
+++ b/pkg/api/setup_test.go
@@ -149,7 +149,7 @@ func withExpiredAuth(t *testing.T, ctx context.Context) context.Context {
 }
 
 func withMissingAuthData(t *testing.T, ctx context.Context) context.Context {
-	token, _, err := generateAuthToken(time.Now(), false)
+	token, _, err := generateV2AuthToken(time.Now())
 	require.NoError(t, err)
 	token.AuthDataBytes = nil
 	token.AuthDataSignature = nil
@@ -160,7 +160,7 @@ func withMissingAuthData(t *testing.T, ctx context.Context) context.Context {
 
 // Test possible malicious behavior of the client.
 func withMissingIdentityKey(t *testing.T, ctx context.Context) context.Context {
-	token, _, err := generateAuthToken(time.Now(), false)
+	token, _, err := generateV2AuthToken(time.Now())
 	require.NoError(t, err)
 	token.IdentityKey = nil
 	et, err := EncodeAuthToken(token)
@@ -169,7 +169,7 @@ func withMissingIdentityKey(t *testing.T, ctx context.Context) context.Context {
 }
 
 func withAuthWithDetails(t *testing.T, ctx context.Context, when time.Time) (context.Context, *v1.AuthData) {
-	token, data, err := generateAuthToken(when, false)
+	token, data, err := generateV2AuthToken(when)
 	require.NoError(t, err)
 	et, err := EncodeAuthToken(token)
 	require.NoError(t, err)

--- a/pkg/api/token_test.go
+++ b/pkg/api/token_test.go
@@ -17,22 +17,11 @@ func randomBytes(n int) []byte {
 	return b
 }
 
-func Test_NominalV1(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
-	ctx := logging.With(context.Background(), logger)
-	now := time.Now()
-	token, data, err := generateAuthToken(now.Add(-time.Minute), true)
-	require.NoError(t, err)
-	walletAddr, err := validateToken(ctx, logger, token, now)
-	require.NoError(t, err)
-	require.Equal(t, data.WalletAddr, string(walletAddr), "wallet address mismatch")
-}
-
 func Test_NominalV2(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	ctx := logging.With(context.Background(), logger)
 	now := time.Now()
-	token, data, err := generateAuthToken(now.Add(-time.Minute), false)
+	token, data, err := generateV2AuthToken(now.Add(-time.Minute))
 	require.NoError(t, err)
 	walletAddr, err := validateToken(ctx, logger, token, now)
 	require.NoError(t, err)
@@ -59,7 +48,7 @@ func Test_BadAuthSig(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	ctx := logging.With(context.Background(), logger)
 	now := time.Now()
-	token, _, err := generateAuthToken(now.Add(-time.Minute), false)
+	token, _, err := generateV2AuthToken(now.Add(-time.Minute))
 	require.NoError(t, err)
 	token.GetAuthDataSignature().GetEcdsaCompact().Bytes = randomBytes(64)
 	_, err = validateToken(ctx, logger, token, now)
@@ -71,9 +60,9 @@ func Test_SignatureMismatch(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	ctx := logging.With(context.Background(), logger)
 	now := time.Now()
-	token1, _, err := generateAuthToken(now.Add(-time.Minute), false)
+	token1, _, err := generateV2AuthToken(now.Add(-time.Minute))
 	require.NoError(t, err)
-	token2, _, err := generateAuthToken(now.Add(-time.Minute), false)
+	token2, _, err := generateV2AuthToken(now.Add(-time.Minute))
 	require.NoError(t, err)
 
 	// Nominal Checks

--- a/pkg/api/token_test.go
+++ b/pkg/api/token_test.go
@@ -21,7 +21,7 @@ func Test_NominalV1(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	ctx := logging.With(context.Background(), logger)
 	now := time.Now()
-	token, data, err := GenerateToken(now.Add(-time.Minute), true)
+	token, data, err := generateAuthToken(now.Add(-time.Minute), true)
 	require.NoError(t, err)
 	walletAddr, err := validateToken(ctx, logger, token, now)
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func Test_NominalV2(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	ctx := logging.With(context.Background(), logger)
 	now := time.Now()
-	token, data, err := GenerateToken(now.Add(-time.Minute), false)
+	token, data, err := generateAuthToken(now.Add(-time.Minute), false)
 	require.NoError(t, err)
 	walletAddr, err := validateToken(ctx, logger, token, now)
 	require.NoError(t, err)
@@ -48,7 +48,7 @@ func Test_XmtpjsToken(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	ctx := logging.With(context.Background(), logger)
 	now := time.Unix(0, tokenCreatedNs).Add(10 * time.Minute)
-	token, err := decodeToken(tokenBytes)
+	token, err := decodeAuthToken(tokenBytes)
 	require.NoError(t, err)
 	walletAddr, err := validateToken(ctx, logger, token, now)
 	require.NoError(t, err)
@@ -59,7 +59,7 @@ func Test_BadAuthSig(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	ctx := logging.With(context.Background(), logger)
 	now := time.Now()
-	token, _, err := GenerateToken(now.Add(-time.Minute), false)
+	token, _, err := generateAuthToken(now.Add(-time.Minute), false)
 	require.NoError(t, err)
 	token.GetAuthDataSignature().GetEcdsaCompact().Bytes = randomBytes(64)
 	_, err = validateToken(ctx, logger, token, now)
@@ -71,9 +71,9 @@ func Test_SignatureMismatch(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	ctx := logging.With(context.Background(), logger)
 	now := time.Now()
-	token1, _, err := GenerateToken(now.Add(-time.Minute), false)
+	token1, _, err := generateAuthToken(now.Add(-time.Minute), false)
 	require.NoError(t, err)
-	token2, _, err := GenerateToken(now.Add(-time.Minute), false)
+	token2, _, err := generateAuthToken(now.Add(-time.Minute), false)
 	require.NoError(t, err)
 
 	// Nominal Checks
@@ -93,19 +93,19 @@ func Test_SignatureMismatch(t *testing.T) {
 }
 
 func Test_DecodeXmtpjsToken(t *testing.T) {
-	_, err := decodeToken("CpIBCOqy8+iqMBJECkIKQGsPVyMg1ZjfJXCu7+IxuRJ9/JrWvPIPsZ+GjRM+eQ8kLCfuOequP3GscERICC3qRk/l4eCW/kqM5fbd5/TcQHEaQwpBBAzYR20tIAxsD3cXSnrDBoZ8xr2FPgA9d4u1QzaNt/t0tpQ9G6i9ju35nCDTr35iMbZvbYfZJKYbed2ABOZ2xdMSNgoqMHg1NDY3ZUU5ZGU5MmE3ZDgzMGE3MTMxNTZkZjg4ZGQ2Qjg3MDQwZUY2EMCs9dTXv42GFxpGCkQKQBoIQ77Vi0SU3M5s1WsthNiJgI8Vx89cSzZvJiaIVNJYCJO2x55eEex5R4o55XFvoNrgGcRyDOGg3WMsTWlWOx8QAQ==")
+	_, err := decodeAuthToken("CpIBCOqy8+iqMBJECkIKQGsPVyMg1ZjfJXCu7+IxuRJ9/JrWvPIPsZ+GjRM+eQ8kLCfuOequP3GscERICC3qRk/l4eCW/kqM5fbd5/TcQHEaQwpBBAzYR20tIAxsD3cXSnrDBoZ8xr2FPgA9d4u1QzaNt/t0tpQ9G6i9ju35nCDTr35iMbZvbYfZJKYbed2ABOZ2xdMSNgoqMHg1NDY3ZUU5ZGU5MmE3ZDgzMGE3MTMxNTZkZjg4ZGQ2Qjg3MDQwZUY2EMCs9dTXv42GFxpGCkQKQBoIQ77Vi0SU3M5s1WsthNiJgI8Vx89cSzZvJiaIVNJYCJO2x55eEex5R4o55XFvoNrgGcRyDOGg3WMsTWlWOx8QAQ==")
 	require.NoError(t, err)
 }
 
 func Test_DecodeInvalidToken(t *testing.T) {
-	token, err := decodeToken("aGk=")
+	token, err := decodeAuthToken("aGk=")
 	require.Error(t, err)
 	require.Nil(t, token)
 	require.Contains(t, err.Error(), "missing identity key")
 }
 
 func Test_DecodeEmptyToken(t *testing.T) {
-	token, err := decodeToken("")
+	token, err := decodeAuthToken("")
 	require.Error(t, err)
 	require.Nil(t, token)
 	require.Contains(t, err.Error(), "missing identity key")

--- a/pkg/crypto/ecdsa.go
+++ b/pkg/crypto/ecdsa.go
@@ -1,0 +1,22 @@
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+func HexToECDSA(key string) (*ecdsa.PrivateKey, error) {
+	if len(key) == 60 {
+		key = "0000" + key
+	}
+	if len(key) == 62 {
+		key = "00" + key
+	}
+	return ethcrypto.HexToECDSA(key)
+}
+
+func ECDSAToHex(key *ecdsa.PrivateKey) string {
+	return hex.EncodeToString(key.D.Bytes())
+}

--- a/pkg/crypto/ecdsa_test.go
+++ b/pkg/crypto/ecdsa_test.go
@@ -1,0 +1,55 @@
+package crypto_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtp-node-go/pkg/crypto"
+)
+
+func TestHexToECDSA(t *testing.T) {
+	tcs := []struct {
+		name        string
+		key         string
+		expectedErr string
+	}{
+		{
+			name: "length 64 valid",
+			key:  "1df2b07b69f67be885148ef85ced1576048c7c33fb861f7cd8e9b62e13013330",
+		},
+		{
+			name: "length 62 valid",
+			key:  "f2b07b69f67be885148ef85ced1576048c7c33fb861f7cd8e9b62e13013330",
+		},
+		{
+			name: "length 60 valid",
+			key:  "b07b69f67be885148ef85ced1576048c7c33fb861f7cd8e9b62e13013330",
+		},
+		{
+			name:        "length 58 valid",
+			key:         "7b69f67be885148ef85ced1576048c7c33fb861f7cd8e9b62e13013330",
+			expectedErr: "invalid length, need 256 bits",
+		},
+		{
+			name:        "length 66 valid",
+			key:         "c7c33fb07b69f67be885148ef85ced1576048c7c33fb861f7cd8e9b62e13013330",
+			expectedErr: "invalid length, need 256 bits",
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			key, err := crypto.HexToECDSA(tc.key)
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				require.EqualError(t, err, tc.expectedErr)
+			} else {
+				keyHex := hex.EncodeToString(key.D.Bytes())
+				require.Equal(t, tc.key, keyHex)
+			}
+		})
+	}
+}

--- a/pkg/crypto/signatures_test.go
+++ b/pkg/crypto/signatures_test.go
@@ -1,10 +1,11 @@
-package crypto
+package crypto_test
 
 import (
 	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtp-node-go/pkg/crypto"
 	"github.com/xmtp/xmtp-node-go/pkg/types"
 )
 
@@ -15,14 +16,14 @@ func TestStaticSignatureRoundTrip(t *testing.T) {
 	bpk, _ := hex.DecodeString("0497a556a06d5270300967b2d64ae2997af9efe872f8d146c155b91f6bc2315cf6a941a7ea80bb84edea2ffff5637b4f736e2aa64cfb98d6276e168dd1e7cdfc6d")
 	msg := []byte("TestPeerID|0x12345")
 
-	PK, _ := PrivateKeyFromBytes(bPK)
-	pk, _ := PublicKeyFromBytes(bpk)
+	PK, _ := crypto.PrivateKeyFromBytes(bPK)
+	pk, _ := crypto.PublicKeyFromBytes(bpk)
 
-	generatedSig, recovery, err := Sign(PK, msg)
+	generatedSig, recovery, err := crypto.Sign(PK, msg)
 	require.NoError(t, err)
 	require.True(t, recovery == 0 || recovery == 1, "bad recovery code")
 
-	isValid := Verify(pk, msg, generatedSig)
+	isValid := crypto.Verify(pk, msg, generatedSig)
 	require.True(t, isValid, "Signature validation failed")
 }
 
@@ -31,9 +32,9 @@ func TestStaticWalletVerify(t *testing.T) {
 	bSig, _ := hex.DecodeString("b6c023b2f93db3f51c392f8b9019ff2a4f19b30cac6b61f8356f027431332173043c8e0553d87740745a953d437d64a747865c4c28938d3fbbe10f961fd05b8f")
 	expectedAddr := types.WalletAddr("0x9727188932c3f9a218e8Fc9D8744b1B8b751Abfc")
 	recovery := uint8(0)
-	sig, _ := SignatureFromBytes(bSig)
+	sig, _ := crypto.SignatureFromBytes(bSig)
 
-	walletAddr, err := RecoverWalletAddress(bMsg, sig, recovery)
+	walletAddr, err := crypto.RecoverWalletAddress(bMsg, sig, recovery)
 	require.NoError(t, err)
 	require.Equal(t, expectedAddr, walletAddr)
 }

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -33,8 +33,8 @@ type Config struct {
 	DelayBetweenRunsSeconds int
 	GitCommit               string
 
-	WalletKey       *ecdsa.PrivateKey
-	InstallationKey *ecdsa.PrivateKey
+	V2WalletKey       *ecdsa.PrivateKey
+	V2InstallationKey *ecdsa.PrivateKey
 }
 
 type testRunFunc func(log *zap.Logger) error
@@ -45,17 +45,17 @@ type Test struct {
 }
 
 func NewSuite(ctx context.Context, log *zap.Logger, config *Config) *Suite {
-	if config.WalletKey == nil {
-		log.Info("no auth wallet key provided, generating a new one to use")
-		config.WalletKey, _ = ethcrypto.GenerateKey()
+	if config.V2WalletKey == nil {
+		log.Info("no v2 auth wallet key provided, generating a new one to use")
+		config.V2WalletKey, _ = ethcrypto.GenerateKey()
 	}
-	walletPublicKey := crypto.PublicKey(ethcrypto.FromECDSAPub(&config.WalletKey.PublicKey))
+	v2WalletPublicKey := crypto.PublicKey(ethcrypto.FromECDSAPub(&config.V2WalletKey.PublicKey))
 
-	if config.InstallationKey == nil {
-		log.Info("no auth installation key provided, generating a new one to use")
-		config.InstallationKey, _ = ethcrypto.GenerateKey()
+	if config.V2InstallationKey == nil {
+		log.Info("no v2 auth identity key provided, generating a new one to use")
+		config.V2InstallationKey, _ = ethcrypto.GenerateKey()
 	}
-	installationPublicKey := crypto.PublicKey(ethcrypto.FromECDSAPub(&config.InstallationKey.PublicKey))
+	v2IdentityPublicKey := crypto.PublicKey(ethcrypto.FromECDSAPub(&config.V2InstallationKey.PublicKey))
 
 	e := &Suite{
 		ctx:    ctx,
@@ -65,8 +65,8 @@ func NewSuite(ctx context.Context, log *zap.Logger, config *Config) *Suite {
 	}
 
 	log.Info("e2e suite initialized",
-		zap.String("wallet_key_public_address", crypto.PublicKeyToAddress(walletPublicKey).String()),
-		zap.String("installation_key_public_address", crypto.PublicKeyToAddress(installationPublicKey).String()),
+		zap.String("v2_wallet_key_public_address", crypto.PublicKeyToAddress(v2WalletPublicKey).String()),
+		zap.String("v2_identity_key_public_address", crypto.PublicKeyToAddress(v2IdentityPublicKey).String()),
 	)
 	return e
 }
@@ -97,7 +97,7 @@ func (s *Suite) randomStringLower(n int) string {
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz1234567890")
 
 func (s *Suite) withAuth(ctx context.Context) (context.Context, error) {
-	token, _, err := api.BuildAuthToken(s.config.WalletKey, s.config.InstallationKey, time.Now())
+	token, _, err := api.BuildV2AuthToken(s.config.V2WalletKey, s.config.V2InstallationKey, time.Now())
 	if err != nil {
 		return ctx, err
 	}

--- a/pkg/e2e/test_messagev1.go
+++ b/pkg/e2e/test_messagev1.go
@@ -34,7 +34,7 @@ func (s *Suite) testMessageV1PublishSubscribeQuery(log *zap.Logger) error {
 
 	ctx, cancel := context.WithTimeout(s.ctx, 30*time.Second)
 	defer cancel()
-	ctx, err := withAuth(ctx)
+	ctx, err := s.withAuth(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/xmtp/xmtp-node-go/pkg/api"
 	"github.com/xmtp/xmtp-node-go/pkg/authn"
 	"github.com/xmtp/xmtp-node-go/pkg/authz"
+	"github.com/xmtp/xmtp-node-go/pkg/crypto"
 	"github.com/xmtp/xmtp-node-go/pkg/logging"
 	"github.com/xmtp/xmtp-node-go/pkg/metrics"
 	authzmigrations "github.com/xmtp/xmtp-node-go/pkg/migrations/authz"
@@ -464,13 +465,13 @@ func getPrivKey(options Options) (*ecdsa.PrivateKey, error) {
 	var prvKey *ecdsa.PrivateKey
 	var err error
 	if options.NodeKey != "" {
-		if prvKey, err = hexToECDSA(options.NodeKey); err != nil {
+		if prvKey, err = crypto.HexToECDSA(options.NodeKey); err != nil {
 			return nil, fmt.Errorf("error converting key into valid ecdsa key: %w", err)
 		}
 	} else {
 		keyString := os.Getenv("GOWAKU-NODEKEY")
 		if keyString != "" {
-			if prvKey, err = hexToECDSA(keyString); err != nil {
+			if prvKey, err = crypto.HexToECDSA(keyString); err != nil {
 				return nil, fmt.Errorf("error converting key into valid ecdsa key: %w", err)
 			}
 		} else {
@@ -549,14 +550,4 @@ func createDB(dsn string, waitForDB, readTimeout, writeTimeout time.Duration, ma
 		return nil, errors.New("timeout waiting for db")
 	}
 	return db, nil
-}
-
-func hexToECDSA(key string) (*ecdsa.PrivateKey, error) {
-	if len(key) == 60 {
-		key = "0000" + key
-	}
-	if len(key) == 62 {
-		key = "00" + key
-	}
-	return ethcrypto.HexToECDSA(key)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/hex"
 	"testing"
 	"time"
 
@@ -44,52 +43,6 @@ func TestServer_StaticNodesReconnect(t *testing.T) {
 
 	// Expect reconnect to static nodes.
 	test.ExpectPeers(t, server.wakuNode, n1ID, n2ID)
-}
-
-func TestServer_hexToECDSA(t *testing.T) {
-	tcs := []struct {
-		name        string
-		key         string
-		expectedErr string
-	}{
-		{
-			name: "length 64 valid",
-			key:  "1df2b07b69f67be885148ef85ced1576048c7c33fb861f7cd8e9b62e13013330",
-		},
-		{
-			name: "length 62 valid",
-			key:  "f2b07b69f67be885148ef85ced1576048c7c33fb861f7cd8e9b62e13013330",
-		},
-		{
-			name: "length 60 valid",
-			key:  "b07b69f67be885148ef85ced1576048c7c33fb861f7cd8e9b62e13013330",
-		},
-		{
-			name:        "length 58 valid",
-			key:         "7b69f67be885148ef85ced1576048c7c33fb861f7cd8e9b62e13013330",
-			expectedErr: "invalid length, need 256 bits",
-		},
-		{
-			name:        "length 66 valid",
-			key:         "c7c33fb07b69f67be885148ef85ced1576048c7c33fb861f7cd8e9b62e13013330",
-			expectedErr: "invalid length, need 256 bits",
-		},
-	}
-	for _, tc := range tcs {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			key, err := hexToECDSA(tc.key)
-			if tc.expectedErr != "" {
-				require.Error(t, err)
-				require.EqualError(t, err, tc.expectedErr)
-			} else {
-				keyHex := hex.EncodeToString(key.D.Bytes())
-				require.Equal(t, tc.key, keyHex)
-			}
-		})
-	}
 }
 
 func newTestServer(t *testing.T, staticNodes []string) (*Server, func()) {


### PR DESCRIPTION
Support passing in auth keys for e2e runner so that it can have a consistent identity for rate limit overrides in https://github.com/xmtp/xmtp-node-go/pull/289#pullrequestreview-1609891161