### PR TITLE
Error when empty key packages are found

### DIFF
--- a/dev/docker/env
+++ b/dev/docker/env
@@ -2,5 +2,5 @@
 set -e
 
 function docker_compose() {
-  docker-compose -f dev/docker/docker-compose.yml -p xmtpd "$@"
+  docker compose -f dev/docker/docker-compose.yml -p xmtpd "$@"
 }

--- a/dev/e2e/docker/env
+++ b/dev/e2e/docker/env
@@ -2,5 +2,5 @@
 set -e
 
 function docker_compose() {
-  docker-compose -f dev/e2e/docker/docker-compose.yml -p xmtpd-e2e "$@"
+  docker compose -f dev/e2e/docker/docker-compose.yml -p xmtpd-e2e "$@"
 }

--- a/pkg/mls/api/v1/service.go
+++ b/pkg/mls/api/v1/service.go
@@ -147,6 +147,10 @@ func (s *Service) FetchKeyPackages(ctx context.Context, req *mlsv1.FetchKeyPacka
 		keyPackageMap[string(id)] = idx
 	}
 
+	if len(installations) != len(ids) {
+		return nil, status.Errorf(codes.NotFound, "requested %d key packages but only received %s", len(ids), len(installations))
+	}
+
 	resPackages := make([]*mlsv1.FetchKeyPackagesResponse_KeyPackage, len(ids))
 	for _, installation := range installations {
 

--- a/pkg/mls/api/v1/service.go
+++ b/pkg/mls/api/v1/service.go
@@ -148,7 +148,7 @@ func (s *Service) FetchKeyPackages(ctx context.Context, req *mlsv1.FetchKeyPacka
 	}
 
 	if len(installations) != len(ids) {
-		return nil, status.Errorf(codes.NotFound, "requested %d key packages but only received %s", len(ids), len(installations))
+		return nil, status.Errorf(codes.NotFound, "requested %d key packages but only received %d", len(ids), len(installations))
 	}
 
 	resPackages := make([]*mlsv1.FetchKeyPackagesResponse_KeyPackage, len(ids))

--- a/pkg/mls/api/v1/service_test.go
+++ b/pkg/mls/api/v1/service_test.go
@@ -243,8 +243,8 @@ func TestFetchKeyPackagesFail(t *testing.T) {
 	consumeRes, err := svc.FetchKeyPackages(ctx, &mlsv1.FetchKeyPackagesRequest{
 		InstallationKeys: [][]byte{test.RandomBytes(32)},
 	})
-	require.Nil(t, err)
-	require.Equal(t, []*mlsv1.FetchKeyPackagesResponse_KeyPackage{nil}, consumeRes.KeyPackages)
+	require.Error(t, err)
+	require.Nil(t, consumeRes)
 }
 
 func TestSendGroupMessages(t *testing.T) {


### PR DESCRIPTION
## tl;dr

This makes the API more strict when fetching key packages. The current behaviour is to leave an empty element when the key package is not found, which then becomes an empty key package when the client deserializes the message.

Now when you request a bunch of key packages and one is not found it will return an error.

This is actually going to make https://github.com/xmtp/libxmtp/issues/947 worse, since it'll hard fail without returning any results. I'd like to leave this on ice and merge it after we fix the root of the problem, which is that we should pair together registering an installation and the identity update so that it is impossible to submit an identity update creating an installation without registering a key package at the same time.

Maybe we don't even want to merge this ever and just handle the empty results better on the client.