### PR TITLE
More logging for subscribeAll

### DIFF
--- a/pkg/api/message/v1/service.go
+++ b/pkg/api/message/v1/service.go
@@ -16,6 +16,7 @@ import (
 	proto "github.com/xmtp/xmtp-node-go/pkg/proto/message_api/v1"
 	"github.com/xmtp/xmtp-node-go/pkg/store"
 	"github.com/xmtp/xmtp-node-go/pkg/topic"
+	"github.com/xmtp/xmtp-node-go/pkg/utils"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -312,9 +313,10 @@ func (s *Service) Subscribe2(stream proto.MessageApi_Subscribe2Server) error {
 }
 
 func (s *Service) SubscribeAll(req *proto.SubscribeAllRequest, stream proto.MessageApi_SubscribeAllServer) error {
-	log := s.log.Named("subscribeAll")
+	ip := utils.ClientIPFromContext(stream.Context())
+	log := s.log.Named("subscribeAll").With(zap.String("client_ip", ip))
 	log.Info("started")
-	defer log.Debug("stopped")
+	defer log.Info("stopped")
 
 	// Subscribe to all nats subjects via wildcard
 	// https://docs.nats.io/nats-concepts/subjects#wildcards


### PR DESCRIPTION
### Add client IP address logging to `MessageApi.SubscribeAll` method to improve observability
Modifies the `SubscribeAll` method in [service.go](https://github.com/xmtp/xmtp-node-go/pull/424/files#diff-fca044a67739348a40a89b54d2ffe6b049c3a4cfe6909fc08fb7b2e216071838) to include client IP address in log messages and elevates the "stopped" log message from `Debug` to `Info` level. The client IP is extracted from the stream context using `utils.ClientIPFromContext`.

#### 📍Where to Start
Start with the `SubscribeAll` method in [service.go](https://github.com/xmtp/xmtp-node-go/pull/424/files#diff-fca044a67739348a40a89b54d2ffe6b049c3a4cfe6909fc08fb7b2e216071838) which contains the logging modifications.

----

_[Macroscope](https://app.macroscope.com) summarized c1c387e._