### PR TITLE
Add gating interceptor, log whether clients are supported

### DIFF
--- a/pkg/api/gating.go
+++ b/pkg/api/gating.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+)
+
+type GatingInterceptor struct {
+	log *zap.Logger
+}
+
+func NewGatingInterceptor(log *zap.Logger) *GatingInterceptor {
+	return &GatingInterceptor{
+		log: log,
+	}
+}
+
+func (ti *GatingInterceptor) Unary() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		res, err := handler(ctx, req)
+		return res, err
+	}
+}
+
+func (ti *GatingInterceptor) Stream() grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		stream grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		err := handler(srv, stream)
+		return err
+	}
+}

--- a/pkg/api/gating.go
+++ b/pkg/api/gating.go
@@ -3,9 +3,14 @@ package api
 import (
 	"context"
 
+	apicontext "github.com/xmtp/xmtp-node-go/pkg/api/message/v1/context"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+const IS_GATING_ENABLED = false
 
 type GatingInterceptor struct {
 	log *zap.Logger
@@ -24,6 +29,10 @@ func (ti *GatingInterceptor) Unary() grpc.UnaryServerInterceptor {
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (interface{}, error) {
+		ri := apicontext.NewRequesterInfo(ctx)
+		if IS_GATING_ENABLED && !ri.IsSupportedClient {
+			return nil, status.Errorf(codes.Unimplemented, "unsupported libxmtp version "+ri.LibxmtpVersion)
+		}
 		res, err := handler(ctx, req)
 		return res, err
 	}
@@ -36,6 +45,10 @@ func (ti *GatingInterceptor) Stream() grpc.StreamServerInterceptor {
 		info *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,
 	) error {
+		ri := apicontext.NewRequesterInfo(stream.Context())
+		if IS_GATING_ENABLED && !ri.IsSupportedClient {
+			return status.Errorf(codes.Unimplemented, "unsupported libxmtp version "+ri.LibxmtpVersion)
+		}
 		err := handler(srv, stream)
 		return err
 	}

--- a/pkg/api/message/v1/context/context.go
+++ b/pkg/api/message/v1/context/context.go
@@ -77,9 +77,6 @@ func (ri *requesterInfo) isSupportedClient() bool {
 	if ri.LibxmtpVersion == "" || !semver.IsValid(ri.LibxmtpVersion) {
 		return true
 	}
-	if ri.LibxmtpVersion == "1.2.0-dev" {
-		return true
-	}
 	if semver.Compare(ri.LibxmtpVersion, "1.1.5") >= 0 {
 		return true
 	}

--- a/pkg/api/message/v1/context/context.go
+++ b/pkg/api/message/v1/context/context.go
@@ -2,9 +2,11 @@ package context
 
 import (
 	"context"
+	"os"
 	"strings"
 
 	"go.uber.org/zap"
+	"golang.org/x/mod/semver"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -21,6 +23,8 @@ type requesterInfo struct {
 	ClientName    string
 	ClientVersion string
 
+	IsSupportedClient bool
+
 	LibxmtpVersion string
 }
 
@@ -33,6 +37,7 @@ func NewRequesterInfo(ctx context.Context) *requesterInfo {
 	ri.AppName, _, ri.AppVersion = parseVersionHeaderValue(md.Get(AppVersionMetadataKey))
 	ri.ClientName, _, ri.ClientVersion = parseVersionHeaderValue(md.Get(ClientVersionMetadataKey))
 	_, _, ri.LibxmtpVersion = parseVersionHeaderValue(md.Get(LibxmtpVersionMetadataKey))
+	ri.IsSupportedClient = ri.isSupportedClient()
 	md.Append("X-User-Id", "real_user_id")
 	return ri
 }
@@ -43,6 +48,7 @@ func (ri *requesterInfo) ZapFields() []zap.Field {
 		zap.String("app_version", ri.AppVersion),
 		zap.String("client", ri.ClientName),
 		zap.String("client_version", ri.ClientVersion),
+		zap.Bool("is_supported_client", ri.IsSupportedClient),
 		zap.String("libxmtp_version", ri.LibxmtpVersion),
 	}
 }
@@ -60,4 +66,23 @@ func parseVersionHeaderValue(vals []string) (name string, version string, full s
 		}
 	}
 	return
+}
+
+func (ri *requesterInfo) isSupportedClient() bool {
+	// Only version-gate on production
+	if os.Getenv("ENV") != "production" {
+		return true
+	}
+	// Err on the side of caution for unknown versions
+	if ri.LibxmtpVersion == "" || !semver.IsValid(ri.LibxmtpVersion) {
+		return true
+	}
+	if ri.LibxmtpVersion == "1.2.0-dev" {
+		return true
+	}
+	if semver.Compare(ri.LibxmtpVersion, "1.1.5") >= 0 {
+		return true
+	}
+
+	return false
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -107,8 +107,9 @@ func (s *Server) startGRPC() error {
 	stream := []grpc.StreamServerInterceptor{prometheus.StreamServerInterceptor}
 
 	telemetryInterceptor := NewTelemetryInterceptor(s.Log)
-	unary = append(unary, telemetryInterceptor.Unary())
-	stream = append(stream, telemetryInterceptor.Stream())
+	gatingInterceptor := NewGatingInterceptor(s.Log)
+	unary = append(unary, telemetryInterceptor.Unary(), gatingInterceptor.Unary())
+	stream = append(stream, telemetryInterceptor.Stream(), gatingInterceptor.Stream())
 
 	// Initialize nats for API subscribers.
 	s.natsServer, err = server.NewServer(&server.Options{

--- a/pkg/metrics/api.go
+++ b/pkg/metrics/api.go
@@ -19,6 +19,7 @@ var (
 		"app_version",
 		"client",
 		"client_version",
+		"is_supported_client",
 		"libxmtp_version",
 	}
 	apiRequestTagKeys = append([]string{


### PR DESCRIPTION
1. Adds a gating interceptor that is disabled for now
2. Log whether clients are supported or not to help us validate whether it will gate what we expect

Once we are ready, we need only flip the IS_GATING_ENABLED flag to true.