### PR TITLE
Remove noisy log line

### DIFF
--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -367,11 +367,7 @@ func (s *Service) Query(ctx context.Context, req *proto.QueryRequest) (*proto.Qu
 
 func (s *Service) BatchQuery(ctx context.Context, req *proto.BatchQueryRequest) (*proto.BatchQueryResponse, error) {
 	log := s.log.Named("batchQuery")
-	logFunc := log.Debug
-	if len(req.Requests) > 10 {
-		logFunc = log.Info
-	}
-	logFunc("large batch query", zap.Int("num_queries", len(req.Requests)))
+	log.Debug("batch query", zap.Int("num_queries", len(req.Requests)))
 
 	// NOTE: in our implementation, we implicitly limit batch size to 50 requests (maxQueriesPerBatch = 50)
 	if len(req.Requests) > maxQueriesPerBatch {

--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -354,14 +354,6 @@ func (s *Service) Query(ctx context.Context, req *proto.QueryRequest) (*proto.Qu
 		log = log.With(zap.String("topic_type", topic.Category(req.ContentTopics[0])))
 	}
 	log = log.With(logging.QueryParameters(req))
-	if req.StartTimeNs != 0 || req.EndTimeNs != 0 {
-		ri := apicontext.NewRequesterInfo(ctx)
-		log.Info("query with time filters", append(
-			ri.ZapFields(),
-			zap.Uint64("start_time", req.StartTimeNs),
-			zap.Uint64("end_time", req.EndTimeNs),
-		)...)
-	}
 
 	if req.PagingInfo != nil && req.PagingInfo.Cursor != nil {
 		cursor := req.PagingInfo.Cursor.GetIndex()


### PR DESCRIPTION
## Summary

A huge chunk of our logs from `xmtp-node-go` are a completely useless log line that I believe was meant to be temporary to see if people are using queries with time filters (they are).

This removes that