### PR TITLE
Add comment field to models

### DIFF
--- a/pkg/authz/models.go
+++ b/pkg/authz/models.go
@@ -14,4 +14,5 @@ type WalletAddress struct {
 	CreatedAt     time.Time  `bun:"created_at"`
 	DeletedAt     *time.Time `bun:"deleted_at"`
 	Permission    string     `bun:"permission"`
+	Comment       string     `bun:"comment"`
 }

--- a/pkg/migrations/authz/20230905000435_add_comment_field.down.sql
+++ b/pkg/migrations/authz/20230905000435_add_comment_field.down.sql
@@ -1,0 +1,6 @@
+SET
+    statement_timeout = 0;
+
+--bun:split
+ALTER TABLE
+    authz_addresses DROP COLUMN comment;

--- a/pkg/migrations/authz/20230905000435_add_comment_field.up.sql
+++ b/pkg/migrations/authz/20230905000435_add_comment_field.up.sql
@@ -1,0 +1,8 @@
+SET
+    statement_timeout = 0;
+
+--bun:split
+ALTER TABLE
+    authz_addresses
+ADD
+    COLUMN comment TEXT NULL;


### PR DESCRIPTION
## Summary

- Adds a field to `authz_addresses` table allowing for a comment to be set. This will be used in Retool to better manage allow-lists. The `comment` field is not required for authorization, and is nullable.