### PR TITLE
Fix issue with loop iterator

### DIFF
--- a/pkg/mls/store/store.go
+++ b/pkg/mls/store/store.go
@@ -87,9 +87,10 @@ func (s *Store) GetInboxIds(ctx context.Context, req *identity.GetInboxIdsReques
 		resp := identity.GetInboxIdsResponse_Response{}
 		resp.Address = address
 
-		for _, log_entry := range addressLogEntries {
-			if log_entry.Address == address {
-				resp.InboxId = &log_entry.InboxID
+		for _, logEntry := range addressLogEntries {
+			if logEntry.Address == address {
+				inboxId := logEntry.InboxID
+				resp.InboxId = &inboxId
 			}
 		}
 		out[index] = &resp


### PR DESCRIPTION
## tl;dr

- Fixes a [loop iterator](https://mohamed-abdel-mohaimen.medium.com/using-loop-iterator-variable-issues-in-golang-b76c17fb71b6) issue. My absolute least-favourite design quirk of Go. We should also think about upgrading to [1.22](https://go.dev/blog/loopvar-preview), which finally lets you do away with this behaviour.

## What this fixes

Previously, when querying `GetInboxIds` all results would be set to the last inbox ID.