### PR TITLE
Add metric for api request duration

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -57,6 +57,7 @@ func registerCollectors(reg prometheus.Registerer) {
 		BootstrapPeers,
 		StoredMessages,
 		apiRequests,
+		apiRequestsDuration,
 		subscribeTopicsLength,
 		publishedEnvelopeSize,
 		publishedEnvelopeCount,


### PR DESCRIPTION
Adds metric for better visibility into non-HTTP request durations.