### PR TITLE
Normalize libxmtp version for semver checks

### DIFF
--- a/pkg/api/message/v1/context/context.go
+++ b/pkg/api/message/v1/context/context.go
@@ -73,11 +73,15 @@ func (ri *requesterInfo) isSupportedClient() bool {
 	if os.Getenv("ENV") != "production" {
 		return true
 	}
+	normalizedVersion := ri.LibxmtpVersion
+	if normalizedVersion == "" || normalizedVersion[0] != 'v' {
+		normalizedVersion = "v" + normalizedVersion
+	}
 	// Err on the side of caution for unknown versions
-	if ri.LibxmtpVersion == "" || !semver.IsValid(ri.LibxmtpVersion) {
+	if !semver.IsValid(normalizedVersion) {
 		return true
 	}
-	if semver.Compare(ri.LibxmtpVersion, "1.1.5") >= 0 {
+	if semver.Compare(normalizedVersion, "v1.1.5") >= 0 {
 		return true
 	}
 


### PR DESCRIPTION
### Add version string normalization to `isSupportedClient()` in `requesterInfo` struct to ensure consistent semver validation
The `isSupportedClient()` function in [context.go](https://github.com/xmtp/xmtp-node-go/pull/435/files#diff-f0c63b62b4f3e86244dfa09d55d984d3a4d94b839d4392fbea2e6e5f1b4eb18b) now normalizes version strings by ensuring they have a 'v' prefix before performing semver validation. The function compares the normalized version against `v1.1.5` as the minimum supported version.

#### 📍Where to Start
Start with the `isSupportedClient()` method in the `requesterInfo` struct in [context.go](https://github.com/xmtp/xmtp-node-go/pull/435/files#diff-f0c63b62b4f3e86244dfa09d55d984d3a4d94b839d4392fbea2e6e5f1b4eb18b), which contains the version normalization and validation logic.

----

_[Macroscope](https://app.macroscope.com) summarized dcac267._