### PR TITLE
Define SQL formatting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": ["bradymholt.pgformatter", "golang.go"],
+  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  "unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "pgFormatter.typeCase": "uppercase",
+  "pgFormatter.tabs": true
+}

--- a/pkg/migrations/mls/20231023050806_init-schema.down.sql
+++ b/pkg/migrations/mls/20231023050806_init-schema.down.sql
@@ -1,5 +1,5 @@
-SET
-    statement_timeout = 0;
+SET statement_timeout = 0;
 
 --bun:split
 DROP TABLE IF EXISTS installations;
+

--- a/pkg/migrations/mls/20231023050806_init-schema.up.sql
+++ b/pkg/migrations/mls/20231023050806_init-schema.up.sql
@@ -1,17 +1,15 @@
-SET
-    statement_timeout = 0;
+SET statement_timeout = 0;
 
 --bun:split
-CREATE TABLE installations (
-    id BYTEA PRIMARY KEY,
-    wallet_address TEXT NOT NULL,
-    created_at BIGINT NOT NULL,
-    updated_at BIGINT NOT NULL,
-    credential_identity BYTEA NOT NULL,
-    revoked_at BIGINT,
-
-    key_package BYTEA NOT NULL,
-    expiration BIGINT NOT NULL
+CREATE TABLE installations(
+	id BYTEA PRIMARY KEY,
+	wallet_address TEXT NOT NULL,
+	created_at BIGINT NOT NULL,
+	updated_at BIGINT NOT NULL,
+	credential_identity BYTEA NOT NULL,
+	revoked_at BIGINT,
+	key_package BYTEA NOT NULL,
+	expiration BIGINT NOT NULL
 );
 
 --bun:split
@@ -22,3 +20,4 @@ CREATE INDEX idx_installations_created_at ON installations(created_at);
 
 --bun:split
 CREATE INDEX idx_installations_revoked_at ON installations(revoked_at);
+

--- a/pkg/migrations/mls/20240109001927_add-messages.down.sql
+++ b/pkg/migrations/mls/20240109001927_add-messages.down.sql
@@ -1,6 +1,5 @@
 SET statement_timeout = 0;
 
 --bun:split
-
 DROP TABLE IF EXISTS messages;
 

--- a/pkg/migrations/mls/20240109001927_add-messages.up.sql
+++ b/pkg/migrations/mls/20240109001927_add-messages.up.sql
@@ -1,37 +1,32 @@
 SET statement_timeout = 0;
 
 --bun:split
-
-CREATE TABLE group_messages (
-    id BIGSERIAL PRIMARY KEY,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    group_id BYTEA NOT NULL,
-    data BYTEA NOT NULL,
-    group_id_data_hash BYTEA NOT NULL
+CREATE TABLE group_messages(
+	id BIGSERIAL PRIMARY KEY,
+	created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+	group_id BYTEA NOT NULL,
+	data BYTEA NOT NULL,
+	group_id_data_hash BYTEA NOT NULL
 );
 
 --bun:split
-
 CREATE INDEX idx_group_messages_group_id_created_at ON group_messages(group_id, created_at);
 
 --bun:split
-
-CREATE UNIQUE INDEX idx_group_messages_group_id_data_hash ON group_messages (group_id_data_hash);
+CREATE UNIQUE INDEX idx_group_messages_group_id_data_hash ON group_messages(group_id_data_hash);
 
 --bun:split
-
-CREATE TABLE welcome_messages (
-    id BIGSERIAL PRIMARY KEY,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    installation_key BYTEA NOT NULL,
-    data BYTEA NOT NULL,
-    installation_key_data_hash BYTEA NOT NULL
+CREATE TABLE welcome_messages(
+	id BIGSERIAL PRIMARY KEY,
+	created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+	installation_key BYTEA NOT NULL,
+	data BYTEA NOT NULL,
+	installation_key_data_hash BYTEA NOT NULL
 );
 
 --bun:split
-
 CREATE INDEX idx_welcome_messages_installation_key_created_at ON welcome_messages(installation_key, created_at);
 
 --bun:split
+CREATE UNIQUE INDEX idx_welcome_messages_group_key_data_hash ON welcome_messages(installation_key_data_hash);
 
-CREATE UNIQUE INDEX idx_welcome_messages_group_key_data_hash ON welcome_messages (installation_key_data_hash);

--- a/pkg/migrations/mls/20240122230601_add-hpke-key.down.sql
+++ b/pkg/migrations/mls/20240122230601_add-hpke-key.down.sql
@@ -1,4 +1,5 @@
 SET statement_timeout = 0;
 
 ALTER TABLE welcome_messages
-DROP COLUMN IF EXISTS hpke_public_key BYTEA;
+	DROP COLUMN IF EXISTS hpke_public_key BYTEA;
+

--- a/pkg/migrations/mls/20240122230601_add-hpke-key.up.sql
+++ b/pkg/migrations/mls/20240122230601_add-hpke-key.up.sql
@@ -1,4 +1,5 @@
 SET statement_timeout = 0;
 
 ALTER TABLE welcome_messages
-ADD COLUMN hpke_public_key BYTEA;
+	ADD COLUMN hpke_public_key BYTEA;
+

--- a/pkg/migrations/mls/20240411200242_init-identity.down.sql
+++ b/pkg/migrations/mls/20240411200242_init-identity.down.sql
@@ -1,9 +1,8 @@
 SET statement_timeout = 0;
 
 --bun:split
-
 DROP TABLE IF EXISTS inbox_log;
 
 --bun:split
-
 DROP TABLE IF EXISTS address_log;
+

--- a/pkg/migrations/mls/20240411200242_init-identity.up.sql
+++ b/pkg/migrations/mls/20240411200242_init-identity.up.sql
@@ -1,23 +1,24 @@
 SET statement_timeout = 0;
 
 --bun:split
-CREATE TABLE inbox_log (
-    sequence_id BIGSERIAL PRIMARY KEY,
-    inbox_id TEXT NOT NULL,
-    server_timestamp_ns BIGINT NOT NULL,
-    identity_update_proto BYTEA NOT NULL
+CREATE TABLE inbox_log(
+	sequence_id BIGSERIAL PRIMARY KEY,
+	inbox_id TEXT NOT NULL,
+	server_timestamp_ns BIGINT NOT NULL,
+	identity_update_proto BYTEA NOT NULL
 );
 
 --bun:split
 CREATE INDEX idx_inbox_log_inbox_id ON inbox_log(inbox_id);
 
 --bun:split
-CREATE TABLE address_log (
-    address TEXT NOT NULL,
-    inbox_id TEXT NOT NULL,
-    association_sequence_id BIGINT,
-    revocation_sequence_id BIGINT
+CREATE TABLE address_log(
+	address TEXT NOT NULL,
+	inbox_id TEXT NOT NULL,
+	association_sequence_id BIGINT,
+	revocation_sequence_id BIGINT
 );
 
 --bun:split
 CREATE INDEX idx_address_log_address_inbox_id ON address_log(address, inbox_id);
+

--- a/pkg/migrations/mls/20240425021053_add-inbox-filters.down.sql
+++ b/pkg/migrations/mls/20240425021053_add-inbox-filters.down.sql
@@ -1,5 +1,5 @@
 SET statement_timeout = 0;
 
 --bun:split
-
 DROP TYPE IF EXISTS inbox_filter;
+

--- a/pkg/migrations/mls/20240425021053_add-inbox-filters.up.sql
+++ b/pkg/migrations/mls/20240425021053_add-inbox-filters.up.sql
@@ -1,8 +1,8 @@
 SET statement_timeout = 0;
 
 --bun:split
-
 CREATE TYPE inbox_filter AS (
-    inbox_id TEXT,
-    sequence_id BIGINT
+	inbox_id TEXT,
+	sequence_id BIGINT
 );
+

--- a/pkg/mls/store/queries.sql
+++ b/pkg/mls/store/queries.sql
@@ -1,150 +1,179 @@
 -- name: GetAllInboxLogs :many
-SELECT *
-FROM inbox_log
-WHERE inbox_id = $1
-ORDER BY sequence_id ASC FOR
-UPDATE;
+SELECT
+	*
+FROM
+	inbox_log
+WHERE
+	inbox_id = $1
+ORDER BY
+	sequence_id ASC
+FOR UPDATE;
 
 -- name: GetInboxLogFiltered :many
-SELECT a.*
-FROM inbox_log AS a
-    JOIN (
-        SELECT *
-        FROM json_populate_recordset(null::inbox_filter, sqlc.arg(filters)) as b(inbox_id, sequence_id)
-    ) as b on b.inbox_id = a.inbox_id
-    AND a.sequence_id > b.sequence_id
-ORDER BY a.sequence_id ASC;
+SELECT
+	a.*
+FROM
+	inbox_log AS a
+	JOIN (
+		SELECT
+			*
+		FROM
+			json_populate_recordset(NULL::inbox_filter, sqlc.arg(filters)) AS b(inbox_id,
+				sequence_id)) AS b ON b.inbox_id = a.inbox_id
+		AND a.sequence_id > b.sequence_id
+	ORDER BY
+		a.sequence_id ASC;
 
 -- name: GetAddressLogs :many
-SELECT a.address,
-    a.inbox_id,
-    a.association_sequence_id
-FROM address_log a
-    INNER JOIN (
-        SELECT address,
-            MAX(association_sequence_id) AS max_association_sequence_id
-        FROM address_log
-        WHERE address = ANY (@addresses::text [])
-            AND revocation_sequence_id IS NULL
-        GROUP BY address
-    ) b ON a.address = b.address
-    AND a.association_sequence_id = b.max_association_sequence_id;
+SELECT
+	a.address,
+	a.inbox_id,
+	a.association_sequence_id
+FROM
+	address_log a
+	INNER JOIN (
+		SELECT
+			address,
+			MAX(association_sequence_id) AS max_association_sequence_id
+		FROM
+			address_log
+		WHERE
+			address = ANY (@addresses::TEXT[])
+			AND revocation_sequence_id IS NULL
+		GROUP BY
+			address) b ON a.address = b.address
+	AND a.association_sequence_id = b.max_association_sequence_id;
 
 -- name: InsertAddressLog :one
-INSERT INTO address_log (
-        address,
-        inbox_id,
-        association_sequence_id,
-        revocation_sequence_id
-    )
-VALUES ($1, $2, $3, $4)
-RETURNING *;
+INSERT INTO address_log(address, inbox_id, association_sequence_id, revocation_sequence_id)
+	VALUES ($1, $2, $3, $4)
+RETURNING
+	*;
 
 -- name: InsertInboxLog :one
-INSERT INTO inbox_log (
-        inbox_id,
-        server_timestamp_ns,
-        identity_update_proto
-    )
-VALUES ($1, $2, $3)
-RETURNING sequence_id;
+INSERT INTO inbox_log(inbox_id, server_timestamp_ns, identity_update_proto)
+	VALUES ($1, $2, $3)
+RETURNING
+	sequence_id;
 
 -- name: RevokeAddressFromLog :exec
-UPDATE address_log
-SET revocation_sequence_id = $1
-WHERE (address, inbox_id, association_sequence_id) = (
-        SELECT address,
-            inbox_id,
-            MAX(association_sequence_id)
-        FROM address_log AS a
-        WHERE a.address = $2
-            AND a.inbox_id = $3
-        GROUP BY address,
-            inbox_id
-    );
+UPDATE
+	address_log
+SET
+	revocation_sequence_id = $1
+WHERE (address, inbox_id, association_sequence_id) =(
+	SELECT
+		address,
+		inbox_id,
+		MAX(association_sequence_id)
+	FROM
+		address_log AS a
+	WHERE
+		a.address = $2
+		AND a.inbox_id = $3
+	GROUP BY
+		address,
+		inbox_id);
 
 -- name: CreateInstallation :exec
-INSERT INTO installations (
-        id,
-        wallet_address,
-        created_at,
-        updated_at,
-        credential_identity,
-        key_package,
-        expiration
-    )
-VALUES ($1, $2, $3, $3, $4, $5, $6);
+INSERT INTO installations(id, wallet_address, created_at, updated_at, credential_identity, key_package, expiration)
+	VALUES ($1, $2, $3, $3, $4, $5, $6);
 
 -- name: UpdateKeyPackage :execrows
-UPDATE installations
-SET key_package = @key_package,
-    updated_at = @updated_at,
-    expiration = @expiration
-WHERE id = @id;
+UPDATE
+	installations
+SET
+	key_package = @key_package,
+	updated_at = @updated_at,
+	expiration = @expiration
+WHERE
+	id = @id;
 
 -- name: FetchKeyPackages :many
-SELECT id,
-    key_package
-FROM installations
-WHERE id = ANY (sqlc.arg(installation_ids)::bytea []);
+SELECT
+	id,
+	key_package
+FROM
+	installations
+WHERE
+	id = ANY (sqlc.arg(installation_ids)::BYTEA[]);
 
 -- name: GetIdentityUpdates :many
-SELECT *
-FROM installations
-WHERE wallet_address = ANY (@wallet_addresses::text [])
-    AND (
-        created_at > @start_time
-        OR revoked_at > @start_time
-    )
-ORDER BY created_at ASC;
+SELECT
+	*
+FROM
+	installations
+WHERE
+	wallet_address = ANY (@wallet_addresses::TEXT[])
+	AND (created_at > @start_time
+		OR revoked_at > @start_time)
+ORDER BY
+	created_at ASC;
 
 -- name: RevokeInstallation :exec
-UPDATE installations
-SET revoked_at = @revoked_at
-WHERE id = @installation_id
-    AND revoked_at IS NULL;
+UPDATE
+	installations
+SET
+	revoked_at = @revoked_at
+WHERE
+	id = @installation_id
+	AND revoked_at IS NULL;
 
 -- name: InsertGroupMessage :one
-INSERT INTO group_messages (group_id, data, group_id_data_hash)
-VALUES ($1, $2, $3)
-RETURNING *;
+INSERT INTO group_messages(group_id, data, group_id_data_hash)
+	VALUES ($1, $2, $3)
+RETURNING
+	*;
 
 -- name: InsertWelcomeMessage :one
-INSERT INTO welcome_messages (
-        installation_key,
-        data,
-        installation_key_data_hash,
-        hpke_public_key
-    )
-VALUES ($1, $2, $3, $4)
-RETURNING *;
+INSERT INTO welcome_messages(installation_key, data, installation_key_data_hash, hpke_public_key)
+	VALUES ($1, $2, $3, $4)
+RETURNING
+	*;
 
 -- name: QueryGroupMessagesAsc :many
-SELECT *
-FROM group_messages
-WHERE group_id = @group_id
-ORDER BY id ASC
+SELECT
+	*
+FROM
+	group_messages
+WHERE
+	group_id = @group_id
+ORDER BY
+	id ASC
 LIMIT @numrows;
 
 -- name: QueryGroupMessagesDesc :many
-SELECT *
-FROM group_messages
-WHERE group_id = @group_id
-ORDER BY id DESC
+SELECT
+	*
+FROM
+	group_messages
+WHERE
+	group_id = @group_id
+ORDER BY
+	id DESC
 LIMIT @numrows;
 
 -- name: QueryGroupMessagesWithCursorAsc :many
-SELECT *
-FROM group_messages
-WHERE group_id = $1
-    AND id > $2
-ORDER BY id ASC
+SELECT
+	*
+FROM
+	group_messages
+WHERE
+	group_id = $1
+	AND id > $2
+ORDER BY
+	id ASC
 LIMIT $3;
 
 -- name: QueryGroupMessagesWithCursorDesc :many
-SELECT *
-FROM group_messages
-WHERE group_id = $1
-    AND id < $2
-ORDER BY id DESC
+SELECT
+	*
+FROM
+	group_messages
+WHERE
+	group_id = $1
+	AND id < $2
+ORDER BY
+	id DESC
 LIMIT $3;
+

--- a/pkg/mls/store/queries/queries.sql.go
+++ b/pkg/mls/store/queries/queries.sql.go
@@ -14,16 +14,8 @@ import (
 )
 
 const createInstallation = `-- name: CreateInstallation :exec
-INSERT INTO installations (
-        id,
-        wallet_address,
-        created_at,
-        updated_at,
-        credential_identity,
-        key_package,
-        expiration
-    )
-VALUES ($1, $2, $3, $3, $4, $5, $6)
+INSERT INTO installations(id, wallet_address, created_at, updated_at, credential_identity, key_package, expiration)
+	VALUES ($1, $2, $3, $3, $4, $5, $6)
 `
 
 type CreateInstallationParams struct {
@@ -48,10 +40,13 @@ func (q *Queries) CreateInstallation(ctx context.Context, arg CreateInstallation
 }
 
 const fetchKeyPackages = `-- name: FetchKeyPackages :many
-SELECT id,
-    key_package
-FROM installations
-WHERE id = ANY ($1::bytea [])
+SELECT
+	id,
+	key_package
+FROM
+	installations
+WHERE
+	id = ANY ($1::BYTEA[])
 `
 
 type FetchKeyPackagesRow struct {
@@ -83,19 +78,24 @@ func (q *Queries) FetchKeyPackages(ctx context.Context, installationIds [][]byte
 }
 
 const getAddressLogs = `-- name: GetAddressLogs :many
-SELECT a.address,
-    a.inbox_id,
-    a.association_sequence_id
-FROM address_log a
-    INNER JOIN (
-        SELECT address,
-            MAX(association_sequence_id) AS max_association_sequence_id
-        FROM address_log
-        WHERE address = ANY ($1::text [])
-            AND revocation_sequence_id IS NULL
-        GROUP BY address
-    ) b ON a.address = b.address
-    AND a.association_sequence_id = b.max_association_sequence_id
+SELECT
+	a.address,
+	a.inbox_id,
+	a.association_sequence_id
+FROM
+	address_log a
+	INNER JOIN (
+		SELECT
+			address,
+			MAX(association_sequence_id) AS max_association_sequence_id
+		FROM
+			address_log
+		WHERE
+			address = ANY ($1::TEXT[])
+			AND revocation_sequence_id IS NULL
+		GROUP BY
+			address) b ON a.address = b.address
+	AND a.association_sequence_id = b.max_association_sequence_id
 `
 
 type GetAddressLogsRow struct {
@@ -128,11 +128,15 @@ func (q *Queries) GetAddressLogs(ctx context.Context, addresses []string) ([]Get
 }
 
 const getAllInboxLogs = `-- name: GetAllInboxLogs :many
-SELECT sequence_id, inbox_id, server_timestamp_ns, identity_update_proto
-FROM inbox_log
-WHERE inbox_id = $1
-ORDER BY sequence_id ASC FOR
-UPDATE
+SELECT
+	sequence_id, inbox_id, server_timestamp_ns, identity_update_proto
+FROM
+	inbox_log
+WHERE
+	inbox_id = $1
+ORDER BY
+	sequence_id ASC
+FOR UPDATE
 `
 
 func (q *Queries) GetAllInboxLogs(ctx context.Context, inboxID string) ([]InboxLog, error) {
@@ -164,14 +168,16 @@ func (q *Queries) GetAllInboxLogs(ctx context.Context, inboxID string) ([]InboxL
 }
 
 const getIdentityUpdates = `-- name: GetIdentityUpdates :many
-SELECT id, wallet_address, created_at, updated_at, credential_identity, revoked_at, key_package, expiration
-FROM installations
-WHERE wallet_address = ANY ($1::text [])
-    AND (
-        created_at > $2
-        OR revoked_at > $2
-    )
-ORDER BY created_at ASC
+SELECT
+	id, wallet_address, created_at, updated_at, credential_identity, revoked_at, key_package, expiration
+FROM
+	installations
+WHERE
+	wallet_address = ANY ($1::TEXT[])
+	AND (created_at > $2
+		OR revoked_at > $2)
+ORDER BY
+	created_at ASC
 `
 
 type GetIdentityUpdatesParams struct {
@@ -212,14 +218,19 @@ func (q *Queries) GetIdentityUpdates(ctx context.Context, arg GetIdentityUpdates
 }
 
 const getInboxLogFiltered = `-- name: GetInboxLogFiltered :many
-SELECT a.sequence_id, a.inbox_id, a.server_timestamp_ns, a.identity_update_proto
-FROM inbox_log AS a
-    JOIN (
-        SELECT inbox_id, sequence_id
-        FROM json_populate_recordset(null::inbox_filter, $1) as b(inbox_id, sequence_id)
-    ) as b on b.inbox_id = a.inbox_id
-    AND a.sequence_id > b.sequence_id
-ORDER BY a.sequence_id ASC
+SELECT
+	a.sequence_id, a.inbox_id, a.server_timestamp_ns, a.identity_update_proto
+FROM
+	inbox_log AS a
+	JOIN (
+		SELECT
+			inbox_id, sequence_id
+		FROM
+			json_populate_recordset(NULL::inbox_filter, $1) AS b(inbox_id,
+				sequence_id)) AS b ON b.inbox_id = a.inbox_id
+		AND a.sequence_id > b.sequence_id
+	ORDER BY
+		a.sequence_id ASC
 `
 
 func (q *Queries) GetInboxLogFiltered(ctx context.Context, filters json.RawMessage) ([]InboxLog, error) {
@@ -251,14 +262,10 @@ func (q *Queries) GetInboxLogFiltered(ctx context.Context, filters json.RawMessa
 }
 
 const insertAddressLog = `-- name: InsertAddressLog :one
-INSERT INTO address_log (
-        address,
-        inbox_id,
-        association_sequence_id,
-        revocation_sequence_id
-    )
-VALUES ($1, $2, $3, $4)
-RETURNING address, inbox_id, association_sequence_id, revocation_sequence_id
+INSERT INTO address_log(address, inbox_id, association_sequence_id, revocation_sequence_id)
+	VALUES ($1, $2, $3, $4)
+RETURNING
+	address, inbox_id, association_sequence_id, revocation_sequence_id
 `
 
 type InsertAddressLogParams struct {
@@ -286,9 +293,10 @@ func (q *Queries) InsertAddressLog(ctx context.Context, arg InsertAddressLogPara
 }
 
 const insertGroupMessage = `-- name: InsertGroupMessage :one
-INSERT INTO group_messages (group_id, data, group_id_data_hash)
-VALUES ($1, $2, $3)
-RETURNING id, created_at, group_id, data, group_id_data_hash
+INSERT INTO group_messages(group_id, data, group_id_data_hash)
+	VALUES ($1, $2, $3)
+RETURNING
+	id, created_at, group_id, data, group_id_data_hash
 `
 
 type InsertGroupMessageParams struct {
@@ -311,13 +319,10 @@ func (q *Queries) InsertGroupMessage(ctx context.Context, arg InsertGroupMessage
 }
 
 const insertInboxLog = `-- name: InsertInboxLog :one
-INSERT INTO inbox_log (
-        inbox_id,
-        server_timestamp_ns,
-        identity_update_proto
-    )
-VALUES ($1, $2, $3)
-RETURNING sequence_id
+INSERT INTO inbox_log(inbox_id, server_timestamp_ns, identity_update_proto)
+	VALUES ($1, $2, $3)
+RETURNING
+	sequence_id
 `
 
 type InsertInboxLogParams struct {
@@ -334,14 +339,10 @@ func (q *Queries) InsertInboxLog(ctx context.Context, arg InsertInboxLogParams) 
 }
 
 const insertWelcomeMessage = `-- name: InsertWelcomeMessage :one
-INSERT INTO welcome_messages (
-        installation_key,
-        data,
-        installation_key_data_hash,
-        hpke_public_key
-    )
-VALUES ($1, $2, $3, $4)
-RETURNING id, created_at, installation_key, data, installation_key_data_hash, hpke_public_key
+INSERT INTO welcome_messages(installation_key, data, installation_key_data_hash, hpke_public_key)
+	VALUES ($1, $2, $3, $4)
+RETURNING
+	id, created_at, installation_key, data, installation_key_data_hash, hpke_public_key
 `
 
 type InsertWelcomeMessageParams struct {
@@ -371,10 +372,14 @@ func (q *Queries) InsertWelcomeMessage(ctx context.Context, arg InsertWelcomeMes
 }
 
 const queryGroupMessagesAsc = `-- name: QueryGroupMessagesAsc :many
-SELECT id, created_at, group_id, data, group_id_data_hash
-FROM group_messages
-WHERE group_id = $1
-ORDER BY id ASC
+SELECT
+	id, created_at, group_id, data, group_id_data_hash
+FROM
+	group_messages
+WHERE
+	group_id = $1
+ORDER BY
+	id ASC
 LIMIT $2
 `
 
@@ -413,10 +418,14 @@ func (q *Queries) QueryGroupMessagesAsc(ctx context.Context, arg QueryGroupMessa
 }
 
 const queryGroupMessagesDesc = `-- name: QueryGroupMessagesDesc :many
-SELECT id, created_at, group_id, data, group_id_data_hash
-FROM group_messages
-WHERE group_id = $1
-ORDER BY id DESC
+SELECT
+	id, created_at, group_id, data, group_id_data_hash
+FROM
+	group_messages
+WHERE
+	group_id = $1
+ORDER BY
+	id DESC
 LIMIT $2
 `
 
@@ -455,11 +464,15 @@ func (q *Queries) QueryGroupMessagesDesc(ctx context.Context, arg QueryGroupMess
 }
 
 const queryGroupMessagesWithCursorAsc = `-- name: QueryGroupMessagesWithCursorAsc :many
-SELECT id, created_at, group_id, data, group_id_data_hash
-FROM group_messages
-WHERE group_id = $1
-    AND id > $2
-ORDER BY id ASC
+SELECT
+	id, created_at, group_id, data, group_id_data_hash
+FROM
+	group_messages
+WHERE
+	group_id = $1
+	AND id > $2
+ORDER BY
+	id ASC
 LIMIT $3
 `
 
@@ -499,11 +512,15 @@ func (q *Queries) QueryGroupMessagesWithCursorAsc(ctx context.Context, arg Query
 }
 
 const queryGroupMessagesWithCursorDesc = `-- name: QueryGroupMessagesWithCursorDesc :many
-SELECT id, created_at, group_id, data, group_id_data_hash
-FROM group_messages
-WHERE group_id = $1
-    AND id < $2
-ORDER BY id DESC
+SELECT
+	id, created_at, group_id, data, group_id_data_hash
+FROM
+	group_messages
+WHERE
+	group_id = $1
+	AND id < $2
+ORDER BY
+	id DESC
 LIMIT $3
 `
 
@@ -543,18 +560,23 @@ func (q *Queries) QueryGroupMessagesWithCursorDesc(ctx context.Context, arg Quer
 }
 
 const revokeAddressFromLog = `-- name: RevokeAddressFromLog :exec
-UPDATE address_log
-SET revocation_sequence_id = $1
-WHERE (address, inbox_id, association_sequence_id) = (
-        SELECT address,
-            inbox_id,
-            MAX(association_sequence_id)
-        FROM address_log AS a
-        WHERE a.address = $2
-            AND a.inbox_id = $3
-        GROUP BY address,
-            inbox_id
-    )
+UPDATE
+	address_log
+SET
+	revocation_sequence_id = $1
+WHERE (address, inbox_id, association_sequence_id) =(
+	SELECT
+		address,
+		inbox_id,
+		MAX(association_sequence_id)
+	FROM
+		address_log AS a
+	WHERE
+		a.address = $2
+		AND a.inbox_id = $3
+	GROUP BY
+		address,
+		inbox_id)
 `
 
 type RevokeAddressFromLogParams struct {
@@ -569,10 +591,13 @@ func (q *Queries) RevokeAddressFromLog(ctx context.Context, arg RevokeAddressFro
 }
 
 const revokeInstallation = `-- name: RevokeInstallation :exec
-UPDATE installations
-SET revoked_at = $1
-WHERE id = $2
-    AND revoked_at IS NULL
+UPDATE
+	installations
+SET
+	revoked_at = $1
+WHERE
+	id = $2
+	AND revoked_at IS NULL
 `
 
 type RevokeInstallationParams struct {
@@ -586,11 +611,14 @@ func (q *Queries) RevokeInstallation(ctx context.Context, arg RevokeInstallation
 }
 
 const updateKeyPackage = `-- name: UpdateKeyPackage :execrows
-UPDATE installations
-SET key_package = $1,
-    updated_at = $2,
-    expiration = $3
-WHERE id = $4
+UPDATE
+	installations
+SET
+	key_package = $1,
+	updated_at = $2,
+	expiration = $3
+WHERE
+	id = $4
 `
 
 type UpdateKeyPackageParams struct {


### PR DESCRIPTION
## tl;dr

With the new `queries.sql` we should align on a default formatter for all SQL to avoid weird merge conflicts.

This PR sets `pgFormatter` as the recommended extension. This will be recommended to all VSCode users. Non-VSCode users should manually format any changes to .sql files, although we aren't currently linting for this in CI.