### PR TITLE
Remove race conditions from algorithm

### DIFF
--- a/pkg/identity/api/v1/service.go
+++ b/pkg/identity/api/v1/service.go
@@ -67,11 +67,11 @@ Start transaction (SERIALIZABLE isolation level)
  2. If the log has 256 or more entries, abort the transaction.
  3. Concatenate the update in-memory and validate it sequentially. If
     failed, abort the transaction.
- 4. For each affected address:
+ 4. Insert the update into the inbox_log table
+ 5. For each affected address:
     a. Insert or update the record with (address, inbox_id) into
     the address_log table, updating the relevant sequence_id (it should
     always be higher)
- 5. Insert the update into the inbox_log table
 
 End transaction
 */

--- a/pkg/identity/api/v1/service.go
+++ b/pkg/identity/api/v1/service.go
@@ -69,8 +69,8 @@ Start transaction (SERIALIZABLE isolation level)
     failed, abort the transaction.
  4. For each affected address:
     a. Insert or update the record with (address, inbox_id) into
-    the address_log table. Update the sequence_id if it is
-    higher
+    the address_log table, updating the relevant sequence_id (it should
+    always be higher)
  5. Insert the update into the inbox_log table
 
 End transaction

--- a/pkg/identity/api/v1/service.go
+++ b/pkg/identity/api/v1/service.go
@@ -63,7 +63,6 @@ Start transaction (SERIALIZABLE isolation level)
 
  1. Read the log for the inbox_id, ordering by sequence_id
     - Use FOR UPDATE to block other transactions on the same inbox_id
-    if the log is non-empty
  2. If the log has 256 or more entries, abort the transaction.
  3. Concatenate the update in-memory and validate it sequentially. If
     failed, abort the transaction.


### PR DESCRIPTION
Consistency is important here, because any inconsistency will break commit validation, irrevocably breaking MLS groups.

The problem with the last algorithm is that if multiple transactions execute concurrently, the sequence number is [not guaranteed](https://stackoverflow.com/questions/52432459/postgresql-serialized-inserts-interleaving-sequence-numbers) to increase in the same 'serialization order' as the transactions. In other words, property 3.b) in the code comments is violated.

To remedy this (thanks @neekolas for the suggestion):
1. Use FOR UPDATE to block concurrent execution of transactions on the same inbox, provided the inbox is non-empty.
2. Use SERIALIZABLE isolation level to make sure that only one transaction ever operates successfully on the same inbox, when it is empty.

Other notes:
- This only guarantees property 3.b) is honored over the *same* inbox. Property 3.c) identifies this limitation.
- For the address log, we assume that strict ordering/strong consistency is not required across inboxes. Resolving eventually to any non-revoked inbox_id is acceptable.