### PR TITLE
Change allowlisted IPs

### DIFF
--- a/pkg/api/interceptor.go
+++ b/pkg/api/interceptor.go
@@ -242,10 +242,7 @@ func allowedToPublish(topic string, wallet types.WalletAddr) bool {
 }
 
 var allowListedIps = []string{
-	"162.220.232.99",
-	"172.226.164.50",
-	"162.220.234.15",
-	"162.213.133.202",
+	"12.76.45.218",
 }
 
 func isAllowListedIp(ip string) bool {


### PR DESCRIPTION
### Reduce allowlisted IPs from four to one in `pkg/api/interceptor.go`
The `allowListedIps` slice in [interceptor.go](https://github.com/xmtp/xmtp-node-go/pull/440/files#diff-67d229c52434ff3934aa5a96707a41539b637297d757fff76ff9912e00d9cdd3) has been modified to contain a single redacted IP address instead of the previous four entries.

#### 📍Where to Start
Start with the `allowListedIps` slice definition in [interceptor.go](https://github.com/xmtp/xmtp-node-go/pull/440/files#diff-67d229c52434ff3934aa5a96707a41539b637297d757fff76ff9912e00d9cdd3) which contains the IP address whitelist.

----

_[Macroscope](https://app.macroscope.com) summarized 15a8454._