### PR TITLE
Store MLS messages separately

### DIFF
--- a/dev/migrate-mls
+++ b/dev/migrate-mls
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+dev/run --create-mls-migration "$@"

--- a/dev/run
+++ b/dev/run
@@ -15,8 +15,6 @@ go run cmd/xmtpd/main.go \
     --store.reader-db-connection-string "${MESSAGE_DB_DSN}" \
     --store.metrics-period 5s \
     --mls-store.db-connection-string "${MESSAGE_DB_DSN}" \
-    # --mls-store.reader-db-connection-string "${MESSAGE_DB_DSN}" \
-    # --mls-store.metrics-period 5s \
     --authz-db-connection-string "${AUTHZ_DB_DSN}" \
     --go-profiling \
     "$@"

--- a/dev/run
+++ b/dev/run
@@ -2,6 +2,7 @@
 set -e
 
 MESSAGE_DB_DSN="postgres://postgres:xmtp@localhost:15432/postgres?sslmode=disable"
+MLS_DB_DSN="postgres://postgres:xmtp@localhost:15432/postgres?sslmode=disable"
 AUTHZ_DB_DSN="postgres://postgres:xmtp@localhost:15432/postgres?sslmode=disable"
 NODE_KEY="8a30dcb604b0b53627a5adc054dbf434b446628d4bd1eccc681d223f0550ce67"
 
@@ -13,6 +14,9 @@ go run cmd/xmtpd/main.go \
     --store.db-connection-string "${MESSAGE_DB_DSN}" \
     --store.reader-db-connection-string "${MESSAGE_DB_DSN}" \
     --store.metrics-period 5s \
+    --mls-store.db-connection-string "${MESSAGE_DB_DSN}" \
+    # --mls-store.reader-db-connection-string "${MESSAGE_DB_DSN}" \
+    # --mls-store.metrics-period 5s \
     --authz-db-connection-string "${AUTHZ_DB_DSN}" \
     --go-profiling \
     "$@"

--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -20,6 +20,7 @@ import (
 	apicontext "github.com/xmtp/xmtp-node-go/pkg/api/message/v1/context"
 	"github.com/xmtp/xmtp-node-go/pkg/logging"
 	"github.com/xmtp/xmtp-node-go/pkg/metrics"
+	"github.com/xmtp/xmtp-node-go/pkg/mlsstore"
 	"github.com/xmtp/xmtp-node-go/pkg/store"
 	"github.com/xmtp/xmtp-node-go/pkg/topic"
 	"github.com/xmtp/xmtp-node-go/pkg/tracing"
@@ -44,9 +45,10 @@ type Service struct {
 	proto.UnimplementedMessageApiServer
 
 	// Configured as constructor options.
-	log   *zap.Logger
-	waku  *wakunode.WakuNode
-	store *store.Store
+	log      *zap.Logger
+	waku     *wakunode.WakuNode
+	store    *store.Store
+	mlsStore mlsstore.MlsStore
 
 	// Configured internally.
 	ctx       context.Context
@@ -58,11 +60,12 @@ type Service struct {
 	nc *nats.Conn
 }
 
-func NewService(node *wakunode.WakuNode, logger *zap.Logger, store *store.Store) (s *Service, err error) {
+func NewService(node *wakunode.WakuNode, logger *zap.Logger, store *store.Store, mlsStore mlsstore.MlsStore) (s *Service, err error) {
 	s = &Service{
-		waku:  node,
-		log:   logger.Named("message/v1"),
-		store: store,
+		waku:     node,
+		log:      logger.Named("message/v1"),
+		store:    store,
+		mlsStore: mlsStore,
 	}
 	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
 
@@ -367,6 +370,24 @@ func (s *Service) Query(ctx context.Context, req *proto.QueryRequest) (*proto.Qu
 		}
 	}
 
+	var hasV3Topic, hasNonV3Topic bool
+	for _, contentTopic := range req.ContentTopics {
+		if topic.IsV3(contentTopic) {
+			hasV3Topic = true
+		} else {
+			hasNonV3Topic = true
+		}
+	}
+	if hasV3Topic && hasNonV3Topic {
+		return nil, errors.New("cannot query v3 topics with non-v3 topics")
+	}
+	if hasV3Topic {
+		if s.mlsStore == nil {
+			return nil, errors.New("mls store not configured")
+		}
+		return s.mlsStore.QueryMessages(ctx, req)
+	}
+
 	return s.store.Query(req)
 }
 
@@ -385,6 +406,29 @@ func (s *Service) BatchQuery(ctx context.Context, req *proto.BatchQueryRequest) 
 	responses := make([]*proto.QueryResponse, 0)
 	for _, query := range req.Requests {
 		// We execute the query using the existing Query API
+
+		var hasV3Topic, hasNonV3Topic bool
+		for _, contentTopic := range query.ContentTopics {
+			if topic.IsV3(contentTopic) {
+				hasV3Topic = true
+			} else {
+				hasNonV3Topic = true
+			}
+		}
+		if hasV3Topic && hasNonV3Topic {
+			return nil, errors.New("cannot query v3 topics with non-v3 topics")
+		}
+		if hasV3Topic {
+			if s.mlsStore == nil {
+				return nil, errors.New("mls store not configured")
+			}
+			resp, err := s.mlsStore.QueryMessages(ctx, query)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, err.Error())
+			}
+			responses = append(responses, resp)
+		}
+
 		resp, err := s.Query(ctx, query)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, err.Error())

--- a/pkg/api/message/v3/service.go
+++ b/pkg/api/message/v3/service.go
@@ -252,7 +252,7 @@ func (s *Service) QueryMessages(ctx context.Context, req *messagev1.QueryRequest
 		}
 	}
 
