### PR TITLE
Add proxy protocol

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -135,6 +135,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/philhofer/fwd v1.1.1 // indirect
+	github.com/pires/go-proxyproto v0.7.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -910,6 +910,8 @@ github.com/pierrec/lz4 v0.0.0-20190327172049-315a67e90e41/go.mod h1:3/3N9NVKO0je
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pires/go-proxyproto v0.7.0 h1:IukmRewDQFWC7kfnb66CSomk2q/seBuilHBYFwyq0Hs=
+github.com/pires/go-proxyproto v0.7.0/go.mod h1:Vz/1JPY/OACxWGQNIRY2BeyDmpoaWmEP40O9LbuiFR4=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/api/interceptor.go
+++ b/pkg/api/interceptor.go
@@ -149,6 +149,8 @@ func (wa *WalletAuthorizer) applyLimits(ctx context.Context, fullMethod string, 
 		// requests without an IP address are bucketed together as "ip_unknown"
 		ip = "ip_unknown"
 	}
+	// TODO: Remove this noisy log line
+	wa.Log.Info("got peer address", logging.String("client_ip", ip))
 
 	// with no wallet apply regular limits
 	var isPriority bool

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/pires/go-proxyproto"
 	messagev1 "github.com/xmtp/xmtp-node-go/pkg/api/message/v1"
 	apicontext "github.com/xmtp/xmtp-node-go/pkg/api/message/v1/context"
 	mlsv1 "github.com/xmtp/xmtp-node-go/pkg/mls/api/v1"
@@ -86,7 +87,8 @@ func New(config *Config) (*Server, error) {
 func (s *Server) startGRPC() error {
 	var err error
 
-	s.grpcListener, err = net.Listen("tcp", addrString(s.GRPCAddress, s.GRPCPort))
+	grpcListener, err := net.Listen("tcp", addrString(s.GRPCAddress, s.GRPCPort))
+	s.grpcListener = &proxyproto.Listener{Listener: grpcListener}
 	if err != nil {
 		return errors.Wrap(err, "creating grpc listener")
 	}


### PR DESCRIPTION
## Summary

- Wraps the underlying TCP listener for GRPC with https://github.com/pires/go-proxyproto to parse the proxy protocol headers
- Reads those headers if no `x-forwarded-for` address is set