### PR TITLE
Debug subscription issues

### DIFF
--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -210,7 +210,7 @@ func (s *Service) Subscribe(req *proto.SubscribeRequest, stream proto.MessageApi
 				}()
 			} else {
 				// channel got closed; likely due to backpressure of the sending channel.
-				log.Debug("stream closed due to backpressure")
+				log.Info("stream closed due to backpressure")
 				exit = true
 			}
 		case <-stream.Context().Done():
@@ -326,7 +326,7 @@ func (s *Service) Subscribe2(stream proto.MessageApi_Subscribe2Server) error {
 
 func (s *Service) SubscribeAll(req *proto.SubscribeAllRequest, stream proto.MessageApi_SubscribeAllServer) error {
 	log := s.log.Named("subscribeAll")
-	log.Debug("started")
+	log.Info("started")
 	defer log.Debug("stopped")
 
 	// Subscribe to all nats subjects via wildcard

--- a/pkg/api/message/v1/subscription.go
+++ b/pkg/api/message/v1/subscription.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/nats-io/nats.go"                                  // NATS messaging system
 	proto "github.com/xmtp/xmtp-node-go/pkg/proto/message_api/v1" // Custom XMTP Protocol Buffers definition
-	"go.uber.org/zap"                                             // Logging library
-	pb "google.golang.org/protobuf/proto"                         // Protocol Buffers for serialization
+	"github.com/xmtp/xmtp-node-go/pkg/topic"
+	"go.uber.org/zap"                     // Logging library
+	pb "google.golang.org/protobuf/proto" // Protocol Buffers for serialization
 )
 
 const (
@@ -150,6 +151,6 @@ func (sub *subscription) Unsubscribe() {
 	delete(sub.dispatcher.subscriptions, sub)
 }
 
-func isValidSubscribeAllTopic(topic string) bool {
-	return strings.HasPrefix(topic, validXMTPTopicPrefix)
+func isValidSubscribeAllTopic(contentTopic string) bool {
+	return strings.HasPrefix(contentTopic, validXMTPTopicPrefix) || topic.IsMLSV1(contentTopic)
 }


### PR DESCRIPTION
## Summary

We've received reports about a large volume of messages coming over the `SubscribeAll` endpoint. Investigating whether https://github.com/xmtp/xmtp-node-go/pull/354 is causing disconnect/reconnect loops