### PR TITLE
Set PermitWithoutStream to true

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -142,8 +142,12 @@ func (s *Server) startGRPC() error {
 		grpc.Creds(insecure.NewCredentials()),
 		grpc.UnaryInterceptor(middleware.ChainUnaryServer(unary...)),
 		grpc.StreamInterceptor(middleware.ChainStreamServer(stream...)),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time: 5 * time.Minute,
+		}),
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-			MinTime: 15 * time.Second,
+			PermitWithoutStream: true,
+			MinTime:             15 * time.Second,
 		}),
 		grpc.MaxRecvMsgSize(s.Config.Options.MaxMsgSize),
 	}


### PR DESCRIPTION
## tl;dr

- Our Rust GRPC clients have `keep_alive_while_idle` set to true, but our nodes have the `PermitWithoutStream` option defaulted to `false`. When these pings come in without an open stream, the server should be sending a GOAWAY message and disconnecting. I'm surprised it isn't causing more issues, but it's safe to enable the flag on the server so we might as well try and see if it improves mobile streaming.