### PR TITLE
Logging improvements

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 
+	grpcPrometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/pires/go-proxyproto"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -32,6 +33,7 @@ func NewMetricsServer(ctx context.Context, address string, port int, log *zap.Lo
 		return nil, err
 	}
 	registerCollectors(reg)
+	reg.MustRegister(grpcPrometheus.DefaultServerMetrics)
 	srv := http.Server{
 		Addr:    addr,
 		Handler: promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}),

--- a/pkg/mls/api/v1/service.go
+++ b/pkg/mls/api/v1/service.go
@@ -83,7 +83,7 @@ func (s *Service) HandleIncomingWakuRelayMessage(wakuMsg *wakupb.WakuMessage) er
 
 		// Build the nats subject from the topic
 		natsSubject := envelopes.BuildNatsSubject(wakuMsg.ContentTopic)
-		s.log.Info("publishing to nats subject from relay", zap.String("subject", natsSubject))
+		s.log.Debug("publishing to nats subject from relay", zap.String("subject", natsSubject))
 		env := envelopes.BuildEnvelope(wakuMsg)
 		envB, err := pb.Marshal(env)
 		if err != nil {
@@ -96,10 +96,10 @@ func (s *Service) HandleIncomingWakuRelayMessage(wakuMsg *wakupb.WakuMessage) er
 			return err
 		}
 	} else if topic.IsMLSV1Welcome(wakuMsg.ContentTopic) {
-		s.log.Info("received welcome message from waku relay", zap.String("topic", wakuMsg.ContentTopic))
+		s.log.Debug("received welcome message from waku relay", zap.String("topic", wakuMsg.ContentTopic))
 
 		natsSubject := envelopes.BuildNatsSubject(wakuMsg.ContentTopic)
-		s.log.Info("publishing to nats subject from relay", zap.String("subject", natsSubject))
+		s.log.Debug("publishing to nats subject from relay", zap.String("subject", natsSubject))
 		env := envelopes.BuildEnvelope(wakuMsg)
 		envB, err := pb.Marshal(env)
 		if err != nil {


### PR DESCRIPTION
## tl;dr

- Updates logging on the server and adds some more metrics collection

### Enable gRPC Prometheus metrics collection and reduce relay message logging verbosity in MLS service
* Integrates gRPC Prometheus metrics by registering `DefaultServerMetrics` with the Prometheus registry in [metrics.go](https://github.com/xmtp/xmtp-node-go/pull/428/files#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23)
* Reduces log verbosity in [service.go](https://github.com/xmtp/xmtp-node-go/pull/428/files#diff-6d11ce32bdc179716d251a2646ec61f8b921f7d7eecd5e50d98b9ce1592287b4) by changing three relay message handling log statements from `Info` to `Debug` level in the `HandleIncomingWakuRelayMessage` method

#### 📍Where to Start
Start with the metrics registration changes in [metrics.go](https://github.com/xmtp/xmtp-node-go/pull/428/files#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23), then review the logging level changes in the `HandleIncomingWakuRelayMessage` method in [service.go](https://github.com/xmtp/xmtp-node-go/pull/428/files#diff-6d11ce32bdc179716d251a2646ec61f8b921f7d7eecd5e50d98b9ce1592287b4).

----

_[Macroscope](https://app.macroscope.com) summarized 6da9952._