### PR TITLE
Log bool as string

### DIFF
--- a/pkg/api/message/v1/context/context.go
+++ b/pkg/api/message/v1/context/context.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -48,7 +49,7 @@ func (ri *requesterInfo) ZapFields() []zap.Field {
 		zap.String("app_version", ri.AppVersion),
 		zap.String("client", ri.ClientName),
 		zap.String("client_version", ri.ClientVersion),
-		zap.Bool("is_supported_client", ri.IsSupportedClient),
+		zap.String("is_supported_client", fmt.Sprintf("%t", ri.IsSupportedClient)),
 		zap.String("libxmtp_version", ri.LibxmtpVersion),
 	}
 }


### PR DESCRIPTION
The bool is not formatting correctly in datadog, maybe prometheus only supports strings