### PR TITLE
Remove legacy options and CLI args

### DIFF
--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -73,12 +73,4 @@ type Options struct {
 	Metrics   MetricsOptions   `group:"Metrics Options"`
 	Tracing   TracingOptions   `group:"DD APM Tracing Options"`
 	Profiling ProfilingOptions `group:"DD APM Profiling Options" namespace:"profiling"`
-
-	// Legacy args
-	StoreEnable     bool `long:"store"`
-	FilterEnable    bool `long:"filter"`
-	LightpushEnable bool `long:"lightpush"`
-	KeepHistoryDays int  `long:"keep-history-days" default:"7"`
-	Resume          bool `long:"resume"`
-	CleanerEnable   bool `long:"cleaner.enable"`
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -143,10 +143,7 @@ func New(ctx context.Context, log *zap.Logger, options Options) (*Server, error)
 		}
 	}
 
-	if options.StoreEnable || options.Store.Enable {
-		if options.CleanerEnable {
-			options.Store.Cleaner.Enable = true
-		}
+	if options.Store.Enable {
 		s.db, err = createDB(options.Store.DbConnectionString, options.WaitForDB, options.Store.ReadTimeout, options.Store.WriteTimeout, options.Store.MaxOpenConns)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating db")


### PR DESCRIPTION
Following up on https://github.com/xmtp/xmtp-node-go/pull/299, this PR removes the legacy options and CLI args that were in place for the transition.