### PR TITLE
Add HpkePublicKey to stream

### DIFF
--- a/pkg/mls/api/v1/service.go
+++ b/pkg/mls/api/v1/service.go
@@ -310,6 +310,7 @@ func (s *Service) SendWelcomeMessages(ctx context.Context, req *mlsv1.SendWelcom
 					CreatedNs:       uint64(msg.CreatedAt.UnixNano()),
 					InstallationKey: msg.InstallationKey,
 					Data:            msg.Data,
+					HpkePublicKey:   msg.HpkePublicKey,
 				},
 			},
 		})

--- a/pkg/mls/api/v1/service_test.go
+++ b/pkg/mls/api/v1/service_test.go
@@ -436,7 +436,6 @@ func TestSubscribeWelcomeMessages(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	for _, msg := range msgs {
-		require.NotNil(t, msg.GetV1().HpkePublicKey, "missing hpke public key")
 		msgB, err := proto.Marshal(msg)
 		require.NoError(t, err)
 

--- a/pkg/mls/api/v1/service_test.go
+++ b/pkg/mls/api/v1/service_test.go
@@ -409,6 +409,7 @@ func TestSubscribeWelcomeMessages(t *testing.T) {
 					CreatedNs:       uint64(i + 1),
 					InstallationKey: installationKey,
 					Data:            []byte(fmt.Sprintf("data%d", i+1)),
+					HpkePublicKey:   []byte(fmt.Sprintf("hpke%d", i+1)),
 				},
 			},
 		}
@@ -435,6 +436,7 @@ func TestSubscribeWelcomeMessages(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	for _, msg := range msgs {
+		require.NotNil(t, msg.GetV1().HpkePublicKey, "missing hpke public key")
 		msgB, err := proto.Marshal(msg)
 		require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

I realized the `HpkePublicKey` was getting returned in the query results, but not the streaming results. The root cause was that it was not included in the Waku message being sent over the wire.