### PR TITLE
refactor: move api/message/v3 to mls/api/v1

### DIFF
--- a/.github/workflows/push-mls.yml
+++ b/.github/workflows/push-mls.yml
@@ -1,4 +1,4 @@
-name: Deploy Nodes
+name: Push MLS Container
 on:
   push:
     branches:

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/uptrace/bun/driver/pgdriver v1.1.16
 	github.com/waku-org/go-waku v0.8.0
 	github.com/xmtp/go-msgio v0.2.1-0.20220510223757-25a701b79cd3
-	github.com/xmtp/proto/v3 v3.36.1
+	github.com/xmtp/proto/v3 v3.36.3-0.20240111132545-4e1d2b1b2399
 	github.com/yoheimuta/protolint v0.39.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/sync v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1146,8 +1146,8 @@ github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xmtp/go-msgio v0.2.1-0.20220510223757-25a701b79cd3 h1:wzUffJGCTBGXIDyNU+1UBu1fn2Nzo+OQzM1pLrheh58=
 github.com/xmtp/go-msgio v0.2.1-0.20220510223757-25a701b79cd3/go.mod h1:bJREWk+NDnZYjgLQdAi8SUWuq/5pkMme4GqiffEhUF4=
-github.com/xmtp/proto/v3 v3.36.1 h1:eBUsWlA/jbfhxfbDtbAofBpi8Q+TIXPMz84e64o1XTE=
-github.com/xmtp/proto/v3 v3.36.1/go.mod h1:NF2zAjtNpVIhS4tFG19g4L1tJcPZHm81oeDFXltmOiY=
+github.com/xmtp/proto/v3 v3.36.3-0.20240111132545-4e1d2b1b2399 h1:i5qynxHZRn7mIXQPt8M7c6ac0NBb+MEn2g2qKzvRTyM=
+github.com/xmtp/proto/v3 v3.36.3-0.20240111132545-4e1d2b1b2399/go.mod h1:NF2zAjtNpVIhS4tFG19g4L1tJcPZHm81oeDFXltmOiY=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/yoheimuta/go-protoparser/v4 v4.6.0 h1:uvz1e9/5Ihsm4Ku8AJeDImTpirKmIxubZdSn0QJNdnw=
 github.com/yoheimuta/go-protoparser/v4 v4.6.0/go.mod h1:AHNNnSWnb0UoL4QgHPiOAg2BniQceFscPI5X/BZNHl8=

--- a/pkg/api/authentication_test.go
+++ b/pkg/api/authentication_test.go
@@ -19,7 +19,7 @@ func Test_AuthnNoToken(t *testing.T) {
 	})
 }
 
