### PR TITLE
Remove inbox validation for uploading key packages

### DIFF
--- a/dev/docker/env
+++ b/dev/docker/env
@@ -2,5 +2,5 @@
 set -e
 
 function docker_compose() {
-  docker-compose -f dev/docker/docker-compose.yml -p xmtpd "$@"
+  docker compose -f dev/docker/docker-compose.yml -p xmtpd "$@"
 }

--- a/dev/e2e/docker/env
+++ b/dev/e2e/docker/env
@@ -2,5 +2,5 @@
 set -e
 
 function docker_compose() {
-  docker-compose -f dev/e2e/docker/docker-compose.yml -p xmtpd-e2e "$@"
+  docker compose -f dev/e2e/docker/docker-compose.yml -p xmtpd-e2e "$@"
 }

--- a/dev/lint
+++ b/dev/lint
@@ -7,6 +7,6 @@ if [[ $(gofmt -l .) ]]; then
     echo "gofmt errors, run 'gofmt -w .' and commit"
 fi 
 
-golangci-lint --config dev/.golangci.yaml run ./... --deadline=5m
+golangci-lint --config dev/.golangci.yaml run ./...
 
 protolint .

--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -130,17 +130,17 @@ func (s *Service) Publish(ctx context.Context, req *proto.PublishRequest) (*prot
 		log.Debug("received message")
 
 		if len(env.ContentTopic) > MaxContentTopicNameSize {
-			return nil, status.Errorf(codes.InvalidArgument, "topic length too big")
+			return nil, status.Error(codes.InvalidArgument, "topic length too big")
 		}
 
 		if len(env.Message) > MaxMessageSize {
-			return nil, status.Errorf(codes.InvalidArgument, "message too big")
+			return nil, status.Error(codes.InvalidArgument, "message too big")
 		}
 
 		if !topic.IsEphemeral(env.ContentTopic) {
 			_, err := s.store.InsertMessage(env)
 			if err != nil {
-				return nil, status.Errorf(codes.Internal, err.Error())
+				return nil, status.Error(codes.Internal, err.Error())
 			}
 		}
 
@@ -150,7 +150,7 @@ func (s *Service) Publish(ctx context.Context, req *proto.PublishRequest) (*prot
 			Payload:      env.Message,
 		})
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, err.Error())
+			return nil, status.Error(codes.Internal, err.Error())
 		}
 
 		metrics.EmitPublishedEnvelope(ctx, log, env)
@@ -393,7 +393,7 @@ func (s *Service) BatchQuery(ctx context.Context, req *proto.BatchQueryRequest) 
 		// We execute the query using the existing Query API
 		resp, err := s.Query(ctx, query)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, err.Error())
+			return nil, status.Error(codes.Internal, err.Error())
 		}
 		responses = append(responses, resp)
 	}

--- a/pkg/migrations/mls/20240814032323_remove-inbox-id-from-installation.down.sql
+++ b/pkg/migrations/mls/20240814032323_remove-inbox-id-from-installation.down.sql
@@ -1,0 +1,7 @@
+SET statement_timeout = 0;
+
+--bun:split
+ALTER TABLE installations
+	ADD COLUMN inbox_id BYTEA NOT NULL,
+	ADD COLUMN expiration BIGINT NOT NULL;
+

--- a/pkg/migrations/mls/20240814032323_remove-inbox-id-from-installation.up.sql
+++ b/pkg/migrations/mls/20240814032323_remove-inbox-id-from-installation.up.sql
@@ -1,0 +1,7 @@
+SET statement_timeout = 0;
+
+--bun:split
+ALTER TABLE installations
+	DROP COLUMN IF EXISTS inbox_id,
+	DROP COLUMN IF EXISTS expiration;
+

