### PR TITLE
Concurrent welcome writes

### DIFF
--- a/pkg/mls/api/v1/service.go
+++ b/pkg/mls/api/v1/service.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"database/sql"
 	"encoding/hex"
 	"fmt"
 	"sync"
@@ -12,13 +13,14 @@ import (
 	"github.com/xmtp/xmtp-node-go/pkg/envelopes"
 	"github.com/xmtp/xmtp-node-go/pkg/metrics"
 	mlsstore "github.com/xmtp/xmtp-node-go/pkg/mls/store"
+	"github.com/xmtp/xmtp-node-go/pkg/mls/store/queries"
 	"github.com/xmtp/xmtp-node-go/pkg/mlsvalidate"
 	v1proto "github.com/xmtp/xmtp-node-go/pkg/proto/message_api/v1"
 	mlsv1 "github.com/xmtp/xmtp-node-go/pkg/proto/mls/api/v1"
 	"github.com/xmtp/xmtp-node-go/pkg/topic"
 	"github.com/xmtp/xmtp-node-go/pkg/tracing"
-	"github.com/xmtp/xmtp-node-go/pkg/utils"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -282,27 +284,44 @@ func (s *Service) SendWelcomeMessages(ctx context.Context, req *mlsv1.SendWelcom
 		return nil, err
 	}
 
-	// TODO: Remove after debugging is done
-	ip := utils.ClientIPFromContext(ctx)
-
 	err = tracing.Wrap(ctx, log, "send-welcome-messages", func(ctx context.Context, log *zap.Logger, span tracing.Span) error {
-		tracing.SpanTag(span, "client_ip", ip)
 		tracing.SpanTag(span, "message_count", len(req.Messages))
+		savedMessages := make([]*queries.WelcomeMessage, len(req.Messages))
 
-		// TODO: Wrap this in a transaction so publishing is all or nothing
-		for _, input := range req.Messages {
-			insertSpan, insertCtx := tracer.StartSpanFromContext(ctx, "insert-welcome-message")
-			insertLogger := tracing.Link(insertSpan, log)
-			insertLogger.Info("inserting welcome message", zap.String("client_ip", ip), zap.Int("message_length", len(input.GetV1().Data)))
-			msg, err := s.store.InsertWelcomeMessage(insertCtx, input.GetV1().InstallationKey, input.GetV1().Data, input.GetV1().HpkePublicKey)
-			insertSpan.Finish(tracing.WithError(err))
-			if err != nil {
-				if mlsstore.IsAlreadyExistsError(err) {
-					continue
-				}
-				return status.Errorf(codes.Internal, "failed to insert message: %s", err)
+		txErr := s.store.RunInTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead}, func(ctx context.Context, txQueries *queries.Queries) error {
+			g, ctx := errgroup.WithContext(ctx)
+			for idx, input := range req.Messages {
+				idx := idx
+				input := input
+				g.Go(func() error {
+					insertSpan, insertCtx := tracer.StartSpanFromContext(ctx, "insert-welcome-message")
+					msg, err := s.store.InsertWelcomeMessage(insertCtx, input.GetV1().InstallationKey, input.GetV1().Data, input.GetV1().HpkePublicKey)
+					insertSpan.Finish(tracing.WithError(err))
+					if err != nil {
+						if mlsstore.IsAlreadyExistsError(err) {
+							return nil
+						}
+
+						return status.Errorf(codes.Internal, "failed to insert message: %s", err)
+					}
+					savedMessages[idx] = msg
+					return nil
+				})
 			}
+			return g.Wait()
+		})
 
+		if txErr != nil {
+			return txErr
+		}
+
+		// Publish any new messages to Waku
+		for idx, input := range req.Messages {
+			msg := savedMessages[idx]
+			if msg == nil {
+				// If the message is nil, it was already inserted or there was an error
+				continue
+			}
 			msgB, err := pb.Marshal(&mlsv1.WelcomeMessage{
 				Version: &mlsv1.WelcomeMessage_V1_{
 					V1: &mlsv1.WelcomeMessage_V1{

--- a/pkg/mls/store/store.go
+++ b/pkg/mls/store/store.go
@@ -45,6 +45,7 @@ type MlsStore interface {
 	InsertWelcomeMessage(ctx context.Context, installationId []byte, data []byte, hpkePublicKey []byte) (*queries.WelcomeMessage, error)
 	QueryGroupMessagesV1(ctx context.Context, query *mlsv1.QueryGroupMessagesRequest) (*mlsv1.QueryGroupMessagesResponse, error)
 	QueryWelcomeMessagesV1(ctx context.Context, query *mlsv1.QueryWelcomeMessagesRequest) (*mlsv1.QueryWelcomeMessagesResponse, error)
+	RunInTx(ctx context.Context, opts *sql.TxOptions, fn func(ctx context.Context, txQueries *queries.Queries) error) error
 }
 
 func New(ctx context.Context, config Config) (*Store, error) {


### PR DESCRIPTION
### Implement concurrent welcome message processing with transaction support in MLS API service's `SendWelcomeMessages` function
* Refactors `SendWelcomeMessages` in [service.go](https://github.com/xmtp/xmtp-node-go/pull/425/files#diff-6d11ce32bdc179716d251a2646ec61f8b921f7d7eecd5e50d98b9ce1592287b4) to use database transactions with `RepeatableRead` isolation level and concurrent message processing via `errgroup`
* Adds new `RunInTx` method to MLS store interface in [store.go](https://github.com/xmtp/xmtp-node-go/pull/425/files#diff-8ae91da76478f07e4469f3b427e850132f6e8cc6b048929f83c6ba9b4ddbadfd) for transaction management
* Introduces concurrent and duplicate message handling tests in [service_test.go](https://github.com/xmtp/xmtp-node-go/pull/425/files#diff-dc510d5145d0d7390ab03c69164a8ddf95c336de60b7d4973e17eacaef2f578f)
* Removes client IP tracking and debug logging from welcome message processing

#### 📍Where to Start
Start with the modified `SendWelcomeMessages` function in [service.go](https://github.com/xmtp/xmtp-node-go/pull/425/files#diff-6d11ce32bdc179716d251a2646ec61f8b921f7d7eecd5e50d98b9ce1592287b4), which contains the core changes for transaction handling and concurrent processing.

----

_[Macroscope](https://app.macroscope.com) summarized 0175994._