### PR TITLE
Restore centralized subscription handler

### DIFF
--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -41,13 +41,13 @@ const (
 	// maxTopicsPerQueryRequest defines the maximum number of topics that can be queried in a single request.
 	// the number is likely to be more than we want it to be, but would be a safe place to put it -
 	// per Test_LargeQueryTesting, the request decoding already failing before it reaches th handler.
-	maxTopicsPerQueryRequest = 157733
+	// maxTopicsPerQueryRequest = 157733
 
 	// maxTopicsPerBatchQueryRequest defines the maximum number of topics that can be queried in a batch query. This
 	// limit is imposed in additional to the per-query limit maxTopicsPerRequest.
 	// as a starting value, we've using the same value as above, since the entire request would be tossed
 	// away before this is reached.
-	maxTopicsPerBatchQueryRequest = maxTopicsPerQueryRequest
+	// maxTopicsPerBatchQueryRequest = maxTopicsPerQueryRequest
 )
 
 type Service struct {
@@ -345,9 +345,9 @@ func (s *Service) Query(ctx context.Context, req *proto.QueryRequest) (*proto.Qu
 	}
 
 	if len(req.ContentTopics) > 1 {
-		if len(req.ContentTopics) > maxTopicsPerQueryRequest {
-			return nil, status.Errorf(codes.InvalidArgument, "the number of content topics(%d) exceed the maximum topics per query request (%d)", len(req.ContentTopics), maxTopicsPerQueryRequest)
-		}
+		// if len(req.ContentTopics) > maxTopicsPerQueryRequest {
+		// 	return nil, status.Errorf(codes.InvalidArgument, "the number of content topics(%d) exceed the maximum topics per query request (%d)", len(req.ContentTopics), maxTopicsPerQueryRequest)
+		// }
 		ri := apicontext.NewRequesterInfo(ctx)
 		log.Info("query with multiple topics", ri.ZapFields()...)
 	} else {
@@ -387,26 +387,26 @@ func (s *Service) BatchQuery(ctx context.Context, req *proto.BatchQueryRequest) 
 	}
 
 	// calculate the total number of topics being requested in this batch request.
-	totalRequestedTopicsCount := 0
-	for _, query := range req.Requests {
-		totalRequestedTopicsCount += len(query.ContentTopics)
-	}
+	// totalRequestedTopicsCount := 0
+	// for _, query := range req.Requests {
+	// 	totalRequestedTopicsCount += len(query.ContentTopics)
+	// }
 
-	if totalRequestedTopicsCount == 0 {
-		return nil, status.Errorf(codes.InvalidArgument, "content topics required")
-	}
+	// if totalRequestedTopicsCount == 0 {
+	// 	return nil, status.Errorf(codes.InvalidArgument, "content topics required")
+	// }
 
-	// are we still within limits ?
-	if totalRequestedTopicsCount > maxTopicsPerBatchQueryRequest {
-		return nil, status.Errorf(codes.InvalidArgument, "the total number of content topics(%d) exceed the maximum topics per batch query request(%d)", totalRequestedTopicsCount, maxTopicsPerBatchQueryRequest)
-	}
+	// // are we still within limits ?
+	// if totalRequestedTopicsCount > maxTopicsPerBatchQueryRequest {
+	// 	return nil, status.Errorf(codes.InvalidArgument, "the total number of content topics(%d) exceed the maximum topics per batch query request(%d)", totalRequestedTopicsCount, maxTopicsPerBatchQueryRequest)
+	// }
 
 	// Naive implementation, perform all sub query requests sequentially
 	responses := make([]*proto.QueryResponse, 0)
 	for _, query := range req.Requests {
-		if len(query.ContentTopics) > maxTopicsPerQueryRequest {
-			return nil, status.Errorf(codes.InvalidArgument, "the number of content topics(%d) exceed the maximum topics per query request (%d)", len(query.ContentTopics), maxTopicsPerQueryRequest)
-		}
+		// if len(query.ContentTopics) > maxTopicsPerQueryRequest {
+		// 	return nil, status.Errorf(codes.InvalidArgument, "the number of content topics(%d) exceed the maximum topics per query request (%d)", len(query.ContentTopics), maxTopicsPerQueryRequest)
+		// }
 		// We execute the query using the existing Query API
 		resp, err := s.Query(ctx, query)
 		if err != nil {

--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -210,7 +210,7 @@ func (s *Service) Subscribe(req *proto.SubscribeRequest, stream proto.MessageApi
 				}()
 			} else {
 				// channel got closed; likely due to backpressure of the sending channel.
-				log.Debug("stream closed due to backpressure")
+				log.Info("stream closed due to backpressure")
 				exit = true
 			}
 		case <-stream.Context().Done():
@@ -326,7 +326,7 @@ func (s *Service) Subscribe2(stream proto.MessageApi_Subscribe2Server) error {
 
 func (s *Service) SubscribeAll(req *proto.SubscribeAllRequest, stream proto.MessageApi_SubscribeAllServer) error {
 	log := s.log.Named("subscribeAll")
-	log.Debug("started")
+	log.Info("started")
 	defer log.Debug("stopped")
 
 	// Subscribe to all nats subjects via wildcard

--- a/pkg/api/message/v1/subscription.go
+++ b/pkg/api/message/v1/subscription.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// allTopicsBacklogLength defines the buffer size for subscriptions that listen to all topics.
-	allTopicsBacklogLength = 1024
+	allTopicsBacklogLength = 4096
 
 	// minBacklogBufferLength defines the minimal length used for backlog buffer.
 	minBacklogBufferLength

--- a/pkg/api/message/v1/subscription.go
+++ b/pkg/api/message/v1/subscription.go
@@ -78,12 +78,13 @@ func (d *subscriptionDispatcher) messageHandler(msg *nats.Msg) {
 			select {
 			case subscription.messagesCh <- &env:
 			default:
+				d.log.Info(fmt.Sprintf("Subscription message channel is full, is subscribeAll: %t, numTopics: %d", subscription.all, len(subscription.topics)))
 				// we got here since the message channel was full. This happens when the client cannot
 				// consume the data fast enough. In that case, we don't want to block further since it migth
 				// slow down other users. Instead, we're going to close the channel and let the
 				// consumer re-establish the connection if needed.
-				close(subscription.messagesCh)
-				delete(d.subscriptions, subscription)
+				// close(subscription.messagesCh)
+				// delete(d.subscriptions, subscription)
 			}
 		}
 	}

--- a/pkg/api/message/v1/subscription.go
+++ b/pkg/api/message/v1/subscription.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/nats-io/nats.go"                                  // NATS messaging system
 	proto "github.com/xmtp/xmtp-node-go/pkg/proto/message_api/v1" // Custom XMTP Protocol Buffers definition
-	"go.uber.org/zap"                                             // Logging library
-	pb "google.golang.org/protobuf/proto"                         // Protocol Buffers for serialization
+	"github.com/xmtp/xmtp-node-go/pkg/topic"
+	"go.uber.org/zap"                     // Logging library
+	pb "google.golang.org/protobuf/proto" // Protocol Buffers for serialization
 )
 
 const (
@@ -150,6 +151,6 @@ func (sub *subscription) Unsubscribe() {
 	delete(sub.dispatcher.subscriptions, sub)
 }
 
-func isValidSubscribeAllTopic(topic string) bool {
-	return strings.HasPrefix(topic, validXMTPTopicPrefix)
+func isValidSubscribeAllTopic(contentTopic string) bool {
+	return strings.HasPrefix(contentTopic, validXMTPTopicPrefix) || topic.IsMLSV1(contentTopic)
 }

--- a/pkg/api/message/v1/subscription.go
+++ b/pkg/api/message/v1/subscription.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/nats-io/nats.go"                                  // NATS messaging system
+	proto "github.com/xmtp/xmtp-node-go/pkg/proto/message_api/v1" // Custom XMTP Protocol Buffers definition
+	"go.uber.org/zap"                                             // Logging library
+	pb "google.golang.org/protobuf/proto"                         // Protocol Buffers for serialization
+)
+
+const (
+	// allTopicsBacklogLength defines the buffer size for subscriptions that listen to all topics.
+	allTopicsBacklogLength = 1024
+
+	// minBacklogBufferLength defines the minimal length used for backlog buffer.
+	minBacklogBufferLength
+)
+
+// subscriptionDispatcher manages subscriptions and message dispatching.
+type subscriptionDispatcher struct {
+	natsConn      *nats.Conn                    // Connection to NATS server
+	natsSub       *nats.Subscription            // Subscription to NATS topics
+	log           *zap.Logger                   // Logger instance
+	subscriptions map[*subscription]interface{} // Active subscriptions
+	mu            sync.Mutex                    // Mutex for concurrency control
+}
+
+// newSubscriptionDispatcher creates a new dispatcher for managing subscriptions.
+func newSubscriptionDispatcher(conn *nats.Conn, log *zap.Logger) (*subscriptionDispatcher, error) {
+	dispatcher := &subscriptionDispatcher{
+		natsConn:      conn,
+		log:           log,
+		subscriptions: make(map[*subscription]interface{}),
+	}
+
+	// Subscribe to NATS wildcard topic and assign message handler
+	var err error
+	dispatcher.natsSub, err = conn.Subscribe(natsWildcardTopic, dispatcher.messageHandler)
+	if err != nil {
+		return nil, err
+	}
+	return dispatcher, nil
+}
+
+// Shutdown gracefully shuts down the dispatcher, unsubscribing from all topics.
+func (d *subscriptionDispatcher) Shutdown() {
+	_ = d.natsSub.Unsubscribe()
+	// the lock/unlock ensures that there is no in-process dispatching.
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.natsSub = nil
+	d.natsConn = nil
+	d.subscriptions = nil
+
+}
+
+// messageHandler processes incoming messages, dispatching them to the correct subscription.
+func (d *subscriptionDispatcher) messageHandler(msg *nats.Msg) {
+	var env proto.Envelope
+	err := pb.Unmarshal(msg.Data, &env)
+	if err != nil {
+		d.log.Info("unmarshaling envelope", zap.Error(err))
+		return
+	}
+
+	xmtpTopic := isValidSubscribeAllTopic(env.ContentTopic)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for subscription := range d.subscriptions {
+		if subscription.all && !xmtpTopic {
+			continue
+		}
+		if subscription.all || subscription.topics[env.ContentTopic] {
+			select {
+			case subscription.messagesCh <- &env:
+			default:
+				// we got here since the message channel was full. This happens when the client cannot
+				// consume the data fast enough. In that case, we don't want to block further since it migth
+				// slow down other users. Instead, we're going to close the channel and let the
+				// consumer re-establish the connection if needed.
+				close(subscription.messagesCh)
+				delete(d.subscriptions, subscription)
+			}
+		}
+	}
+}
+
+// subscription represents a single subscription, including its message channel and topics.
+type subscription struct {
+	messagesCh chan *proto.Envelope    // Channel for receiving messages
+	topics     map[string]bool         // Map of topics to subscribe to
+	all        bool                    // Flag indicating subscription to all topics
+	dispatcher *subscriptionDispatcher // Parent dispatcher
+}
+
+// log2 calculates the base-2 logarithm of an integer using bitwise operations.
+// It returns the floor of the actual base-2 logarithm.
+func log2(n uint) (log2 uint) {
+	if n == 0 {
+		return 0
+	}
+
+	// Keep shifting n right until it becomes 0.
+	// The number of shifts needed is the floor of log2(n).
+	for n > 1 {
+		n >>= 1
+		log2++
+	}
+	return log2
+}
+
+// Subscribe creates a new subscription for the given topics.
+func (d *subscriptionDispatcher) Subscribe(topics map[string]bool) *subscription {
+	sub := &subscription{
+		dispatcher: d,
+	}
+
+	// Determine if subscribing to all topics or specific ones
+	for topic := range topics {
+		if natsWildcardTopic == topic {
+			sub.all = true
+			break
+		}
+	}
+	if !sub.all {
+		sub.topics = topics
+		// use a log2(length) as a backbuffer
+		backlogBufferSize := log2(uint(len(topics))) + 1
+		if backlogBufferSize < minBacklogBufferLength {
+			backlogBufferSize = minBacklogBufferLength
+		}
+		sub.messagesCh = make(chan *proto.Envelope, backlogBufferSize)
+	} else {
+		sub.messagesCh = make(chan *proto.Envelope, allTopicsBacklogLength)
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.subscriptions[sub] = true
+	return sub
+}
+
+// Unsubscribe removes the subscription from its dispatcher.
+func (sub *subscription) Unsubscribe() {
+	sub.dispatcher.mu.Lock()
+	defer sub.dispatcher.mu.Unlock()
+	delete(sub.dispatcher.subscriptions, sub)
+}
+
+func isValidSubscribeAllTopic(topic string) bool {
+	return strings.HasPrefix(topic, validXMTPTopicPrefix)
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -283,6 +283,7 @@ func (s *Server) Close() {
 		if err != nil {
 			s.Log.Error("closing http listener", zap.Error(err))
 		}
+		s.httpListener = nil
 	}
 
 	if s.grpcListener != nil {
@@ -290,6 +291,7 @@ func (s *Server) Close() {
 		if err != nil {
 			s.Log.Error("closing grpc listener", zap.Error(err))
 		}
+		s.grpcListener = nil
 	}
 
 	s.wg.Wait()

--- a/pkg/api/utils_test.go
+++ b/pkg/api/utils_test.go
@@ -24,7 +24,7 @@ func makeEnvelopes(count int) (envs []*messageV1.Envelope) {
 	return envs
 }
 
-func subscribeExpect(t *testing.T, stream messageclient.Stream, expected []*messageV1.Envelope) {
+func subscribeExpect(t testing.TB, stream messageclient.Stream, expected []*messageV1.Envelope) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	received := []*messageV1.Envelope{}
@@ -38,7 +38,7 @@ func subscribeExpect(t *testing.T, stream messageclient.Stream, expected []*mess
 	requireEnvelopesEqual(t, expected, received)
 }
 
-func requireEventuallyStored(t *testing.T, ctx context.Context, client messageclient.Client, expected []*messageV1.Envelope) {
+func requireEventuallyStored(t testing.TB, ctx context.Context, client messageclient.Client, expected []*messageV1.Envelope) {
 	var queryRes *messageV1.QueryResponse
 	require.Eventually(t, func() bool {
 		var err error
@@ -54,14 +54,14 @@ func requireEventuallyStored(t *testing.T, ctx context.Context, client messagecl
 	requireEnvelopesEqual(t, expected, queryRes.Envelopes)
 }
 
-func requireEnvelopesEqual(t *testing.T, expected, received []*messageV1.Envelope) {
+func requireEnvelopesEqual(t testing.TB, expected, received []*messageV1.Envelope) {
 	require.Equal(t, len(expected), len(received), "length mismatch")
 	for i, env := range received {
 		requireEnvelopeEqual(t, expected[i], env, "mismatched message[%d]", i)
 	}
 }
 
-func requireEnvelopeEqual(t *testing.T, expected, actual *messageV1.Envelope, msgAndArgs ...interface{}) {
+func requireEnvelopeEqual(t testing.TB, expected, actual *messageV1.Envelope, msgAndArgs ...interface{}) {
 	require.Equal(t, expected.ContentTopic, actual.ContentTopic, msgAndArgs...)
 	require.Equal(t, expected.Message, actual.Message, msgAndArgs...)
 	if expected.TimestampNs != 0 {

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -91,9 +91,9 @@ func TestNodes_Deployment(t *testing.T) {
 			n2PrivKey := test.NewPrivateKey(t)
 
 			// Spin up initial instances of the nodes.
-			n1, cleanup := test.NewNode(t, wakunode.WithPrivateKey(n1PrivKey))
+			n1, cleanup := test.NewNode(t, test.NewLog(t), wakunode.WithPrivateKey(n1PrivKey))
 			defer cleanup()
-			n2, cleanup := test.NewNode(t, wakunode.WithPrivateKey(n2PrivKey))
+			n2, cleanup := test.NewNode(t, test.NewLog(t), wakunode.WithPrivateKey(n2PrivKey))
 			defer cleanup()
 
 			// Connect the nodes.
@@ -101,9 +101,9 @@ func TestNodes_Deployment(t *testing.T) {
 			test.Connect(t, n2, n1)
 
 			// Spin up new instances of the nodes.
-			newN1, cleanup := test.NewNode(t, wakunode.WithPrivateKey(n1PrivKey))
+			newN1, cleanup := test.NewNode(t, test.NewLog(t), wakunode.WithPrivateKey(n1PrivKey))
 			defer cleanup()
-			newN2, cleanup := test.NewNode(t, wakunode.WithPrivateKey(n2PrivKey))
+			newN2, cleanup := test.NewNode(t, test.NewLog(t), wakunode.WithPrivateKey(n2PrivKey))
 			defer cleanup()
 
 			// Expect matching peer IDs for new and old instances.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -21,11 +21,11 @@ func TestServer_NewShutdown(t *testing.T) {
 func TestServer_StaticNodesReconnect(t *testing.T) {
 	t.Parallel()
 
-	n1, cleanup := test.NewNode(t)
+	n1, cleanup := test.NewNode(t, test.NewLog(t))
 	defer cleanup()
 	n1ID := n1.Host().ID()
 
-	n2, cleanup := test.NewNode(t)
+	n2, cleanup := test.NewNode(t, test.NewLog(t))
 	defer cleanup()
 	n2ID := n2.Host().ID()
 

--- a/pkg/testing/log.go
+++ b/pkg/testing/log.go
@@ -14,7 +14,7 @@ func init() {
 	flag.BoolVar(&debug, "debug", false, "debug level logging in tests")
 }
 
-func NewLog(t *testing.T) *zap.Logger {
+func NewLog(t testing.TB) *zap.Logger {
 	cfg := zap.NewDevelopmentConfig()
 	if !debug {
 		cfg.Level = zap.NewAtomicLevelAt(zap.InfoLevel)

--- a/pkg/testing/node.go
+++ b/pkg/testing/node.go
@@ -18,6 +18,7 @@ import (
 	"github.com/waku-org/go-waku/tests"
 	wakunode "github.com/waku-org/go-waku/waku/v2/node"
 	"github.com/waku-org/go-waku/waku/v2/peerstore"
+	"go.uber.org/zap"
 )
 
 func Connect(t *testing.T, n1 *wakunode.WakuNode, n2 *wakunode.WakuNode, protocols ...protocol.ID) {
@@ -65,11 +66,10 @@ func Disconnect(t *testing.T, n1 *wakunode.WakuNode, n2 *wakunode.WakuNode) {
 	}, 3*time.Second, 50*time.Millisecond)
 }
 
-func NewNode(t *testing.T, opts ...wakunode.WakuNodeOption) (*wakunode.WakuNode, func()) {
+func NewNode(t testing.TB, log *zap.Logger, opts ...wakunode.WakuNodeOption) (*wakunode.WakuNode, func()) {
 	hostAddr, _ := net.ResolveTCPAddr("tcp", "0.0.0.0:0")
 	prvKey := NewPrivateKey(t)
 	ctx := context.Background()
-	log := NewLog(t)
 	opts = append([]wakunode.WakuNodeOption{
 		wakunode.WithLogger(log),
 		wakunode.WithPrivateKey(prvKey),
@@ -94,7 +94,7 @@ func NewPeer(t *testing.T) host.Host {
 	return host
 }
 
-func NewPrivateKey(t *testing.T) *ecdsa.PrivateKey {
+func NewPrivateKey(t testing.TB) *ecdsa.PrivateKey {
 	key, err := tests.RandomHex(32)
 	require.NoError(t, err)
 	prvKey, err := crypto.HexToECDSA(key)

--- a/pkg/testing/store.go
+++ b/pkg/testing/store.go
@@ -19,7 +19,7 @@ const (
 	localTestDBDSNSuffix = "?sslmode=disable"
 )
 
-func NewDB(t *testing.T) (*sql.DB, string, func()) {
+func NewDB(t testing.TB) (*sql.DB, string, func()) {
 	dsn := localTestDBDSNPrefix + localTestDBDSNSuffix
 	ctlDB := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))
 	dbName := "test_" + RandomStringLower(12)
@@ -36,7 +36,7 @@ func NewDB(t *testing.T) (*sql.DB, string, func()) {
 	}
 }
 
-func NewAuthzDB(t *testing.T) (*bun.DB, string, func()) {
+func NewAuthzDB(t testing.TB) (*bun.DB, string, func()) {
 	db, dsn, cleanup := NewDB(t)
 	bunDB := bun.NewDB(db, pgdialect.New())
 


### PR DESCRIPTION
1. Restore the centralized subscription handler (#354)
2. Remove the RPC request limits that were added - to reduce number of variables (can add separately)
3. Include @neekolas 's additional logging
4. Log lots of info when a subscription channel is full, but don't close it
5. 4x the backlog length for subscribeAll