### PR TITLE
Allow larger queries for user preferences

### DIFF
--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -400,6 +400,8 @@ func (s *Service) BatchQuery(ctx context.Context, req *proto.BatchQueryRequest) 
 	}, nil
 }
 
+// Temporarily using this function to allow for flexible limits depending on topic.
+// See: https://github.com/xmtp/xmtp-node-go/pull/373
 func getMaxRows(contentTopics []string) int {
 	if len(contentTopics) == 1 && topic.IsUserPreferences(contentTopics[0]) {
 		return maxUserPreferencesRowsPerQuery

--- a/pkg/topic/topic.go
+++ b/pkg/topic/topic.go
@@ -5,20 +5,25 @@ import (
 )
 
 var topicCategoryByPrefix = map[string]string{
-	"test":         "test",
-	"contact":      "contact",
-	"intro":        "v1-intro",
-	"dm":           "v1-conversation",
-	"dmE":          "v1-conversation-ephemeral",
-	"invite":       "v2-invite",
-	"groupInvite":  "v2-group-invite",
-	"m":            "v2-conversation",
-	"mE":           "v2-conversation-ephemeral",
-	"privatestore": "private",
+	"test":            "test",
+	"contact":         "contact",
+	"intro":           "v1-intro",
+	"dm":              "v1-conversation",
+	"dmE":             "v1-conversation-ephemeral",
+	"invite":          "v2-invite",
+	"groupInvite":     "v2-group-invite",
+	"m":               "v2-conversation",
+	"mE":              "v2-conversation-ephemeral",
+	"privatestore":    "private",
+	"userpreferences": "userpreferences",
 }
 
 func IsEphemeral(contentTopic string) bool {
 	return Category(contentTopic) == "v2-conversation-ephemeral" || Category(contentTopic) == "v1-conversation-ephemeral"
+}
+
+func IsUserPreferences(contentTopic string) bool {
+	return Category(contentTopic) == "userpreferences"
 }
 
 func Category(contentTopic string) string {


### PR DESCRIPTION
## tl;dr

We are putting in this hack to allow for larger request sizes for User Preferences requests.

This will be removed once MLS/Groups moves into production and we can start caching these results locally.