### PR TITLE
Close subscriptions on full channel

### DIFF
--- a/pkg/api/message/v1/subscription.go
+++ b/pkg/api/message/v1/subscription.go
@@ -83,8 +83,8 @@ func (d *subscriptionDispatcher) messageHandler(msg *nats.Msg) {
 				// consume the data fast enough. In that case, we don't want to block further since it migth
 				// slow down other users. Instead, we're going to close the channel and let the
 				// consumer re-establish the connection if needed.
-				// close(subscription.messagesCh)
-				// delete(d.subscriptions, subscription)
+				close(subscription.messagesCh)
+				delete(d.subscriptions, subscription)
 			}
 		}
 	}


### PR DESCRIPTION
## tl;dr

- When the subscription channel is full, we should close the subscription which will kill the client connection. Consumers of the stream need to be able to keep up or they will get cut off. This is particularly important for `StreamAllMessages` consumers. 

With this change anyone who falls more than 4096 messages behind the stream will have their connection closed.