### PR TITLE
Use a shared nats server

### DIFF
--- a/pkg/api/message/v1/subscription.go
+++ b/pkg/api/message/v1/subscription.go
@@ -55,7 +55,6 @@ func (d *subscriptionDispatcher) Shutdown() {
 	d.natsSub = nil
 	d.natsConn = nil
 	d.subscriptions = nil
-
 }
 
 // messageHandler processes incoming messages, dispatching them to the correct subscription.
@@ -66,6 +65,7 @@ func (d *subscriptionDispatcher) messageHandler(msg *nats.Msg) {
 		d.log.Info("unmarshaling envelope", zap.Error(err))
 		return
 	}
+	d.log.Info("sending message to topic", zap.String("content_topic", env.ContentTopic))
 
 	xmtpTopic := isValidSubscribeAllTopic(env.ContentTopic)
 


### PR DESCRIPTION
## Summary

There is an issue with `SubscribeAll` and group messages. Both the legacy and the MLS APIs create their own nats servers. That means that the servers cannot talk to one another. This only becomes an issue with `SubscribeAll`, which is expected to receive messages from both servers.

- This PR creates a shared nats server for both APIs and passes it in as an argument