### PR TITLE
MLS subscribe from cursor

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -14,7 +14,7 @@ go run cmd/xmtpd/main.go \
     --store.db-connection-string "${MESSAGE_DB_DSN}" \
     --store.reader-db-connection-string "${MESSAGE_DB_DSN}" \
     --store.metrics-period 5s \
-    --mls-store.db-connection-string "${MESSAGE_DB_DSN}" \
+    --mls-store.db-connection-string "${MLS_DB_DSN}" \
     --authz-db-connection-string "${AUTHZ_DB_DSN}" \
     --go-profiling \
     "$@"

--- a/pkg/mls/api/v1/service.go
+++ b/pkg/mls/api/v1/service.go
@@ -362,8 +362,32 @@ func (s *Service) SubscribeGroupMessages(req *mlsv1.SubscribeGroupMessagesReques
 	// See: https://github.com/xmtp/libxmtp/pull/58
 	_ = stream.SendHeader(metadata.Pairs("subscribed", "true"))
 
-	var streamLock sync.Mutex
+	streamed := map[string]*mlsv1.GroupMessage{}
+	var streamingLock sync.Mutex
+	streamMessages := func(msgs []*mlsv1.GroupMessage) {
+		streamingLock.Lock()
+		defer streamingLock.Unlock()
+
+		for _, msg := range msgs {
+			if msg.GetV1() == nil {
+				continue
+			}
+			encodedId := fmt.Sprintf("%x", msg.GetV1().Id)
+			if _, ok := streamed[encodedId]; ok {
+				log.Debug("skipping already streamed message", zap.String("id", encodedId))
+				continue
+			}
+			err := stream.Send(msg)
+			if err != nil {
+				log.Error("error streaming group message", zap.Error(err))
+			}
+			streamed[encodedId] = msg
+		}
+	}
+
 	for _, filter := range req.Filters {
+		filter := filter
+
 		natsSubject := buildNatsSubjectForGroupMessages(filter.GroupId)
 		log.Info("subscribing to nats subject", zap.String("subject", natsSubject), zap.String("group_id", hex.EncodeToString(filter.GroupId)))
 		sub, err := s.nc.Subscribe(natsSubject, func(natsMsg *nats.Msg) {
@@ -374,14 +398,7 @@ func (s *Service) SubscribeGroupMessages(req *mlsv1.SubscribeGroupMessagesReques
 				log.Error("parsing group message from bytes", zap.Error(err))
 				return
 			}
-			func() {
-				streamLock.Lock()
-				defer streamLock.Unlock()
-				err := stream.Send(&msg)
-				if err != nil {
-					log.Error("sending group message to subscribe", zap.Error(err))
-				}
-			}()
+			streamMessages([]*mlsv1.GroupMessage{&msg})
 		})
 		if err != nil {
 			log.Error("error subscribing to group messages", zap.Error(err))
@@ -390,6 +407,43 @@ func (s *Service) SubscribeGroupMessages(req *mlsv1.SubscribeGroupMessagesReques
 		defer func() {
 			_ = sub.Unsubscribe()
 		}()
+
+		if filter.IdCursor > 0 {
+			go func() {
+				pagingInfo := &mlsv1.PagingInfo{
+					IdCursor:  filter.IdCursor,
+					Direction: mlsv1.SortDirection_SORT_DIRECTION_ASCENDING,
+				}
+				for {
+					select {
+					case <-stream.Context().Done():
+						return
+					case <-s.ctx.Done():
+						return
+					default:
+					}
+
+					resp, err := s.store.QueryGroupMessagesV1(stream.Context(), &mlsv1.QueryGroupMessagesRequest{
+						GroupId:    filter.GroupId,
+						PagingInfo: pagingInfo,
+					})
+					if err != nil {
+						if err == context.Canceled {
+							return
+						}
+						log.Error("error querying for subscription cursor messages", zap.Error(err))
+						return
+					}
+
+					streamMessages(resp.Messages)
+
+					if len(resp.Messages) == 0 || resp.PagingInfo == nil || resp.PagingInfo.IdCursor == 0 {
+						break
+					}
+					pagingInfo = resp.PagingInfo
+				}
+			}()
+		}
 	}
 
 	select {
@@ -408,8 +462,32 @@ func (s *Service) SubscribeWelcomeMessages(req *mlsv1.SubscribeWelcomeMessagesRe
 	// See: https://github.com/xmtp/libxmtp/pull/58
 	_ = stream.SendHeader(metadata.Pairs("subscribed", "true"))
 
-	var streamLock sync.Mutex
+	streamed := map[string]*mlsv1.WelcomeMessage{}
+	var streamingLock sync.Mutex
+	streamMessages := func(msgs []*mlsv1.WelcomeMessage) {
+		streamingLock.Lock()
+		defer streamingLock.Unlock()
+
+		for _, msg := range msgs {
+			if msg.GetV1() == nil {
+				continue
+			}
+			encodedId := fmt.Sprintf("%x", msg.GetV1().Id)
+			if _, ok := streamed[encodedId]; ok {
+				log.Debug("skipping already streamed message", zap.String("id", encodedId))
+				continue
+			}
+			err := stream.Send(msg)
+			if err != nil {
+				log.Error("error streaming welcome message", zap.Error(err))
+			}
+			streamed[encodedId] = msg
+		}
+	}
+
 	for _, filter := range req.Filters {
+		filter := filter
+
 		natsSubject := buildNatsSubjectForWelcomeMessages(filter.InstallationKey)
 		sub, err := s.nc.Subscribe(natsSubject, func(natsMsg *nats.Msg) {
 			log.Info("received message from nats")
@@ -419,14 +497,7 @@ func (s *Service) SubscribeWelcomeMessages(req *mlsv1.SubscribeWelcomeMessagesRe
 				log.Error("parsing welcome message from bytes", zap.Error(err))
 				return
 			}
-			func() {
-				streamLock.Lock()
-				defer streamLock.Unlock()
-				err := stream.Send(&msg)
-				if err != nil {
-					log.Error("sending welcome message to subscribe", zap.Error(err))
-				}
-			}()
+			streamMessages([]*mlsv1.WelcomeMessage{&msg})
 		})
 		if err != nil {
 			log.Error("error subscribing to welcome messages", zap.Error(err))
@@ -435,6 +506,43 @@ func (s *Service) SubscribeWelcomeMessages(req *mlsv1.SubscribeWelcomeMessagesRe
 		defer func() {
 			_ = sub.Unsubscribe()
 		}()
+
+		if filter.IdCursor > 0 {
+			go func() {
+				pagingInfo := &mlsv1.PagingInfo{
+					IdCursor:  filter.IdCursor,
+					Direction: mlsv1.SortDirection_SORT_DIRECTION_ASCENDING,
+				}
+				for {
+					select {
+					case <-stream.Context().Done():
+						return
+					case <-s.ctx.Done():
+						return
+					default:
+					}
+
+					resp, err := s.store.QueryWelcomeMessagesV1(stream.Context(), &mlsv1.QueryWelcomeMessagesRequest{
+						InstallationKey: filter.InstallationKey,
+						PagingInfo:      pagingInfo,
+					})
+					if err != nil {
+						if err == context.Canceled {
+							return
+						}
+						log.Error("error querying for subscription cursor messages", zap.Error(err))
+						return
+					}
+
+					streamMessages(resp.Messages)
+
+					if len(resp.Messages) == 0 || resp.PagingInfo == nil || resp.PagingInfo.IdCursor == 0 {
+						break
+					}
+					pagingInfo = resp.PagingInfo
+				}
+			}()
+		}
 	}
 
 	select {

--- a/pkg/mls/store/store.go
+++ b/pkg/mls/store/store.go
@@ -328,10 +328,11 @@ func (s *Store) QueryWelcomeMessagesV1(ctx context.Context, req *mlsv1.QueryWelc
 		messages = append(messages, &mlsv1.WelcomeMessage{
 			Version: &mlsv1.WelcomeMessage_V1_{
 				V1: &mlsv1.WelcomeMessage_V1{
-					Id:            msg.Id,
-					CreatedNs:     uint64(msg.CreatedAt.UnixNano()),
-					Data:          msg.Data,
-					HpkePublicKey: msg.HpkePublicKey,
+					Id:              msg.Id,
+					CreatedNs:       uint64(msg.CreatedAt.UnixNano()),
+					Data:            msg.Data,
+					InstallationKey: msg.InstallationKey,
+					HpkePublicKey:   msg.HpkePublicKey,
 				},
 			},
 		})


### PR DESCRIPTION
Adds support to the MLS subscribe {group,welcome} messages endpoints for resuming from a given cursor id.

Fixes https://github.com/xmtp/xmtp-node-go/issues/344