### PR TITLE
Add error logging to subscribe2

### DIFF
--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -206,7 +206,7 @@ func (s *Service) Subscribe(req *proto.SubscribeRequest, stream proto.MessageApi
 			}()
 		})
 		if err != nil {
-			log.Error("error subscribing", zap.Error(err))
+			log.Error("error subscribing", zap.Error(err), zap.Int("topics", len(req.ContentTopics)))
 			return err
 		}
 		defer func() {
@@ -310,7 +310,7 @@ func (s *Service) Subscribe2(stream proto.MessageApi_Subscribe2Server) error {
 						}()
 					})
 					if err != nil {
-						log.Error("error subscribing", zap.Error(err))
+						log.Error("error subscribing", zap.Error(err), zap.Int("topics", len(req.ContentTopics)))
 						return err
 					}
 					subs[topic] = sub

--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -310,6 +310,7 @@ func (s *Service) Subscribe2(stream proto.MessageApi_Subscribe2Server) error {
 						}()
 					})
 					if err != nil {
+						log.Error("error subscribing", zap.Error(err))
 						return err
 					}
 					subs[topic] = sub


### PR DESCRIPTION
Adds error logging to Subscribe2 consistent with what's in Subscribe. I noticed that this is happening sometimes in Subscribe, and so curious if it is in Subscribe2 too and for what reason. I think this would be skewing the sub/unsub metrics a bit as well, which I'll fix in a follow-up PR.