### PR TITLE
Include libxmtp version tag on metrics

### DIFF
--- a/pkg/metrics/api.go
+++ b/pkg/metrics/api.go
@@ -15,10 +15,11 @@ import (
 
 var (
 	appClientVersionTagKeys = []string{
-		"client",
-		"client_version",
 		"app",
 		"app_version",
+		"client",
+		"client_version",
+		"libxmtp_version",
 	}
 	apiRequestTagKeys = append([]string{
 		"service",


### PR DESCRIPTION
I missed a spot in order to expose this on DataDog metrics, including it here!