### PR TITLE
Allow libxmtp and app-specific headers to grpc-gateway

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -379,6 +379,8 @@ func preflightHandler(w http.ResponseWriter, r *http.Request) {
 		"Sec-CH-UA-Platform",
 		"Sentry-Trace",
 		"User-Agent",
+		"x-libxmtp-version",
+		"x-app-version",
 	}
 	w.Header().Set("Access-Control-Allow-Headers", strings.Join(headers, ","))
 	methods := []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"}


### PR DESCRIPTION
otherwise webassembly HTTP client errors with CORS