### PR TITLE
Register gzip compressor

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/xmtp/xmtp-node-go/pkg/ratelimiter"
 	"github.com/xmtp/xmtp-node-go/pkg/topic"
 	"github.com/xmtp/xmtp-node-go/pkg/tracing"
+	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/health"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"


### PR DESCRIPTION
## tl;dr

I've been profiling some of the slower calls inside libxmtp, and I would like to test if enabling compression will help.

All that's required is to import this package and it will register itself inside an `init` method. Then the caller can specify gzip encoding and everything should work.

This doesn't actually turn on gzip for requests, it just allows for us to set it from the client so we can test if it is actually a performance improvement or not.