--- a/pkg/mls/api/v1/service_test.go
+++ b/pkg/mls/api/v1/service_test.go
@@ -81,13 +81,13 @@ func TestRegisterInstallation(t *testing.T) {
 	defer cleanup()
 
 	installationId := test.RandomBytes(32)
-	inboxId := test.RandomInboxId()
+	keyPackage := []byte("test")
 
-	mockValidateInboxIdKeyPackages(mlsValidationService, installationId, inboxId)
+	mockValidateInboxIdKeyPackages(mlsValidationService, installationId, test.RandomInboxId())
 
 	res, err := svc.RegisterInstallation(ctx, &mlsv1.RegisterInstallationRequest{
 		KeyPackage: &mlsv1.KeyPackageUpload{
-			KeyPackageTlsSerialized: []byte("test"),
+			KeyPackageTlsSerialized: keyPackage,
 		},
 		IsInboxIdCredential: false,
 	})
@@ -98,7 +98,8 @@ func TestRegisterInstallation(t *testing.T) {
 	installation, err := queries.New(mlsDb.DB).GetInstallation(ctx, installationId)
 	require.NoError(t, err)
 
-	require.Equal(t, inboxId, installation.InboxID)
+	require.Equal(t, installationId, installation.ID)
+	require.Equal(t, []byte("test"), installation.KeyPackage)
 }
 
 func TestRegisterInstallationError(t *testing.T) {

--- a/pkg/mls/store/queries.sql
+++ b/pkg/mls/store/queries.sql
@@ -83,32 +83,23 @@ WHERE (address, inbox_id, association_sequence_id) =(
 		address,
 		inbox_id);
 
--- name: CreateInstallation :exec
-INSERT INTO installations(id, created_at, updated_at, inbox_id, key_package, expiration)
-	VALUES (@id, @created_at, @updated_at, decode(@inbox_id, 'hex'), @key_package, @expiration);
+-- name: CreateOrUpdateInstallation :exec
+INSERT INTO installations(id, created_at, updated_at, key_package)
+	VALUES (@id, @created_at, @updated_at, @key_package)
+ON CONFLICT (id)
+	DO UPDATE SET
+		key_package = @key_package, updated_at = @updated_at;
 
 -- name: GetInstallation :one
 SELECT
 	id,
 	created_at,
 	updated_at,
-	encode(inbox_id, 'hex') AS inbox_id,
-	key_package,
-	expiration
+	key_package
 FROM
 	installations
 WHERE
 	id = $1;
-
--- name: UpdateKeyPackage :execrows
-UPDATE
-	installations
-SET
-	key_package = @key_package,
-	updated_at = @updated_at,
-	expiration = @expiration
-WHERE
-	id = @id;
 
 -- name: FetchKeyPackages :many
 SELECT

--- a/pkg/mls/store/queries/models.go
+++ b/pkg/mls/store/queries/models.go
@@ -35,9 +35,7 @@ type Installation struct {
 	ID         []byte
 	CreatedAt  int64
 	UpdatedAt  int64
-	InboxID    []byte
 	KeyPackage []byte
-	Expiration int64
 }
 
 type WelcomeMessage struct {

--- a/pkg/mlsvalidate/service_test.go
+++ b/pkg/mlsvalidate/service_test.go
@@ -76,6 +76,37 @@ func TestValidateKeyPackages(t *testing.T) {
 	assert.Equal(t, []byte("456"), res[0].CredentialIdentity)
 }
 
-func TestValidateKeyPackagesError(t *testing.T) {
+func TestValidateInboxIdKeyPackages(t *testing.T) {
+	mockGrpc, service := getMockedService()
 
+	ctx := context.Background()
+	installationKey := []byte("key")
+	firstResponse := svc.ValidateInboxIdKeyPackagesResponse_Response{
+		IsOk:                  true,
+		Credential:            nil,
+		InstallationPublicKey: installationKey,
+		ErrorMessage:          "",
+	}
+	mockGrpc.On("ValidateInboxIdKeyPackages", ctx, mock.Anything).Return(&svc.ValidateInboxIdKeyPackagesResponse{Responses: []*svc.ValidateInboxIdKeyPackagesResponse_Response{&firstResponse}}, nil)
+
+	res, err := service.ValidateInboxIdKeyPackages(ctx, [][]byte{[]byte("123")})
+	assert.NoError(t, err)
+	assert.Equal(t, res[0].InstallationKey, installationKey)
+}
+
+func TestValidateInboxIdKeyPackagesError(t *testing.T) {
+	mockGrpc, service := getMockedService()
+
+	ctx := context.Background()
+	firstResponse := svc.ValidateInboxIdKeyPackagesResponse_Response{
+		IsOk:                  false,
+		Credential:            nil,
+		InstallationPublicKey: []byte("foo"),
+		ErrorMessage:          "DERP",
+	}
+	mockGrpc.On("ValidateInboxIdKeyPackages", ctx, mock.Anything).Return(&svc.ValidateInboxIdKeyPackagesResponse{Responses: []*svc.ValidateInboxIdKeyPackagesResponse_Response{&firstResponse}}, nil)
+
+	res, err := service.ValidateInboxIdKeyPackages(ctx, [][]byte{[]byte("123")})
+	assert.Error(t, err)
+	assert.Nil(t, res)
 }


### PR DESCRIPTION
## tl;dr
- Implements part of Phase 1 of https://github.com/xmtp/xmtp-node-go/issues/399
- Goal here is to loosen the validations on uploading key packages so that uploads can happen before `PublishIdentityUpdate` is called
- Begins the process of cleaning up these APIs and simplifying things

## AI Assisted Summary
This pull request includes several changes to the project, primarily focused on refactoring the installation registration process and updating the database schema. The key changes made are:
1. Removed `inbox_id` and `expiration` columns from the `installations` table.
2. Updated SQL queries to reflect the schema changes, including the removal of `UpdateKeyPackage` query and the addition of `CreateOrUpdateInstallation` query with upsert logic.
3. Deprecated the `RegisterInstallation` method in favor of `UploadKeyPackage`.
4. Updated test cases to align with the new schema and methods.
5. Simplified the `ValidateInboxIdKeyPackages` method by removing intermediate validation requests and leveraging direct validation responses.

These changes aim to streamline the installation registration process, reduce database schema complexity, and improve overall code maintainability.

---

