### PR TITLE
Allow MLS topics in subscribeall

### DIFF
--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -394,8 +394,8 @@ func buildEnvelope(msg *wakupb.WakuMessage) *proto.Envelope {
 	}
 }
 
-func isValidSubscribeAllTopic(topic string) bool {
-	return strings.HasPrefix(topic, validXMTPTopicPrefix)
+func isValidSubscribeAllTopic(contentTopic string) bool {
+	return strings.HasPrefix(contentTopic, validXMTPTopicPrefix) || topic.IsMLSV1(contentTopic)
 }
 
 func fromWakuTimestamp(ts int64) uint64 {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -165,7 +165,6 @@ func (s *Server) startGRPC() error {
 				wakuMsg := wakuEnv.Message()
 
 				if topic.IsMLSV1(wakuMsg.ContentTopic) {
-					s.Log.Info("handling waku relay message in mlsv1 service", zap.String("topic", wakuMsg.ContentTopic))
 					if s.mlsv1 != nil {
 						err := s.mlsv1.HandleIncomingWakuRelayMessage(wakuEnv.Message())
 						if err != nil {


### PR DESCRIPTION
## Summary

- Allow MLS topics in `SubscribeAll`
- Removes some noisy logging on group subscriptions