### PR TITLE
Enable version gating

### DIFF
--- a/pkg/api/gating.go
+++ b/pkg/api/gating.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const IS_GATING_ENABLED = false
+const IS_GATING_ENABLED = true
 
 type GatingInterceptor struct {
 	log *zap.Logger


### PR DESCRIPTION
This enables the changes from [this PR](https://github.com/xmtp/xmtp-node-go/pull/433).

The effect of this change can be predicted via the `is_supported_version` metric displayed in 'Client Version Breakdown' graph shown [here](https://app.datadoghq.com/dashboard/ezd-qhb-877/mls-api-metrics?fromUser=true&refresh_mode=paused&tpl_var_env%5B0%5D=production&tpl_var_method%5B0%5D=sendgroupmessages&tpl_var_method%5B1%5D=fetchkeypackages&tpl_var_method%5B2%5D=getidentityupdates&tpl_var_method%5B3%5D=getinboxids&tpl_var_method%5B4%5D=publishidentityupdate&tpl_var_method%5B5%5D=querygroupmessages&tpl_var_method%5B6%5D=querywelcomemessages&tpl_var_method%5B7%5D=sendwelcomemessages&from_ts=1746130380000&to_ts=1746130560000&live=false). Make sure to adjust the time range to after 1.15pm on May 1, Pacific Time.