-func Test_AuthnNoTokenNonV3(t *testing.T) {
+func Test_AuthnNoTokenNonMLS(t *testing.T) {
 	ctx := context.Background()
 	testGRPCAndHTTP(t, ctx, func(t *testing.T, client messageclient.Client, server *Server) {
 		_, err := client.Publish(ctx, &messageV1.PublishRequest{
@@ -36,13 +36,13 @@ func Test_AuthnNoTokenNonV3(t *testing.T) {
 	})
 }
 
-func Test_AuthnNoTokenV3(t *testing.T) {
+func Test_AuthnNoTokenMLS(t *testing.T) {
 	ctx := context.Background()
 	testGRPCAndHTTP(t, ctx, func(t *testing.T, client messageclient.Client, server *Server) {
 		_, err := client.Publish(ctx, &messageV1.PublishRequest{
 			Envelopes: []*messageV1.Envelope{
 				{
-					ContentTopic: "/xmtp/3/m-0x1234/proto",
+					ContentTopic: "/xmtp/mls/1/m-0x1234/proto",
 					TimestampNs:  0,
 					Message:      []byte{},
 				},
@@ -52,7 +52,7 @@ func Test_AuthnNoTokenV3(t *testing.T) {
 	})
 }
 
-func Test_AuthnNoTokenMixedV0V3(t *testing.T) {
+func Test_AuthnNoTokenMixedV0MLS(t *testing.T) {
 	ctx := context.Background()
 	testGRPCAndHTTP(t, ctx, func(t *testing.T, client messageclient.Client, server *Server) {
 		_, err := client.Publish(ctx, &messageV1.PublishRequest{
@@ -63,7 +63,7 @@ func Test_AuthnNoTokenMixedV0V3(t *testing.T) {
 					Message:      []byte{},
 				},
 				{
-					ContentTopic: "/xmtp/3/m-0x1234/proto",
+					ContentTopic: "/xmtp/mls/1/m-0x1234/proto",
 					TimestampNs:  0,
 					Message:      []byte{},
 				},

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 	wakunode "github.com/waku-org/go-waku/waku/v2/node"
 	"github.com/xmtp/xmtp-node-go/pkg/authz"
-	"github.com/xmtp/xmtp-node-go/pkg/mlsstore"
+	mlsstore "github.com/xmtp/xmtp-node-go/pkg/mls/store"
 	"github.com/xmtp/xmtp-node-go/pkg/mlsvalidate"
 	"github.com/xmtp/xmtp-node-go/pkg/ratelimiter"
 	"github.com/xmtp/xmtp-node-go/pkg/store"

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -50,8 +50,8 @@ type AuthnOptions struct {
 		Authenticated requests will be permitted according to the rules of the request type,
 		(i.e. you can't publish into other wallets' contact and private topics).
 	*/
-	Enable   bool `long:"enable" description:"require client authentication via wallet tokens"`
-	EnableV3 bool `long:"enable-v3" description:"require client authentication for V3"`
+	Enable    bool `long:"enable" description:"require client authentication via wallet tokens"`
+	EnableMLS bool `long:"enable-mls" description:"require client authentication for MLS"`
 	/*
 		Ratelimits enables request rate limiting.
 

--- a/pkg/api/interceptor.go
+++ b/pkg/api/interceptor.go
@@ -87,14 +87,14 @@ func (wa *WalletAuthorizer) Stream() grpc.StreamServerInterceptor {
 	}
 }
 
-func (wa *WalletAuthorizer) isProtocolVersion3(request *messagev1.PublishRequest) bool {
+func (wa *WalletAuthorizer) isProtocolMLS(request *messagev1.PublishRequest) bool {
 	envelopes := request.Envelopes
 	if len(envelopes) == 0 {
 		return false
 	}
 	// If any of the envelopes are not for a v3 topic, then we treat the request as non-v3
 	for _, envelope := range envelopes {
-		if !strings.HasPrefix(envelope.ContentTopic, "/xmtp/3/") {
+		if !strings.HasPrefix(envelope.ContentTopic, "/xmtp/mls/") {
 			return false
 		}
 	}
@@ -103,7 +103,7 @@ func (wa *WalletAuthorizer) isProtocolVersion3(request *messagev1.PublishRequest
 
 func (wa *WalletAuthorizer) requiresAuthorization(req interface{}) bool {
 	publishRequest, isPublish := req.(*messagev1.PublishRequest)
-	return isPublish && (!wa.isProtocolVersion3(publishRequest) || wa.AuthnConfig.EnableV3)
+	return isPublish && (!wa.isProtocolMLS(publishRequest) || wa.AuthnConfig.EnableMLS)
 }
 
 func (wa *WalletAuthorizer) getWallet(ctx context.Context) (types.WalletAddr, error) {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pkg/errors"
 	swgui "github.com/swaggest/swgui/v3"
 	proto "github.com/xmtp/proto/v3/go/message_api/v1"
-	v3Proto "github.com/xmtp/proto/v3/go/message_api/v3"
+	mlsv1pb "github.com/xmtp/proto/v3/go/mls/api/v1"
 	messagev1openapi "github.com/xmtp/proto/v3/openapi/message_api/v1"
 	"github.com/xmtp/xmtp-node-go/pkg/ratelimiter"
 	"github.com/xmtp/xmtp-node-go/pkg/tracing"
@@ -28,7 +28,7 @@ import (
 
 	messagev1 "github.com/xmtp/xmtp-node-go/pkg/api/message/v1"
 	apicontext "github.com/xmtp/xmtp-node-go/pkg/api/message/v1/context"
-	messagev3 "github.com/xmtp/xmtp-node-go/pkg/api/message/v3"
+	mlsv1 "github.com/xmtp/xmtp-node-go/pkg/mls/api/v1"
 )
 
 const (
@@ -45,7 +45,7 @@ type Server struct {
 	grpcListener net.Listener
 	httpListener net.Listener
 	messagev1    *messagev1.Service
-	messagev3    *messagev3.Service
+	mlsv1        *mlsv1.Service
 	wg           sync.WaitGroup
 	ctx          context.Context
 
@@ -131,11 +131,11 @@ func (s *Server) startGRPC() error {
 
 	// Enable the MLS server if a store is provided
 	if s.Config.MLSStore != nil && s.Config.MLSValidator != nil && s.Config.EnableMls {
-		s.messagev3, err = messagev3.NewService(s.Waku, s.Log, s.Store, s.Config.MLSStore, s.Config.MLSValidator)
+		s.mlsv1, err = mlsv1.NewService(s.Waku, s.Log, s.Store, s.Config.MLSStore, s.Config.MLSValidator)
 		if err != nil {
 			return errors.Wrap(err, "creating mls service")
 		}
-		v3Proto.RegisterMlsApiServer(grpcServer, s.messagev3)
+		mlsv1pb.RegisterMlsApiServer(grpcServer, s.mlsv1)
 	}
 	prometheus.Register(grpcServer)
 
@@ -184,7 +184,7 @@ func (s *Server) startHTTP() error {
 	}
 
 	if s.Config.MLSStore != nil && s.Config.EnableMls {
-		err = v3Proto.RegisterMlsApiHandler(s.ctx, gwmux, conn)
+		err = mlsv1pb.RegisterMlsApiHandler(s.ctx, gwmux, conn)
 		if err != nil {
 			return errors.Wrap(err, "registering mls handler")
 		}

--- a/pkg/mls/api/v1/service.go
+++ b/pkg/mls/api/v1/service.go
@@ -7,7 +7,7 @@ import (
 	wakupb "github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	proto "github.com/xmtp/proto/v3/go/mls/api/v1"
 	"github.com/xmtp/xmtp-node-go/pkg/metrics"
-	"github.com/xmtp/xmtp-node-go/pkg/mlsstore"
+	mlsstore "github.com/xmtp/xmtp-node-go/pkg/mls/store"
 	"github.com/xmtp/xmtp-node-go/pkg/mlsvalidate"
 	"github.com/xmtp/xmtp-node-go/pkg/store"
 	"github.com/xmtp/xmtp-node-go/pkg/topic"

--- a/pkg/mls/api/v1/service.go
+++ b/pkg/mls/api/v1/service.go
@@ -5,7 +5,7 @@ import (
 
 	wakunode "github.com/waku-org/go-waku/waku/v2/node"
 	wakupb "github.com/waku-org/go-waku/waku/v2/protocol/pb"
-	proto "github.com/xmtp/proto/v3/go/message_api/v3"
+	proto "github.com/xmtp/proto/v3/go/mls/api/v1"
 	"github.com/xmtp/xmtp-node-go/pkg/metrics"
 	"github.com/xmtp/xmtp-node-go/pkg/mlsstore"
 	"github.com/xmtp/xmtp-node-go/pkg/mlsvalidate"
@@ -29,7 +29,7 @@ type Service struct {
 
 func NewService(node *wakunode.WakuNode, logger *zap.Logger, messageStore *store.Store, mlsStore mlsstore.MlsStore, validationService mlsvalidate.MLSValidationService) (s *Service, err error) {
 	s = &Service{
-		log:               logger.Named("message/v3"),
+		log:               logger.Named("mls/v1"),
 		waku:              node,
 		messageStore:      messageStore,
 		mlsStore:          mlsStore,

--- a/pkg/mls/api/v1/service_test.go
+++ b/pkg/mls/api/v1/service_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 	v1 "github.com/xmtp/proto/v3/go/message_api/v1"
-	proto "github.com/xmtp/proto/v3/go/message_api/v3"
+	proto "github.com/xmtp/proto/v3/go/mls/api/v1"
 	messageContents "github.com/xmtp/proto/v3/go/mls/message_contents"
 	"github.com/xmtp/xmtp-node-go/pkg/mlsstore"
 	"github.com/xmtp/xmtp-node-go/pkg/mlsvalidate"
@@ -254,7 +254,7 @@ func TestPublishToGroup(t *testing.T) {
 	require.NoError(t, err)
 
 	results, err := svc.messageStore.Query(&v1.QueryRequest{
-		ContentTopics: []string{fmt.Sprintf("/xmtp/3/g-%s/proto", groupId)},
+		ContentTopics: []string{fmt.Sprintf("/xmtp/mls/1/g-%s/proto", groupId)},
 	})
 	require.NoError(t, err)
 	require.Len(t, results.Envelopes, 1)

--- a/pkg/mls/api/v1/service_test.go
+++ b/pkg/mls/api/v1/service_test.go
@@ -12,7 +12,7 @@ import (
 	v1 "github.com/xmtp/proto/v3/go/message_api/v1"
 	proto "github.com/xmtp/proto/v3/go/mls/api/v1"
 	messageContents "github.com/xmtp/proto/v3/go/mls/message_contents"
-	"github.com/xmtp/xmtp-node-go/pkg/mlsstore"
+	mlsstore "github.com/xmtp/xmtp-node-go/pkg/mls/store"
 	"github.com/xmtp/xmtp-node-go/pkg/mlsvalidate"
 	"github.com/xmtp/xmtp-node-go/pkg/store"
 	test "github.com/xmtp/xmtp-node-go/pkg/testing"

--- a/pkg/mls/store/config.go
+++ b/pkg/mls/store/config.go
@@ -1,4 +1,4 @@
-package mlsstore
+package store
 
 import (
 	"time"

--- a/pkg/mls/store/models.go
+++ b/pkg/mls/store/models.go
@@ -1,4 +1,4 @@
-package mlsstore
+package store
 
 import "github.com/uptrace/bun"
 

--- a/pkg/mls/store/store.go
+++ b/pkg/mls/store/store.go
@@ -1,4 +1,4 @@
-package mlsstore
+package store
 
 import (
 	"context"

--- a/pkg/mls/store/store_test.go
+++ b/pkg/mls/store/store_test.go
@@ -1,4 +1,4 @@
-package mlsstore
+package store
 
 import (
 	"context"

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/xmtp/xmtp-node-go/pkg/api"
-	"github.com/xmtp/xmtp-node-go/pkg/mlsstore"
+	mlsstore "github.com/xmtp/xmtp-node-go/pkg/mls/store"
 	"github.com/xmtp/xmtp-node-go/pkg/mlsvalidate"
 	"github.com/xmtp/xmtp-node-go/pkg/store"
 )

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -38,7 +38,7 @@ import (
 	authzmigrations "github.com/xmtp/xmtp-node-go/pkg/migrations/authz"
 	messagemigrations "github.com/xmtp/xmtp-node-go/pkg/migrations/messages"
 	mlsmigrations "github.com/xmtp/xmtp-node-go/pkg/migrations/mls"
-	"github.com/xmtp/xmtp-node-go/pkg/mlsstore"
+	mlsstore "github.com/xmtp/xmtp-node-go/pkg/mls/store"
 	"github.com/xmtp/xmtp-node-go/pkg/mlsvalidate"
 	xmtpstore "github.com/xmtp/xmtp-node-go/pkg/store"
 	"github.com/xmtp/xmtp-node-go/pkg/tracing"

--- a/pkg/topic/topic.go
+++ b/pkg/topic/topic.go
@@ -40,9 +40,9 @@ func Category(contentTopic string) string {
 }
 
 func BuildGroupTopic(groupId string) string {
-	return fmt.Sprintf("/xmtp/3/g-%s/proto", groupId)
+	return fmt.Sprintf("/xmtp/mls/1/g-%s/proto", groupId)
 }
 
 func BuildWelcomeTopic(installationId []byte) string {
-	return fmt.Sprintf("/xmtp/3/w-%x/proto", installationId)
+	return fmt.Sprintf("/xmtp/mls/1/w-%x/proto", installationId)
 }


### PR DESCRIPTION
PR to match the changes in https://github.com/xmtp/proto/pull/126 - Pulling some individual changes out of a bigger update I've been working on to decouple MLS querying from messagev1.

This PR also moves pkg/mlsstore to pkg/mls/store, along with pkg/mls/api since this code will eventually be completely isolated anyway so no need to mix it in with the other pkgs.