### PR TITLE
Enable go and process metrics collectors

### DIFF
--- a/pkg/e2e/runner.go
+++ b/pkg/e2e/runner.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
@@ -21,11 +22,14 @@ type Runner struct {
 }
 
 func NewRunner(ctx context.Context, log *zap.Logger, config *Config) *Runner {
+	promReg := prometheus.NewRegistry()
+	promReg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	promReg.MustRegister(collectors.NewGoCollector())
 	return &Runner{
 		ctx:    ctx,
 		log:    log,
 		config: config,
-		prom:   prometheus.NewRegistry(),
+		prom:   promReg,
 		suite:  NewSuite(ctx, log, config),
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect/pgdialect"
 	"github.com/uptrace/bun/driver/pgdriver"
@@ -87,6 +88,8 @@ func New(ctx context.Context, log *zap.Logger, options Options) (*Server, error)
 	s.ctx, s.cancel = context.WithCancel(ctx)
 
 	promReg := prometheus.NewRegistry()
+	promReg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	promReg.MustRegister(collectors.NewGoCollector())
 	if options.Metrics.Enable {
 		s.metricsServer, err = metrics.NewMetricsServer(s.ctx, options.Metrics.Address, options.Metrics.Port, s.log, promReg)
 		if err != nil {


### PR DESCRIPTION
Re-enable go and process metrics collectors which we lost after the metrics changes in https://github.com/xmtp/xmtp-node-go/pull/308