### PR TITLE
Add tracing to send welcome messages

### DIFF
--- a/pkg/api/telemetry.go
+++ b/pkg/api/telemetry.go
@@ -7,6 +7,7 @@ import (
 
 	apicontext "github.com/xmtp/xmtp-node-go/pkg/api/message/v1/context"
 	"github.com/xmtp/xmtp-node-go/pkg/metrics"
+	"github.com/xmtp/xmtp-node-go/pkg/utils"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
@@ -63,7 +64,7 @@ func (ti *TelemetryInterceptor) record(ctx context.Context, fullMethod string, d
 		ri.ZapFields()...,
 	)
 
-	if ip := clientIPFromContext(ctx); len(ip) > 0 {
+	if ip := utils.ClientIPFromContext(ctx); len(ip) > 0 {
 		fields = append(fields, zap.String("client_ip", ip))
 	}
 

--- a/pkg/utils/ip.go
+++ b/pkg/utils/ip.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+func ClientIPFromContext(ctx context.Context) string {
+	md, _ := metadata.FromIncomingContext(ctx)
+	vals := md.Get("x-forwarded-for")
+	if len(vals) == 0 {
+		p, ok := peer.FromContext(ctx)
+		if ok {
+			ipAndPort := strings.Split(p.Addr.String(), ":")
+			return ipAndPort[0]
+		} else {
+			return ""
+		}
+	}
+	// There are potentially multiple comma separated IPs bundled in that first value
+	ips := strings.Split(vals[0], ",")
+	return strings.TrimSpace(ips[0])
+}


### PR DESCRIPTION
### TL;DR
Added tracing to MLS welcome messages and moved IP address utility function to a dedicated package.

### What changed?
- Moved `clientIPFromContext` to a new `utils` package for better code organization
- Added DataDog tracing spans around welcome message insertion and publishing
- Added client IP information to tracing spans for debugging purposes
- Updated imports across affected files to use the new utility location

### How to test?
1. Send welcome messages through the MLS API
2. Verify traces appear in DataDog with correct client IP information
3. Confirm welcome messages are still being properly inserted and published
4. Verify IP address detection still works as expected through the utility function

### Why make this change?
To improve observability of the MLS welcome message flow and make debugging easier by adding detailed tracing information. The IP utility function was moved to reduce code duplication and improve maintainability.