### PR TITLE
Allow for more frequent keepalives

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/xmtp/xmtp-node-go/pkg/tracing"
 	"google.golang.org/grpc/health"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -141,6 +142,12 @@ func (s *Server) startGRPC() error {
 		grpc.Creds(insecure.NewCredentials()),
 		grpc.UnaryInterceptor(middleware.ChainUnaryServer(unary...)),
 		grpc.StreamInterceptor(middleware.ChainStreamServer(stream...)),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time: 5 * time.Minute,
+		}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime: 15 * time.Second,
+		}),
 		grpc.MaxRecvMsgSize(s.Config.Options.MaxMsgSize),
 	}
 	grpcServer := grpc.NewServer(options...)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -142,9 +142,6 @@ func (s *Server) startGRPC() error {
 		grpc.Creds(insecure.NewCredentials()),
 		grpc.UnaryInterceptor(middleware.ChainUnaryServer(unary...)),
 		grpc.StreamInterceptor(middleware.ChainStreamServer(stream...)),
-		grpc.KeepaliveParams(keepalive.ServerParameters{
-			Time: 5 * time.Minute,
-		}),
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime: 15 * time.Second,
 		}),


### PR DESCRIPTION
## tl;dr

- Adds an option related to KeepAlives to the node GRPC server. This allows clients to be more aggressive in sending keepalive messages.

## What does this mean?

`keepalive.EnforcementPolicy.MinTime`

```
// MinTime is the minimum amount of time a client should wait before sending
// a keepalive ping.
```