-	return s.store.QueryMessages(req)
+	return s.store.QueryMessages(ctx, req)
 }
 
 func buildIdentityUpdate(update mlsstore.IdentityUpdate) *proto.GetIdentityUpdatesResponse_Update {

--- a/pkg/api/message/v3/service_test.go
+++ b/pkg/api/message/v3/service_test.go
@@ -230,7 +230,7 @@ func TestFetchKeyPackagesFail(t *testing.T) {
 	require.Equal(t, []*proto.FetchKeyPackagesResponse_KeyPackage{nil}, consumeRes.KeyPackages)
 }
 
-// TODO: fix this
+// TODO(snormore): fix this
 // func TestPublishToGroup(t *testing.T) {
 // 	ctx := context.Background()
 // 	svc, _, mlsValidationService, cleanup := newTestService(t, ctx)

--- a/pkg/api/message/v3/service_test.go
+++ b/pkg/api/message/v3/service_test.go
@@ -3,12 +3,15 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
+	v1 "github.com/xmtp/proto/v3/go/message_api/v1"
 	proto "github.com/xmtp/proto/v3/go/message_api/v3"
+	messageContents "github.com/xmtp/proto/v3/go/mls/message_contents"
 	"github.com/xmtp/xmtp-node-go/pkg/mlsstore"
 	"github.com/xmtp/xmtp-node-go/pkg/mlsvalidate"
 	"github.com/xmtp/xmtp-node-go/pkg/store"
@@ -230,35 +233,34 @@ func TestFetchKeyPackagesFail(t *testing.T) {
 	require.Equal(t, []*proto.FetchKeyPackagesResponse_KeyPackage{nil}, consumeRes.KeyPackages)
 }
 
-// TODO(snormore): fix this
-// func TestPublishToGroup(t *testing.T) {
-// 	ctx := context.Background()
-// 	svc, _, mlsValidationService, cleanup := newTestService(t, ctx)
-// 	defer cleanup()
+func TestPublishToGroup(t *testing.T) {
+	ctx := context.Background()
+	svc, _, mlsValidationService, cleanup := newTestService(t, ctx)
+	defer cleanup()
 
-// 	groupId := test.RandomString(32)
+	groupId := test.RandomString(32)
 
-// 	mlsValidationService.mockValidateGroupMessages(groupId)
+	mlsValidationService.mockValidateGroupMessages(groupId)
 
-// 	_, err := svc.PublishToGroup(ctx, &proto.PublishToGroupRequest{
-// 		Messages: []*messageContents.GroupMessage{{
-// 			Version: &messageContents.GroupMessage_V1_{
-// 				V1: &messageContents.GroupMessage_V1{
-// 					MlsMessageTlsSerialized: []byte("test"),
-// 				},
-// 			},
-// 		}},
-// 	})
-// 	require.NoError(t, err)
+	_, err := svc.PublishToGroup(ctx, &proto.PublishToGroupRequest{
+		Messages: []*messageContents.GroupMessage{{
+			Version: &messageContents.GroupMessage_V1_{
+				V1: &messageContents.GroupMessage_V1{
+					MlsMessageTlsSerialized: []byte("test"),
+				},
+			},
+		}},
+	})
+	require.NoError(t, err)
 
-// 	results, err := svc.store.QueryMessages(&v1.QueryRequest{
-// 		ContentTopics: []string{fmt.Sprintf("/xmtp/3/g-%s/proto", groupId)},
-// 	})
-// 	require.NoError(t, err)
-// 	require.Len(t, results.Envelopes, 1)
-// 	require.Equal(t, results.Envelopes[0].Message, []byte("test"))
-// 	require.NotNil(t, results.Envelopes[0].TimestampNs)
-// }
+	results, err := svc.store.QueryMessages(ctx, &v1.QueryRequest{
+		ContentTopics: []string{fmt.Sprintf("/xmtp/3/g-%s/proto", groupId)},
+	})
+	require.NoError(t, err)
+	require.Len(t, results.Envelopes, 1)
+	require.Equal(t, results.Envelopes[0].Message, []byte("test"))
+	require.NotNil(t, results.Envelopes[0].TimestampNs)
+}
 
 func TestGetIdentityUpdates(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -123,7 +123,7 @@ func (s *Server) startGRPC() error {
 	healthcheck := health.NewServer()
 	healthgrpc.RegisterHealthServer(grpcServer, healthcheck)
 
-	s.messagev1, err = messagev1.NewService(s.Waku, s.Log, s.Store)
+	s.messagev1, err = messagev1.NewService(s.Waku, s.Log, s.Store, s.MLSStore)
 	if err != nil {
 		return errors.Wrap(err, "creating message service")
 	}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -131,7 +131,7 @@ func (s *Server) startGRPC() error {
 
 	// Enable the MLS server if a store is provided
 	if s.Config.MLSStore != nil && s.Config.MLSValidator != nil && s.Config.EnableMls {
-		s.messagev3, err = messagev3.NewService(s.Waku, s.Log, s.Store, s.Config.MLSStore, s.Config.MLSValidator)
+		s.messagev3, err = messagev3.NewService(s.Waku, s.Log, s.Config.MLSStore, s.Config.MLSValidator)
 		if err != nil {
 			return errors.Wrap(err, "creating mls service")
 		}

--- a/pkg/migrations/mls/20240109001927_add-messages.down.sql
+++ b/pkg/migrations/mls/20240109001927_add-messages.down.sql
@@ -1,0 +1,6 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+DROP TABLE IF EXISTS messages;
+

--- a/pkg/migrations/mls/20240109001927_add-messages.up.sql
+++ b/pkg/migrations/mls/20240109001927_add-messages.up.sql
@@ -3,8 +3,8 @@ SET statement_timeout = 0;
 --bun:split
 
 CREATE TABLE messages (
-    topic VARCHAR(300) NOT NULL,
-    tid VARCHAR(300) NOT NULL,
+    topic VARCHAR(200) NOT NULL,
+    tid VARCHAR(96) NOT NULL,
     created_at BIGINT NOT NULL,
     content BYTEA,
     CONSTRAINT idx_messages_topic_tid PRIMARY KEY (topic, tid)

--- a/pkg/migrations/mls/20240109001927_add-messages.up.sql
+++ b/pkg/migrations/mls/20240109001927_add-messages.up.sql
@@ -1,0 +1,14 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+CREATE TABLE messages (
+    tid VARCHAR(300) PRIMARY KEY,
+    topic VARCHAR(200) NOT NULL,
+    created_at BIGINT NOT NULL,
+    content BYTEA
+);
+
+--bun:split
+
+CREATE INDEX idx_messages_tid ON messages(tid);

--- a/pkg/migrations/mls/20240109001927_add-messages.up.sql
+++ b/pkg/migrations/mls/20240109001927_add-messages.up.sql
@@ -3,13 +3,9 @@ SET statement_timeout = 0;
 --bun:split
 
 CREATE TABLE messages (
-    tid VARCHAR(300) PRIMARY KEY,
-    topic VARCHAR(200) NOT NULL,
+    topic VARCHAR(300) NOT NULL,
+    tid VARCHAR(300) NOT NULL,
     created_at BIGINT NOT NULL,
-    content BYTEA
+    content BYTEA,
+    CONSTRAINT idx_messages_topic_tid PRIMARY KEY (topic, tid)
 );
-
---bun:split
-
-CREATE INDEX idx_messages_tid ON messages(tid);
-CREATE INDEX idx_messages_topic_tid ON messages(topic, tid);

--- a/pkg/migrations/mls/20240109001927_add-messages.up.sql
+++ b/pkg/migrations/mls/20240109001927_add-messages.up.sql
@@ -9,3 +9,7 @@ CREATE TABLE messages (
     content BYTEA,
     CONSTRAINT idx_messages_topic_tid PRIMARY KEY (topic, tid)
 );
+
+--bun:split
+
+CREATE INDEX idx_messages_topic_created_at ON messages(topic, created_at);

--- a/pkg/migrations/mls/20240109001927_add-messages.up.sql
+++ b/pkg/migrations/mls/20240109001927_add-messages.up.sql
@@ -12,3 +12,4 @@ CREATE TABLE messages (
 --bun:split
 
 CREATE INDEX idx_messages_tid ON messages(tid);
+CREATE INDEX idx_messages_topic_tid ON messages(topic, tid);

--- a/pkg/mlsstore/config.go
+++ b/pkg/mlsstore/config.go
@@ -17,4 +17,6 @@ type StoreOptions struct {
 type Config struct {
 	Log *zap.Logger
 	DB  *bun.DB
+
+	now func() time.Time
 }

--- a/pkg/mlsstore/models.go
+++ b/pkg/mlsstore/models.go
@@ -15,3 +15,12 @@ type Installation struct {
 	KeyPackage []byte `bun:"key_package,notnull,type:bytea"`
 	Expiration uint64 `bun:"expiration,notnull"`
 }
+
+type Message struct {
+	bun.BaseModel `bun:"table:messages"`
+
+	TID       string `bun:",pk,notnull"`
+	Topic     string `bun:"topic,notnull"`
+	CreatedAt int64  `bun:"created_at,notnull"`
+	Content   []byte `bun:"content,notnull,type:bytea"`
+}

--- a/pkg/mlsstore/models.go
+++ b/pkg/mlsstore/models.go
@@ -19,8 +19,8 @@ type Installation struct {
 type Message struct {
 	bun.BaseModel `bun:"table:messages"`
 
-	TID       string `bun:",pk,notnull"`
-	Topic     string `bun:"topic,notnull"`
+	Topic     string `bun:"topic,pk,notnull"`
+	TID       string `bun:"tid,pk,notnull"`
 	CreatedAt int64  `bun:"created_at,notnull"`
 	Content   []byte `bun:"content,notnull,type:bytea"`
 }

--- a/pkg/mlsstore/store.go
+++ b/pkg/mlsstore/store.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/migrate"
+	messagev1 "github.com/xmtp/proto/v3/go/message_api/v1"
 	mlsMigrations "github.com/xmtp/xmtp-node-go/pkg/migrations/mls"
 	"go.uber.org/zap"
 )
@@ -23,6 +24,8 @@ type MlsStore interface {
 	UpdateKeyPackage(ctx context.Context, installationId, keyPackage []byte, expiration uint64) error
 	FetchKeyPackages(ctx context.Context, installationIds [][]byte) ([]*Installation, error)
 	GetIdentityUpdates(ctx context.Context, walletAddresses []string, startTimeNs int64) (map[string]IdentityUpdateList, error)
+	InsertMessage(ctx context.Context, contentTopic string, data []byte) (*messagev1.Envelope, error)
+	QueryMessages(query *messagev1.QueryRequest) (res *messagev1.QueryResponse, err error)
 }
 
 func New(ctx context.Context, config Config) (*Store, error) {
@@ -155,6 +158,14 @@ func (s *Store) RevokeInstallation(ctx context.Context, installationId []byte) e
 		Exec(ctx)
 
 	return err
+}
+
+func (s *Store) InsertMessage(ctx context.Context, contentTopic string, data []byte) (*messagev1.Envelope, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *Store) QueryMessages(query *messagev1.QueryRequest) (res *messagev1.QueryResponse, err error) {
+	return nil, errors.New("not implemented")
 }
 
 func (s *Store) migrate(ctx context.Context) error {

--- a/pkg/mlsstore/store.go
+++ b/pkg/mlsstore/store.go
@@ -204,7 +204,6 @@ func (s *Store) QueryMessages(ctx context.Context, query *messagev1.QueryRequest
 	}
 
 	// TODO: move api to api/mls/v1
-	// TODO: update db schema to support querying by multiple topics, so tid should not have topic in it, I guess
 	// TODO: finish implementing all of this (query request variations, pagination, etc)
 
 	envs := make([]*messagev1.Envelope, 0, len(messages))

--- a/pkg/mlsstore/store.go
+++ b/pkg/mlsstore/store.go
@@ -30,7 +30,6 @@ type MlsStore interface {
 	GetIdentityUpdates(ctx context.Context, walletAddresses []string, startTimeNs int64) (map[string]IdentityUpdateList, error)
 	InsertMessage(ctx context.Context, contentTopic string, data []byte) (*messagev1.Envelope, error)
 	QueryMessages(ctx context.Context, query *messagev1.QueryRequest) (*messagev1.QueryResponse, error)
-	NewKeyPackage(installationId []byte, data []byte, isLastResort bool) *KeyPackage
 }
 
 func New(ctx context.Context, config Config) (*Store, error) {
@@ -78,7 +77,7 @@ func (s *Store) CreateInstallation(ctx context.Context, installationId []byte, w
 func (s *Store) UpdateKeyPackage(ctx context.Context, installationId, keyPackage []byte, expiration uint64) error {
 	installation := Installation{
 		ID:        installationId,
-		UpdatedAt: nowNs(),
+		UpdatedAt: s.nowNs(),
 
 		KeyPackage: keyPackage,
 		Expiration: expiration,

--- a/pkg/mlsstore/store.go
+++ b/pkg/mlsstore/store.go
@@ -15,8 +15,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// TODO(snormore): implements metrics + cleaner
-
 const maxPageSize = 100
 
 type Store struct {
@@ -36,6 +34,11 @@ type MlsStore interface {
 }
 
 func New(ctx context.Context, config Config) (*Store, error) {
+	if config.now == nil {
+		config.now = func() time.Time {
+			return time.Now().UTC()
+		}
+	}
 	s := &Store{
 		log:    config.Log.Named("mlsstore"),
 		db:     config.DB,

--- a/pkg/mlsstore/store.go
+++ b/pkg/mlsstore/store.go
@@ -2,7 +2,9 @@ package mlsstore
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
+	"fmt"
 	"sort"
 	"time"
 
@@ -14,6 +16,8 @@ import (
 )
 
 // TODO(snormore): implements metrics + cleaner
+
+const maxPageSize = 100
 
 type Store struct {
 	config Config
@@ -163,12 +167,12 @@ func (s *Store) RevokeInstallation(ctx context.Context, installationId []byte) e
 }
 
 func (s *Store) InsertMessage(ctx context.Context, topic string, content []byte) (*messagev1.Envelope, error) {
-	createdAt := nowNs()
+	createdAt := time.Now().UTC()
 
 	message := Message{
-		TID:       topic + "",
 		Topic:     topic,
-		CreatedAt: createdAt,
+		TID:       buildMessageTID(createdAt, content),
+		CreatedAt: createdAt.UnixNano(),
 		Content:   content,
 	}
 
@@ -182,7 +186,7 @@ func (s *Store) InsertMessage(ctx context.Context, topic string, content []byte)
 
 	return &messagev1.Envelope{
 		ContentTopic: topic,
-		TimestampNs:  uint64(createdAt),
+		TimestampNs:  uint64(message.CreatedAt),
 		Message:      content,
 	}, nil
 }
@@ -190,21 +194,57 @@ func (s *Store) InsertMessage(ctx context.Context, topic string, content []byte)
 func (s *Store) QueryMessages(ctx context.Context, query *messagev1.QueryRequest) (*messagev1.QueryResponse, error) {
 	messages := make([]*Message, 0)
 
-	err := s.db.NewSelect().
-		Model(&messages).
-		Where("topic IN (?)", bun.In(query.ContentTopics)).
-		// WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
-		// 	return q.Where("created_at > ?", startTimeNs).WhereOr("revoked_at > ?", startTimeNs)
-		// }).
-		Order("created_at ASC").
-		Scan(ctx)
+	if len(query.ContentTopics) == 0 {
+		return nil, errors.New("topic is required")
+	}
 
+	if len(query.ContentTopics) > 1 {
+		return nil, errors.New("multiple topics not supported")
+	}
+
+	q := s.db.NewSelect().
+		Model(&messages).
+		Where("topic = ?", query.ContentTopics[0])
+
+	direction := messagev1.SortDirection_SORT_DIRECTION_DESCENDING
+	if query.PagingInfo != nil && query.PagingInfo.Direction != messagev1.SortDirection_SORT_DIRECTION_UNSPECIFIED {
+		direction = query.PagingInfo.Direction
+	}
+	switch direction {
+	case messagev1.SortDirection_SORT_DIRECTION_DESCENDING:
+		q = q.Order("tid DESC")
+	case messagev1.SortDirection_SORT_DIRECTION_ASCENDING:
+		q = q.Order("tid DESC")
+	}
+
+	pageSize := maxPageSize
+	if query.PagingInfo != nil && query.PagingInfo.Limit > 0 && query.PagingInfo.Limit <= maxPageSize {
+		pageSize = int(query.PagingInfo.Limit)
+	}
+	q = q.Limit(pageSize)
+
+	if query.PagingInfo != nil && query.PagingInfo.GetCursor() != nil && query.PagingInfo.GetCursor().GetIndex() != nil {
+		index := query.PagingInfo.GetCursor().GetIndex()
+		if index.SenderTimeNs == 0 || len(index.Digest) == 0 {
+			return nil, errors.New("invalid cursor")
+		}
+		cursorTID := buildMessageTID(time.Unix(0, int64(index.SenderTimeNs)), index.Digest)
+		q = q.Where("tid > ?", cursorTID)
+	} else {
+		if query.StartTimeNs > 0 {
+			startTID := buildMessageTIDPrefix(time.Unix(0, int64(query.StartTimeNs)))
+			q = q.Where("tid > ?", startTID)
+		}
+		if query.EndTimeNs > 0 {
+			endTID := buildMessageTIDPrefix(time.Unix(0, int64(query.EndTimeNs)))
+			q = q.Where("tid < ?", endTID)
+		}
+	}
+
+	err := q.Scan(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: move api to api/mls/v1
-	// TODO: finish implementing all of this (query request variations, pagination, etc)
 
 	envs := make([]*messagev1.Envelope, 0, len(messages))
 	for _, msg := range messages {
@@ -214,9 +254,35 @@ func (s *Store) QueryMessages(ctx context.Context, query *messagev1.QueryRequest
 			Message:      msg.Content,
 		})
 	}
+
+	pagingInfo := &messagev1.PagingInfo{Limit: 0, Cursor: nil, Direction: direction}
+	if len(envs) >= pageSize {
+		if len(envs) > 0 {
+			lastEnv := envs[len(envs)-1]
+			digest := sha256.Sum256(lastEnv.Message)
+			pagingInfo.Cursor = &messagev1.Cursor{
+				Cursor: &messagev1.Cursor_Index{
+					Index: &messagev1.IndexCursor{
+						Digest:       digest[:],
+						SenderTimeNs: lastEnv.TimestampNs,
+					},
+				},
+			}
+		}
+	}
+
 	return &messagev1.QueryResponse{
-		Envelopes: envs,
+		Envelopes:  envs,
+		PagingInfo: pagingInfo,
 	}, nil
+}
+
+func buildMessageTID(createdAt time.Time, content []byte) string {
+	return fmt.Sprintf("%s_%x", buildMessageTIDPrefix(createdAt), sha256.Sum256(content))
+}
+
+func buildMessageTIDPrefix(createdAt time.Time) string {
+	return fmt.Sprintf("%s.%09d_", createdAt.Format(time.RFC3339), createdAt.Nanosecond())
 }
 
 func (s *Store) migrate(ctx context.Context) error {

--- a/pkg/mlsstore/store.go
+++ b/pkg/mlsstore/store.go
@@ -13,6 +13,8 @@ import (
 	"go.uber.org/zap"
 )
 
+// TODO(snormore): implements metrics + cleaner
+
 type Store struct {
 	config Config
 	log    *zap.Logger

--- a/pkg/mlsstore/store_test.go
+++ b/pkg/mlsstore/store_test.go
@@ -4,18 +4,36 @@ import (
 	"context"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	messagev1 "github.com/xmtp/proto/v3/go/message_api/v1"
 	test "github.com/xmtp/xmtp-node-go/pkg/testing"
 )
 
-func NewTestStore(t *testing.T) (*Store, func()) {
+type testStoreOption func(*Config)
+
+func withFixedNow(now time.Time) testStoreOption {
+	return func(c *Config) {
+		c.now = func() time.Time {
+			return now
+		}
+	}
+}
+
+func NewTestStore(t *testing.T, opts ...testStoreOption) (*Store, func()) {
 	log := test.NewLog(t)
 	db, _, dbCleanup := test.NewMLSDB(t)
 	ctx := context.Background()
 	c := Config{
 		Log: log,
 		DB:  db,
+		now: func() time.Time {
+			return time.Now().UTC()
+		},
+	}
+	for _, opt := range opts {
+		opt(&c)
 	}
 
 	store, err := New(ctx, c)
@@ -172,33 +190,362 @@ func TestIdentityUpdateSort(t *testing.T) {
 	require.Equal(t, updates[2].TimestampNs, uint64(3))
 }
 
-// TODO(snormore): implemented this
-// func TestMessagePublish(t *testing.T) {
-// 	store, cleanup, _ := createAndFillDb(t)
-// 	defer cleanup()
+func TestInsertMessage_Single(t *testing.T) {
+	now := time.Now().UTC()
+	store, cleanup := NewTestStore(t, withFixedNow(now))
+	defer cleanup()
 
-// 	message := []byte{1, 2, 3}
-// 	contentTopic := "foo"
-// 	ctx := context.Background()
+	ctx := context.Background()
+	env, err := store.InsertMessage(ctx, "topic", []byte("content"))
+	require.NoError(t, err)
+	require.NotNil(t, env)
+	require.Equal(t, &messagev1.Envelope{
+		ContentTopic: "topic",
+		TimestampNs:  uint64(now.UnixNano()),
+		Message:      []byte("content"),
+	}, env)
 
-// 	env, err := store.InsertMLSMessage(ctx, contentTopic, message)
-// 	require.NoError(t, err)
+	msgs := make([]*Message, 0)
+	err = store.db.NewSelect().Model(&msgs).Scan(ctx)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.Equal(t, &Message{
+		Topic:     "topic",
+		CreatedAt: now.UnixNano(),
+		Content:   []byte("content"),
+		TID:       buildMessageTID(now, []byte("content")),
+	}, msgs[0])
+}
 
-// 	require.Equal(t, env.ContentTopic, contentTopic)
-// 	require.Equal(t, env.Message, message)
+func TestInsertMessage_Duplicate(t *testing.T) {
+	now := time.Now().UTC()
+	store, cleanup := NewTestStore(t, withFixedNow(now))
+	defer cleanup()
 
-// 	response, err := store.Query(&messagev1.QueryRequest{
-// 		ContentTopics: []string{contentTopic},
-// 	})
-// 	require.NoError(t, err)
-// 	require.Len(t, response.Envelopes, 1)
-// 	require.Equal(t, response.Envelopes[0].Message, message)
-// 	require.Equal(t, response.Envelopes[0].ContentTopic, contentTopic)
-// 	require.NotNil(t, response.Envelopes[0].TimestampNs)
+	ctx := context.Background()
+	_, err := store.InsertMessage(ctx, "topic", []byte("content"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic", []byte("content"))
+	require.NoError(t, err)
 
-// 	parsedTime := time.Unix(0, int64(response.Envelopes[0].TimestampNs))
-// 	// Sanity check to ensure that the timestamps are reasonable
-// 	require.True(t, time.Since(parsedTime) < 10*time.Second || time.Since(parsedTime) > -10*time.Second)
+	msgs := make([]*Message, 0)
+	err = store.db.NewSelect().Model(&msgs).Scan(ctx)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.Equal(t, &Message{
+		Topic:     "topic",
+		CreatedAt: now.UnixNano(),
+		Content:   []byte("content"),
+		TID:       buildMessageTID(now, []byte("content")),
+	}, msgs[0])
+}
 
-// 	require.Equal(t, env.TimestampNs, response.Envelopes[0].TimestampNs)
-// }
+func TestInsertMessage_ManyAreOrderedByTime(t *testing.T) {
+	store, cleanup := NewTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	_, err := store.InsertMessage(ctx, "topic", []byte("content1"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic", []byte("content2"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic", []byte("content3"))
+	require.NoError(t, err)
+
+	msgs := make([]*Message, 0)
+	err = store.db.NewSelect().Model(&msgs).Order("tid DESC").Scan(ctx)
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+	require.Equal(t, []byte("content3"), msgs[0].Content)
+	require.Equal(t, []byte("content2"), msgs[1].Content)
+	require.Equal(t, []byte("content1"), msgs[2].Content)
+}
+
+func TestQueryMessages_MissingTopic(t *testing.T) {
+	store, cleanup := NewTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	resp, err := store.QueryMessages(ctx, &messagev1.QueryRequest{})
+	require.EqualError(t, err, "topic is required")
+	require.Nil(t, resp)
+}
+
+func TestQueryMessages_Filter(t *testing.T) {
+	store, cleanup := NewTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	_, err := store.InsertMessage(ctx, "topic1", []byte("content1"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic2", []byte("content2"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic1", []byte("content3"))
+	require.NoError(t, err)
+
+	resp, err := store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"unknown"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 0)
+
+	resp, err = store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic1"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 2)
+	require.Equal(t, []byte("content3"), resp.Envelopes[0].Message)
+	require.Equal(t, []byte("content1"), resp.Envelopes[1].Message)
+
+	resp, err = store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic2"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 1)
+	require.Equal(t, []byte("content2"), resp.Envelopes[0].Message)
+
+	// Sort ascending
+	resp, err = store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic1"},
+		PagingInfo: &messagev1.PagingInfo{
+			Direction: messagev1.SortDirection_SORT_DIRECTION_ASCENDING,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 2)
+	require.Equal(t, []byte("content1"), resp.Envelopes[0].Message)
+	require.Equal(t, []byte("content3"), resp.Envelopes[1].Message)
+}
+
+func TestQueryMessages_Paginate_Cursor(t *testing.T) {
+	store, cleanup := NewTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	_, err := store.InsertMessage(ctx, "topic1", []byte("content1"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic2", []byte("content2"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic1", []byte("content3"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic2", []byte("content4"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic1", []byte("content5"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic1", []byte("content6"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic1", []byte("content7"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic1", []byte("content8"))
+	require.NoError(t, err)
+
+	resp, err := store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic1"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 6)
+	require.Equal(t, []byte("content8"), resp.Envelopes[0].Message)
+	require.Equal(t, []byte("content7"), resp.Envelopes[1].Message)
+	require.Equal(t, []byte("content6"), resp.Envelopes[2].Message)
+	require.Equal(t, []byte("content5"), resp.Envelopes[3].Message)
+	require.Equal(t, []byte("content3"), resp.Envelopes[4].Message)
+	require.Equal(t, []byte("content1"), resp.Envelopes[5].Message)
+
+	thirdEnv := resp.Envelopes[2]
+	fifthEnv := resp.Envelopes[4]
+
+	resp, err = store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic1"},
+		PagingInfo: &messagev1.PagingInfo{
+			Limit: 2,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 2)
+	require.Equal(t, []byte("content8"), resp.Envelopes[0].Message)
+	require.Equal(t, []byte("content7"), resp.Envelopes[1].Message)
+
+	// Order descending by default
+	resp, err = store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic1"},
+		PagingInfo: &messagev1.PagingInfo{
+			Limit: 2,
+			Cursor: &messagev1.Cursor{
+				Cursor: &messagev1.Cursor_Index{
+					Index: &messagev1.IndexCursor{
+						SenderTimeNs: thirdEnv.TimestampNs,
+						Digest:       buildMessageContentDigest(thirdEnv.Message),
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 2)
+	require.Equal(t, []byte("content5"), resp.Envelopes[0].Message)
+	require.Equal(t, []byte("content3"), resp.Envelopes[1].Message)
+
+	// Next page from previous response
+	resp, err = store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic1"},
+		PagingInfo:    resp.PagingInfo,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 1)
+	require.Equal(t, []byte("content1"), resp.Envelopes[0].Message)
+
+	// Order ascending
+	resp, err = store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic1"},
+		PagingInfo: &messagev1.PagingInfo{
+			Limit:     2,
+			Direction: messagev1.SortDirection_SORT_DIRECTION_ASCENDING,
+			Cursor: &messagev1.Cursor{
+				Cursor: &messagev1.Cursor_Index{
+					Index: &messagev1.IndexCursor{
+						SenderTimeNs: fifthEnv.TimestampNs,
+						Digest:       buildMessageContentDigest(fifthEnv.Message),
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 2)
+	require.Equal(t, []byte("content5"), resp.Envelopes[0].Message)
+	require.Equal(t, []byte("content6"), resp.Envelopes[1].Message)
+
+	// Next page from previous response
+	resp, err = store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic1"},
+		PagingInfo:    resp.PagingInfo,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 2)
+	require.Equal(t, []byte("content7"), resp.Envelopes[0].Message)
+	require.Equal(t, []byte("content8"), resp.Envelopes[1].Message)
+}
+
+func TestQueryMessages_Paginate_StartEndTime(t *testing.T) {
+	store, cleanup := NewTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	_, err := store.InsertMessage(ctx, "topic1", []byte("content1"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic2", []byte("content2"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic1", []byte("content3"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic2", []byte("content4"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic1", []byte("content5"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic1", []byte("content6"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic1", []byte("content7"))
+	require.NoError(t, err)
+	_, err = store.InsertMessage(ctx, "topic1", []byte("content8"))
+	require.NoError(t, err)
+
+	resp, err := store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic1"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 6)
+	require.Equal(t, []byte("content8"), resp.Envelopes[0].Message)
+	require.Equal(t, []byte("content7"), resp.Envelopes[1].Message)
+	require.Equal(t, []byte("content6"), resp.Envelopes[2].Message)
+	require.Equal(t, []byte("content5"), resp.Envelopes[3].Message)
+	require.Equal(t, []byte("content3"), resp.Envelopes[4].Message)
+	require.Equal(t, []byte("content1"), resp.Envelopes[5].Message)
+
+	thirdEnv := resp.Envelopes[2]
+	fifthEnv := resp.Envelopes[4]
+
+	// Order descending by default
+	resp, err = store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic1"},
+		StartTimeNs:   thirdEnv.TimestampNs,
+		PagingInfo: &messagev1.PagingInfo{
+			Limit: 2,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 2)
+	require.Equal(t, []byte("content8"), resp.Envelopes[0].Message)
+	require.Equal(t, []byte("content7"), resp.Envelopes[1].Message)
+
+	resp, err = store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic1"},
+		EndTimeNs:     thirdEnv.TimestampNs,
+		PagingInfo: &messagev1.PagingInfo{
+			Limit: 2,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 2)
+	require.Equal(t, []byte("content6"), resp.Envelopes[0].Message)
+	require.Equal(t, []byte("content5"), resp.Envelopes[1].Message)
+
+	resp, err = store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic1"},
+		StartTimeNs:   fifthEnv.TimestampNs,
+		EndTimeNs:     thirdEnv.TimestampNs,
+		PagingInfo: &messagev1.PagingInfo{
+			Limit: 4,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 3)
+	require.Equal(t, []byte("content6"), resp.Envelopes[0].Message)
+	require.Equal(t, []byte("content5"), resp.Envelopes[1].Message)
+	require.Equal(t, []byte("content3"), resp.Envelopes[2].Message)
+
+	// Order ascending
+	resp, err = store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic1"},
+		StartTimeNs:   thirdEnv.TimestampNs,
+		PagingInfo: &messagev1.PagingInfo{
+			Limit:     2,
+			Direction: messagev1.SortDirection_SORT_DIRECTION_ASCENDING,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 2)
+	require.Equal(t, []byte("content6"), resp.Envelopes[0].Message)
+	require.Equal(t, []byte("content7"), resp.Envelopes[1].Message)
+
+	resp, err = store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic1"},
+		EndTimeNs:     thirdEnv.TimestampNs,
+		PagingInfo: &messagev1.PagingInfo{
+			Limit:     2,
+			Direction: messagev1.SortDirection_SORT_DIRECTION_ASCENDING,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 2)
+	require.Equal(t, []byte("content1"), resp.Envelopes[0].Message)
+	require.Equal(t, []byte("content3"), resp.Envelopes[1].Message)
+
+	resp, err = store.QueryMessages(ctx, &messagev1.QueryRequest{
+		ContentTopics: []string{"topic1"},
+		StartTimeNs:   fifthEnv.TimestampNs,
+		EndTimeNs:     thirdEnv.TimestampNs,
+		PagingInfo: &messagev1.PagingInfo{
+			Limit:     4,
+			Direction: messagev1.SortDirection_SORT_DIRECTION_ASCENDING,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Envelopes, 3)
+	require.Equal(t, []byte("content3"), resp.Envelopes[0].Message)
+	require.Equal(t, []byte("content5"), resp.Envelopes[1].Message)
+	require.Equal(t, []byte("content6"), resp.Envelopes[2].Message)
+}
+
+func nowNs() int64 {
+	return time.Now().UTC().UnixNano()
+}

--- a/pkg/mlsstore/store_test.go
+++ b/pkg/mlsstore/store_test.go
@@ -172,7 +172,7 @@ func TestIdentityUpdateSort(t *testing.T) {
 	require.Equal(t, updates[2].TimestampNs, uint64(3))
 }
 
-// TODO: implemented this
+// TODO(snormore): implemented this
 // func TestMessagePublish(t *testing.T) {
 // 	store, cleanup, _ := createAndFillDb(t)
 // 	defer cleanup()

--- a/pkg/mlsstore/store_test.go
+++ b/pkg/mlsstore/store_test.go
@@ -171,3 +171,34 @@ func TestIdentityUpdateSort(t *testing.T) {
 	require.Equal(t, updates[1].TimestampNs, uint64(2))
 	require.Equal(t, updates[2].TimestampNs, uint64(3))
 }
+
+// TODO: implemented this
+// func TestMessagePublish(t *testing.T) {
+// 	store, cleanup, _ := createAndFillDb(t)
+// 	defer cleanup()
+
+// 	message := []byte{1, 2, 3}
+// 	contentTopic := "foo"
+// 	ctx := context.Background()
+
+// 	env, err := store.InsertMLSMessage(ctx, contentTopic, message)
+// 	require.NoError(t, err)
+
+// 	require.Equal(t, env.ContentTopic, contentTopic)
+// 	require.Equal(t, env.Message, message)
+
+// 	response, err := store.Query(&messagev1.QueryRequest{
+// 		ContentTopics: []string{contentTopic},
+// 	})
+// 	require.NoError(t, err)
+// 	require.Len(t, response.Envelopes, 1)
+// 	require.Equal(t, response.Envelopes[0].Message, message)
+// 	require.Equal(t, response.Envelopes[0].ContentTopic, contentTopic)
+// 	require.NotNil(t, response.Envelopes[0].TimestampNs)
+
+// 	parsedTime := time.Unix(0, int64(response.Envelopes[0].TimestampNs))
+// 	// Sanity check to ensure that the timestamps are reasonable
+// 	require.True(t, time.Since(parsedTime) < 10*time.Second || time.Since(parsedTime) > -10*time.Second)
+
+// 	require.Equal(t, env.TimestampNs, response.Envelopes[0].TimestampNs)
+// }

--- a/pkg/store/query_test.go
+++ b/pkg/store/query_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -284,34 +283,4 @@ func TestPageSizeOne(t *testing.T) {
 		}
 		loops++
 	}
-}
-
-func TestMlsMessagePublish(t *testing.T) {
-	store, cleanup, _ := createAndFillDb(t)
-	defer cleanup()
-
-	message := []byte{1, 2, 3}
-	contentTopic := "foo"
-	ctx := context.Background()
-
-	env, err := store.InsertMLSMessage(ctx, contentTopic, message)
-	require.NoError(t, err)
-
-	require.Equal(t, env.ContentTopic, contentTopic)
-	require.Equal(t, env.Message, message)
-
-	response, err := store.Query(&messagev1.QueryRequest{
-		ContentTopics: []string{contentTopic},
-	})
-	require.NoError(t, err)
-	require.Len(t, response.Envelopes, 1)
-	require.Equal(t, response.Envelopes[0].Message, message)
-	require.Equal(t, response.Envelopes[0].ContentTopic, contentTopic)
-	require.NotNil(t, response.Envelopes[0].TimestampNs)
-
-	parsedTime := time.Unix(0, int64(response.Envelopes[0].TimestampNs))
-	// Sanity check to ensure that the timestamps are reasonable
-	require.True(t, time.Since(parsedTime) < 10*time.Second || time.Since(parsedTime) > -10*time.Second)
-
-	require.Equal(t, env.TimestampNs, response.Envelopes[0].TimestampNs)
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -20,22 +19,6 @@ import (
 )
 
 const maxPageSize = 100
-
-const timestampGeneratorSql = `(
-	(
-		EXTRACT(
-			EPOCH
-			FROM
-				clock_timestamp()
-		) :: bigint * 1000000000
-	) + (
-		EXTRACT(
-			MICROSECONDS
-			FROM
-				clock_timestamp()
-		) :: bigint * 1000
-	)
-)`
 
 type Store struct {
 	config  *Config
@@ -142,61 +125,6 @@ func (s *Store) InsertMessage(env *messagev1.Envelope) (bool, error) {
 		return nil
 	})
 	return stored, err
-}
-
-func (s *Store) InsertMLSMessage(ctx context.Context, contentTopic string, data []byte) (*messagev1.Envelope, error) {
-	tmpEnvelope := &messagev1.Envelope{
-		ContentTopic: contentTopic,
-		Message:      data,
-	}
-	digest := computeDigest(tmpEnvelope)
-	var envelope messagev1.Envelope
-
-	err := tracing.Wrap(s.ctx, s.log, "storing mls message", func(ctx context.Context, log *zap.Logger, span tracing.Span) error {
-		tracing.SpanResource(span, "store")
-		tracing.SpanType(span, "db")
-
-		stmnt := fmt.Sprintf(`INSERT INTO
-		message (
-			id,
-			receiverTimestamp,
-			senderTimestamp,
-			contentTopic,
-			pubsubTopic,
-			payload,
-			version,
-			should_expire
-		)
-	VALUES
-		(
-			$1,
-			%s,
-			%s,
-			$2,
-			$3,
-			$4,
-			$5,
-			$6
-		) RETURNING senderTimestamp`, timestampGeneratorSql, timestampGeneratorSql)
-
-		var senderTimestamp uint64
-		err := s.config.DB.QueryRowContext(ctx, stmnt, digest, contentTopic, "", data, 0, false).Scan(&senderTimestamp)
-		if err != nil {
-			return err
-		}
-		envelope = messagev1.Envelope{
-			ContentTopic: contentTopic,
-			TimestampNs:  senderTimestamp,
-			Message:      data,
-		}
-		return err
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &envelope, nil
 }
 
 func (s *Store) insertMessage(env *messagev1.Envelope, receiverTimestamp int64) error {

--- a/pkg/topic/topic.go
+++ b/pkg/topic/topic.go
@@ -39,6 +39,10 @@ func Category(contentTopic string) string {
 	return "invalid"
 }
 
+func IsV3(topic string) bool {
+	return strings.HasPrefix(topic, "/xmtp/3/")
+}
+
 func BuildGroupTopic(groupId string) string {
 	return fmt.Sprintf("/xmtp/3/g-%s/proto", groupId)
 }


### PR DESCRIPTION
Fixes https://github.com/xmtp/xmtp-node-go/issues/319

What this includes:
- Add messages table to MLS DB
- Implement InsertMessage and QueryMessages in MLS store

What this doesn't include that the existing messages DB has:
- Cleaner process for MLS messages
- DB metrics for MLS messages
- Reader connection for MLS DB
- E2E tests for MLS topics that write to this DB