### PR TITLE
add option to marshal with protobuf

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -234,6 +234,7 @@ func (s *Server) startGRPC() error {
 func (s *Server) startHTTP() error {
 	mux := http.NewServeMux()
 	gwmux := runtime.NewServeMux(
+		runtime.WithMarshalerOption("application/x-protobuf", &runtime.ProtoMarshaller{}),
 		runtime.WithErrorHandler(runtime.DefaultHTTPErrorHandler),
 		runtime.WithStreamErrorHandler(runtime.DefaultStreamErrorHandler),
 		runtime.WithIncomingHeaderMatcher(incomingHeaderMatcher),


### PR DESCRIPTION
Saves us some dependencies + request/response size for http on the rust side, since we must use `prost` anyway, this lets us disable the `json` feature in reqwest and serialize/deserialize network responses directly with protobuf using `Content-Type: application/x-protobuf` and `Accept: application/x-protobuf` http headers