### PR TITLE
Only update delta in subscribe2

### DIFF
--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -308,7 +308,7 @@ func (s *Service) Subscribe2(stream proto.MessageApi_Subscribe2Server) error {
 				delete(subs, topic)
 				numUnsubscribes++
 			}
-			metrics.EmitUnsubscribeTopics(stream.Context(), log, numSubscribes-numUnsubscribes)
+			metrics.EmitSubscriptionChange(stream.Context(), log, numSubscribes-numUnsubscribes)
 		}
 	}
 }

--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -265,9 +265,8 @@ func (s *Service) Subscribe2(stream proto.MessageApi_Subscribe2Server) error {
 			}
 			log.Info("updating subscription", zap.Int("num_content_topics", len(req.ContentTopics)))
 
-			metrics.EmitSubscribeTopics(stream.Context(), log, len(req.ContentTopics))
-
 			topics := map[string]bool{}
+			numSubscribes := 0
 			for _, topic := range req.ContentTopics {
 				topics[topic] = true
 
@@ -295,20 +294,21 @@ func (s *Service) Subscribe2(stream proto.MessageApi_Subscribe2Server) error {
 						return err
 					}
 					subs[topic] = sub
+					numSubscribes++
 				}
 			}
 
 			// If subscription not in topic, then unsubscribe.
-			var count int
+			var numUnsubscribes int
 			for topic, sub := range subs {
 				if topics[topic] {
 					continue
 				}
 				_ = sub.Unsubscribe()
 				delete(subs, topic)
-				count++
+				numUnsubscribes++
 			}
-			metrics.EmitUnsubscribeTopics(stream.Context(), log, count)
+			metrics.EmitUnsubscribeTopics(stream.Context(), log, numSubscribes-numUnsubscribes)
 		}
 	}
 }

--- a/pkg/metrics/api-subscribe.go
+++ b/pkg/metrics/api-subscribe.go
@@ -24,6 +24,11 @@ var subscribeTopicsLength = prometheus.NewHistogramVec(
 	appClientVersionTagKeys,
 )
 
+func EmitSubscriptionChange(ctx context.Context, log *zap.Logger, delta int) {
+	labels := contextLabels(ctx)
+	subscribedTopics.With(labels).Add(float64(delta))
+}
+
 func EmitSubscribeTopics(ctx context.Context, log *zap.Logger, topics int) {
 	labels := contextLabels(ctx)
 	subscribeTopicsLength.With(labels).Observe(float64(topics))


### PR DESCRIPTION
## Summary

In `Subscribe2` we allow a client to update their subscription by passing an updated list of the topics they are interested in. The subscription metrics were incrementing the total subs by the length of the list instead of the delta between the old and new, causing our subscriptions metric to inflate.

## Notes

One caveat to this approach is that we only set the `xmtp_subscribe_topics_length` based on the original request, not any updates. That seems better than observing a new metric every time the subscription changes by 1.