### PR TITLE
Insert Welcome messages concurrently without a transaction

### DIFF
--- a/pkg/mls/api/v1/service.go
+++ b/pkg/mls/api/v1/service.go
@@ -18,8 +18,8 @@ import (
 	"github.com/xmtp/xmtp-node-go/pkg/topic"
 	"github.com/xmtp/xmtp-node-go/pkg/tracing"
 	"github.com/xmtp/xmtp-node-go/pkg/types"
-	"github.com/xmtp/xmtp-node-go/pkg/utils"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -283,59 +283,59 @@ func (s *Service) SendWelcomeMessages(ctx context.Context, req *mlsv1.SendWelcom
 		return nil, err
 	}
 
-	// TODO: Remove after debugging is done
-	ip := utils.ClientIPFromContext(ctx)
-
 	err = tracing.Wrap(ctx, log, "send-welcome-messages", func(ctx context.Context, log *zap.Logger, span tracing.Span) error {
-		tracing.SpanTag(span, "client_ip", ip)
 		tracing.SpanTag(span, "message_count", len(req.Messages))
 
-		// TODO: Wrap this in a transaction so publishing is all or nothing
+		g, ctx := errgroup.WithContext(ctx)
+
 		for _, input := range req.Messages {
-			insertSpan, insertCtx := tracer.StartSpanFromContext(ctx, "insert-welcome-message")
-			insertLogger := tracing.Link(insertSpan, log)
-			insertLogger.Info("inserting welcome message", zap.String("client_ip", ip), zap.Int("message_length", len(input.GetV1().Data)))
-			msg, err := s.store.InsertWelcomeMessage(insertCtx, input.GetV1().InstallationKey, input.GetV1().Data, input.GetV1().HpkePublicKey, types.WrapperAlgorithmFromProto(input.GetV1().WrapperAlgorithm))
-			insertSpan.Finish(tracing.WithError(err))
-			if err != nil {
-				if mlsstore.IsAlreadyExistsError(err) {
-					continue
+			input := input
+			g.Go(func() error {
+				insertSpan, insertCtx := tracer.StartSpanFromContext(ctx, "insert-welcome-message")
+				msg, err := s.store.InsertWelcomeMessage(insertCtx, input.GetV1().InstallationKey, input.GetV1().Data, input.GetV1().HpkePublicKey, types.WrapperAlgorithmFromProto(input.GetV1().WrapperAlgorithm))
+				insertSpan.Finish(tracing.WithError(err))
+				if err != nil {
+					if mlsstore.IsAlreadyExistsError(err) {
+						return nil
+					}
+					return status.Errorf(codes.Internal, "failed to insert message: %s", err)
 				}
-				return status.Errorf(codes.Internal, "failed to insert message: %s", err)
-			}
 
-			msgB, err := pb.Marshal(&mlsv1.WelcomeMessage{
-				Version: &mlsv1.WelcomeMessage_V1_{
-					V1: &mlsv1.WelcomeMessage_V1{
-						Id:               uint64(msg.ID),
-						CreatedNs:        uint64(msg.CreatedAt.UnixNano()),
-						InstallationKey:  msg.InstallationKey,
-						Data:             msg.Data,
-						HpkePublicKey:    msg.HpkePublicKey,
-						WrapperAlgorithm: input.GetV1().WrapperAlgorithm,
+				msgB, err := pb.Marshal(&mlsv1.WelcomeMessage{
+					Version: &mlsv1.WelcomeMessage_V1_{
+						V1: &mlsv1.WelcomeMessage_V1{
+							Id:               uint64(msg.ID),
+							CreatedNs:        uint64(msg.CreatedAt.UnixNano()),
+							InstallationKey:  msg.InstallationKey,
+							Data:             msg.Data,
+							HpkePublicKey:    msg.HpkePublicKey,
+							WrapperAlgorithm: input.GetV1().WrapperAlgorithm,
+						},
 					},
-				},
+				})
+				if err != nil {
+					return err
+				}
+
+				publishSpan, publishCtx := tracer.StartSpanFromContext(ctx, "publish-welcome-to-relay")
+				err = s.publishToWakuRelay(publishCtx, &wakupb.WakuMessage{
+					ContentTopic: topic.BuildMLSV1WelcomeTopic(input.GetV1().InstallationKey),
+					Timestamp:    msg.CreatedAt.UnixNano(),
+					Payload:      msgB,
+				})
+				publishSpan.Finish(tracing.WithError(err))
+
+				if err != nil {
+					return err
+				}
+
+				metrics.EmitMLSSentWelcomeMessage(ctx, log, msg)
+
+				return nil
 			})
-			if err != nil {
-				return err
-			}
-
-			publishSpan, publishCtx := tracer.StartSpanFromContext(ctx, "publish-welcome-to-relay")
-			err = s.publishToWakuRelay(publishCtx, &wakupb.WakuMessage{
-				ContentTopic: topic.BuildMLSV1WelcomeTopic(input.GetV1().InstallationKey),
-				Timestamp:    msg.CreatedAt.UnixNano(),
-				Payload:      msgB,
-			})
-			publishSpan.Finish(tracing.WithError(err))
-
-			if err != nil {
-				return err
-			}
-
-			metrics.EmitMLSSentWelcomeMessage(ctx, log, msg)
 		}
 
-		return nil
+		return g.Wait()
 	})
 
 	if err != nil {


### PR DESCRIPTION
### Modify `SendWelcomeMessages` function in MLS API service to process welcome messages concurrently using errgroup instead of sequential processing
The `SendWelcomeMessages` function in [service.go](https://github.com/xmtp/xmtp-node-go/pull/430/files#diff-6d11ce32bdc179716d251a2646ec61f8b921f7d7eecd5e50d98b9ce1592287b4) replaces sequential message processing with concurrent processing using `golang.org/x/sync/errgroup`. The function creates an error group with context and processes each welcome message in a separate goroutine, removing client IP tracking and modifying error handling to return nil for existing messages. A new test `TestSendWelcomeMessagesConcurrent` in [service_test.go](https://github.com/xmtp/xmtp-node-go/pull/430/files#diff-dc510d5145d0d7390ab03c69164a8ddf95c336de60b7d4973e17eacaef2f578f) verifies concurrent processing of multiple welcome messages with the same installation ID.

## Resolves
- https://github.com/xmtp/libxmtp/issues/2126

#### 📍Where to Start
Start with the `SendWelcomeMessages` function in [service.go](https://github.com/xmtp/xmtp-node-go/pull/430/files#diff-6d11ce32bdc179716d251a2646ec61f8b921f7d7eecd5e50d98b9ce1592287b4).

----

_[Macroscope](https://app.macroscope.com) summarized 3622fae._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Sending and publishing of welcome messages now occurs concurrently, improving processing speed.

- **Tests**
  - Added a new test to verify correct handling of concurrent welcome message delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->