### PR TITLE
Use read replica for subscriptions

### DIFF
--- a/.github/workflows/build-node-go.yml
+++ b/.github/workflows/build-node-go.yml
@@ -7,7 +7,7 @@ on:
       - dev
       - rel/**
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
   workflow_dispatch:
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -36,7 +36,8 @@ type Config struct {
 	Waku         *wakunode.WakuNode
 	Log          *zap.Logger
 	Store        *store.Store
-	MLSStore     mlsstore.MlsStore
+	MLSStore     mlsstore.ReadWriteMlsStore
+	ReadMLSStore mlsstore.ReadMlsStore
 	MLSValidator mlsvalidate.MLSValidationService
 	RateLimiter  ratelimiter.RateLimiter
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -152,7 +152,13 @@ func (s *Server) startGRPC() error {
 
 	// Enable the MLS and identity servers if a store is provided
 	if s.MLSStore != nil && s.MLSValidator != nil && s.EnableMls {
-		s.mlsv1, err = mlsv1.NewService(s.Log, s.MLSStore, subDispatcher, s.MLSValidator)
+		s.mlsv1, err = mlsv1.NewService(
+			s.Log,
+			s.MLSStore,
+			s.ReadMLSStore,
+			subDispatcher,
+			s.MLSValidator,
+		)
 		if err != nil {
 			return errors.Wrap(err, "creating mls service")
 		}

--- a/pkg/identity/api/v1/identity_service.go
+++ b/pkg/identity/api/v1/identity_service.go
@@ -13,7 +13,7 @@ type Service struct {
 	identityV1.UnimplementedIdentityApiServer
 
 	log               *zap.Logger
-	store             mlsstore.MlsStore
+	store             mlsstore.ReadWriteMlsStore
 	validationService mlsvalidate.MLSValidationService
 
 	ctx       context.Context
@@ -22,7 +22,7 @@ type Service struct {
 
 func NewService(
 	log *zap.Logger,
-	store mlsstore.MlsStore,
+	store mlsstore.ReadWriteMlsStore,
 	validationService mlsvalidate.MLSValidationService,
 ) (s *Service, err error) {
 	s = &Service{

--- a/pkg/identity/api/v1/identity_service_test.go
+++ b/pkg/identity/api/v1/identity_service_test.go
@@ -121,10 +121,7 @@ func newMockedValidationService() *mockedMLSValidationService {
 func newTestService(t *testing.T, ctx context.Context) (*Service, *bun.DB, func()) {
 	log := test.NewLog(t)
 	db, _, mlsDbCleanup := test.NewMLSDB(t)
-	store, err := mlsstore.New(ctx, mlsstore.Config{
-		Log: log,
-		DB:  db,
-	})
+	store, err := mlsstore.New(ctx, log, db)
 	require.NoError(t, err)
 	mlsValidationService := newMockedValidationService()
 

--- a/pkg/mls/api/v1/streaming_test.go
+++ b/pkg/mls/api/v1/streaming_test.go
@@ -1,0 +1,1078 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtp-node-go/pkg/mocks"
+	mlsv1 "github.com/xmtp/xmtp-node-go/pkg/proto/mls/api/v1"
+	messageContentsProto "github.com/xmtp/xmtp-node-go/pkg/proto/mls/message_contents"
+	test "github.com/xmtp/xmtp-node-go/pkg/testing"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// testConfig holds common test configuration
+type testConfig struct {
+	timeout           time.Duration
+	subscriptionDelay time.Duration
+	bufferSize        int
+}
+
+// defaultTestConfig returns default test configuration
+func defaultTestConfig() testConfig {
+	return testConfig{
+		timeout:           5 * time.Second,
+		subscriptionDelay: 100 * time.Millisecond,
+		bufferSize:        100,
+	}
+}
+
+// messageCollector handles collecting and tracking received messages
+type messageCollector struct {
+	messages chan *mlsv1.GroupMessage
+	count    int64
+}
+
+// newMessageCollector creates a new message collector
+func newMessageCollector(bufferSize int) *messageCollector {
+	return &messageCollector{
+		messages: make(chan *mlsv1.GroupMessage, bufferSize),
+		count:    0,
+	}
+}
+
+// collect adds a message to the collector
+func (mc *messageCollector) collect(msg *mlsv1.GroupMessage) {
+	mc.messages <- msg
+	atomic.AddInt64(&mc.count, 1)
+}
+
+// waitForCount waits for the collector to receive the expected number of messages
+func (mc *messageCollector) waitForCount(expected int, timeout time.Duration) error {
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			return fmt.Errorf(
+				"timeout waiting for messages: expected %d, got %d",
+				expected,
+				atomic.LoadInt64(&mc.count),
+			)
+		case <-ticker.C:
+			if atomic.LoadInt64(&mc.count) >= int64(expected) {
+				return nil
+			}
+		}
+	}
+}
+
+// getAllMessages returns all collected messages
+func (mc *messageCollector) getAllMessages() []*mlsv1.GroupMessage {
+	close(mc.messages)
+	var messages []*mlsv1.GroupMessage
+	for msg := range mc.messages {
+		messages = append(messages, msg)
+	}
+	return messages
+}
+
+// welcomeMessageCollector handles collecting welcome messages
+type welcomeMessageCollector struct {
+	messages chan *mlsv1.WelcomeMessage
+	count    int64
+}
+
+// newWelcomeMessageCollector creates a new welcome message collector
+func newWelcomeMessageCollector(bufferSize int) *welcomeMessageCollector {
+	return &welcomeMessageCollector{
+		messages: make(chan *mlsv1.WelcomeMessage, bufferSize),
+		count:    0,
+	}
+}
+
+// collect adds a welcome message to the collector
+func (wmc *welcomeMessageCollector) collect(msg *mlsv1.WelcomeMessage) {
+	wmc.messages <- msg
+	atomic.AddInt64(&wmc.count, 1)
+}
+
+// waitForCount waits for the collector to receive the expected number of messages
+func (wmc *welcomeMessageCollector) waitForCount(expected int, timeout time.Duration) error {
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			return fmt.Errorf(
+				"timeout waiting for welcome messages: expected %d, got %d",
+				expected,
+				atomic.LoadInt64(&wmc.count),
+			)
+		case <-ticker.C:
+			if atomic.LoadInt64(&wmc.count) >= int64(expected) {
+				return nil
+			}
+		}
+	}
+}
+
+// getAllMessages returns all collected welcome messages
+func (wmc *welcomeMessageCollector) getAllMessages() []*mlsv1.WelcomeMessage {
+	close(wmc.messages)
+	var messages []*mlsv1.WelcomeMessage
+	for msg := range wmc.messages {
+		messages = append(messages, msg)
+	}
+	return messages
+}
+
+// setupGroupMessageStream creates a mock stream for group message subscriptions
+func setupGroupMessageStream(
+	t *testing.T,
+	ctx context.Context,
+	collector *messageCollector,
+) *mocks.MockMlsApi_SubscribeGroupMessagesServer {
+	stream := mocks.NewMockMlsApi_SubscribeGroupMessagesServer(t)
+	stream.EXPECT().SendHeader(metadata.New(map[string]string{"subscribed": "true"})).Return(nil)
+	stream.EXPECT().
+		Send(mock.AnythingOfType("*apiv1.GroupMessage")).
+		Run(func(msg *mlsv1.GroupMessage) {
+			collector.collect(msg)
+		}).
+		Return(nil).
+		Maybe()
+	stream.EXPECT().Context().Return(ctx)
+	return stream
+}
+
+// setupWelcomeMessageStream creates a mock stream for welcome message subscriptions
+func setupWelcomeMessageStream(
+	t *testing.T,
+	ctx context.Context,
+	collector *welcomeMessageCollector,
+) *mocks.MockMlsApi_SubscribeWelcomeMessagesServer {
+	stream := mocks.NewMockMlsApi_SubscribeWelcomeMessagesServer(t)
+	stream.EXPECT().SendHeader(metadata.New(map[string]string{"subscribed": "true"})).Return(nil)
+	stream.EXPECT().
+		Send(mock.AnythingOfType("*apiv1.WelcomeMessage")).
+		Run(func(msg *mlsv1.WelcomeMessage) {
+			collector.collect(msg)
+		}).
+		Return(nil).
+		Maybe()
+	stream.EXPECT().Context().Return(ctx)
+	return stream
+}
+
+// startGroupMessageSubscription starts a group message subscription
+func startGroupMessageSubscription(
+	t *testing.T,
+	svc *Service,
+	filters []*mlsv1.SubscribeGroupMessagesRequest_Filter,
+	stream *mocks.MockMlsApi_SubscribeGroupMessagesServer,
+) {
+	go func() {
+		err := svc.SubscribeGroupMessages(&mlsv1.SubscribeGroupMessagesRequest{
+			Filters: filters,
+		}, stream)
+		if err != nil {
+			if status.Code(err) == codes.Unavailable || errors.Is(err, context.Canceled) {
+				// Ignore error as context cancellation or shutdown is expected
+				return
+			}
+			// Log unexpected errors using test framework
+			t.Errorf("unexpected error in group message subscription: %v", err)
+		}
+	}()
+}
+
+// startWelcomeMessageSubscription starts a welcome message subscription
+func startWelcomeMessageSubscription(
+	t *testing.T,
+	svc *Service,
+	filters []*mlsv1.SubscribeWelcomeMessagesRequest_Filter,
+	stream *mocks.MockMlsApi_SubscribeWelcomeMessagesServer,
+) {
+	go func() {
+		err := svc.SubscribeWelcomeMessages(&mlsv1.SubscribeWelcomeMessagesRequest{
+			Filters: filters,
+		}, stream)
+		if err != nil {
+			if status.Code(err) == codes.Unavailable || errors.Is(err, context.Canceled) {
+				// Ignore error as context cancellation or shutdown is expected
+				return
+			}
+			// Log unexpected errors using test framework
+			t.Errorf("unexpected error in welcome message subscription: %v", err)
+		}
+	}()
+}
+
+// sendGroupMessages sends multiple group messages concurrently
+func sendGroupMessages(
+	t *testing.T,
+	ctx context.Context,
+	svc *Service,
+	groupId []byte,
+	numGoroutines, messagesPerGoroutine int,
+	messagePrefix string,
+) {
+	var wg sync.WaitGroup
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(goroutineId int) {
+			defer wg.Done()
+			for j := 0; j < messagesPerGoroutine; j++ {
+				msgData := fmt.Sprintf("%s_%d_%d", messagePrefix, goroutineId, j)
+				_, err := svc.SendGroupMessages(ctx, &mlsv1.SendGroupMessagesRequest{
+					Messages: []*mlsv1.GroupMessageInput{
+						{
+							Version: &mlsv1.GroupMessageInput_V1_{
+								V1: &mlsv1.GroupMessageInput_V1{
+									Data:       []byte(msgData),
+									SenderHmac: []byte(fmt.Sprintf("hmac_%d_%d", goroutineId, j)),
+									ShouldPush: true,
+								},
+							},
+						},
+					},
+				})
+				require.NoError(t, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// sendWelcomeMessages sends multiple welcome messages concurrently
+func sendWelcomeMessages(
+	t *testing.T,
+	ctx context.Context,
+	svc *Service,
+	installationKey, hpkePublicKey []byte,
+	numGoroutines, messagesPerGoroutine int,
+	messagePrefix string,
+) {
+	var wg sync.WaitGroup
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(goroutineId int) {
+			defer wg.Done()
+			for j := 0; j < messagesPerGoroutine; j++ {
+				msgData := fmt.Sprintf("%s_%d_%d", messagePrefix, goroutineId, j)
+				_, err := svc.SendWelcomeMessages(ctx, &mlsv1.SendWelcomeMessagesRequest{
+					Messages: []*mlsv1.WelcomeMessageInput{
+						{
+							Version: &mlsv1.WelcomeMessageInput_V1_{
+								V1: &mlsv1.WelcomeMessageInput_V1{
+									InstallationKey:  installationKey,
+									Data:             []byte(msgData),
+									HpkePublicKey:    hpkePublicKey,
+									WrapperAlgorithm: messageContentsProto.WelcomeWrapperAlgorithm_WELCOME_WRAPPER_ALGORITHM_XWING_MLKEM_768_DRAFT_6,
+									WelcomeMetadata: []byte(
+										fmt.Sprintf("metadata_%d_%d", goroutineId, j),
+									),
+								},
+							},
+						},
+					},
+				})
+				require.NoError(t, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// populateGroupMessages sends initial messages to a group
+func populateGroupMessages(
+	t *testing.T,
+	ctx context.Context,
+	svc *Service,
+	groupId []byte,
+	count int,
+	prefix string,
+) {
+	for i := 0; i < count; i++ {
+		_, err := svc.SendGroupMessages(ctx, &mlsv1.SendGroupMessagesRequest{
+			Messages: []*mlsv1.GroupMessageInput{
+				{
+					Version: &mlsv1.GroupMessageInput_V1_{
+						V1: &mlsv1.GroupMessageInput_V1{
+							Data:       []byte(fmt.Sprintf("%s_%d", prefix, i)),
+							SenderHmac: []byte(fmt.Sprintf("hmac_%d", i)),
+							ShouldPush: true,
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+	}
+}
+
+// populateWelcomeMessages sends initial welcome messages
+func populateWelcomeMessages(
+	t *testing.T,
+	ctx context.Context,
+	svc *Service,
+	installationKey, hpkePublicKey []byte,
+	count int,
+	prefix string,
+) {
+	for i := 0; i < count; i++ {
+		_, err := svc.SendWelcomeMessages(ctx, &mlsv1.SendWelcomeMessagesRequest{
+			Messages: []*mlsv1.WelcomeMessageInput{
+				{
+					Version: &mlsv1.WelcomeMessageInput_V1_{
+						V1: &mlsv1.WelcomeMessageInput_V1{
+							InstallationKey:  installationKey,
+							Data:             []byte(fmt.Sprintf("%s_%d", prefix, i)),
+							HpkePublicKey:    hpkePublicKey,
+							WrapperAlgorithm: messageContentsProto.WelcomeWrapperAlgorithm_WELCOME_WRAPPER_ALGORITHM_XWING_MLKEM_768_DRAFT_6,
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+	}
+}
+
+// validateMessageOrdering validates that messages are in ascending order by ID
+func validateMessageOrdering(t *testing.T, messages []*mlsv1.GroupMessage) {
+	for i := 1; i < len(messages); i++ {
+		assert.Greater(t, messages[i].GetV1().Id, messages[i-1].GetV1().Id,
+			"Messages should be in ascending sequence_id order")
+	}
+}
+
+// validateWelcomeMessageOrdering validates that welcome messages are in ascending order by ID
+func validateWelcomeMessageOrdering(t *testing.T, messages []*mlsv1.WelcomeMessage) {
+	for i := 1; i < len(messages); i++ {
+		assert.Greater(t, messages[i].GetV1().Id, messages[i-1].GetV1().Id,
+			"Welcome messages should be in ascending sequence_id order")
+	}
+}
+
+// validateNoDuplicates validates that no duplicate message IDs exist
+func validateNoDuplicates(t *testing.T, messages []*mlsv1.GroupMessage) {
+	seenIds := make(map[uint64]bool)
+	for _, msg := range messages {
+		id := msg.GetV1().Id
+		assert.False(t, seenIds[id], "Should not receive duplicate messages")
+		seenIds[id] = true
+	}
+}
+
+// validateWelcomeMessageNoDuplicates validates that no duplicate welcome message IDs exist
+func validateWelcomeMessageNoDuplicates(t *testing.T, messages []*mlsv1.WelcomeMessage) {
+	seenIds := make(map[uint64]bool)
+	for _, msg := range messages {
+		id := msg.GetV1().Id
+		assert.False(t, seenIds[id], "Should not receive duplicate welcome messages")
+		seenIds[id] = true
+	}
+}
+
+// validateMessagesAfterCursor validates that all messages have IDs greater than the cursor
+func validateMessagesAfterCursor(
+	t *testing.T,
+	messages []*mlsv1.GroupMessage,
+	cursorPosition uint64,
+) {
+	for _, msg := range messages {
+		assert.Greater(t, msg.GetV1().Id, cursorPosition,
+			"All messages should have sequence_id greater than cursor")
+	}
+}
+
+// validateWelcomeMessagesAfterCursor validates that all welcome messages have IDs greater than the cursor
+func validateWelcomeMessagesAfterCursor(
+	t *testing.T,
+	messages []*mlsv1.WelcomeMessage,
+	cursorPosition uint64,
+) {
+	for _, msg := range messages {
+		assert.Greater(t, msg.GetV1().Id, cursorPosition,
+			"All welcome messages should have sequence_id greater than cursor")
+	}
+}
+
+// TestGroupMessageStreaming_OrderingWithConcurrentWrites tests that messages are received in correct sequence_id order
+// even when multiple goroutines are writing concurrently
+func TestGroupMessageStreaming_OrderingWithConcurrentWrites(t *testing.T) {
+	ctx := context.Background()
+	svc, _, validationSvc, cleanup := newTestService(t, ctx)
+	defer cleanup()
+
+	config := defaultTestConfig()
+	groupId := []byte(test.RandomString(32))
+	mockValidateGroupMessages(validationSvc, groupId)
+
+	collector := newMessageCollector(config.bufferSize)
+	stream := setupGroupMessageStream(t, ctx, collector)
+
+	// Start subscription
+	startGroupMessageSubscription(t, svc, []*mlsv1.SubscribeGroupMessagesRequest_Filter{
+		{GroupId: groupId},
+	}, stream)
+
+	time.Sleep(config.subscriptionDelay)
+
+	// Send messages concurrently
+	numGoroutines := 10
+	messagesPerGoroutine := 10
+	totalMessages := numGoroutines * messagesPerGoroutine
+
+	sendGroupMessages(t, ctx, svc, groupId, numGoroutines, messagesPerGoroutine, "msg")
+
+	// Wait for all messages
+	err := collector.waitForCount(totalMessages, config.timeout)
+	require.NoError(t, err, "Should receive all messages within timeout")
+
+	// Validate results
+	messages := collector.getAllMessages()
+	assert.GreaterOrEqual(t, len(messages), totalMessages, "Should receive all messages")
+	validateMessageOrdering(t, messages)
+	validateNoDuplicates(t, messages)
+}
+
+// TestGroupMessageStreaming_CursorConsistency tests that subscriptions with cursors receive all messages after the cursor
+func TestGroupMessageStreaming_CursorConsistency(t *testing.T) {
+	ctx := context.Background()
+	svc, _, validationSvc, cleanup := newTestService(t, ctx)
+	defer cleanup()
+
+	config := defaultTestConfig()
+	groupId := []byte(test.RandomString(32))
+	mockValidateGroupMessages(validationSvc, groupId)
+
+	// Pre-populate with messages
+	numInitialMessages := 20
+	populateGroupMessages(t, ctx, svc, groupId, numInitialMessages, "initial")
+
+	// Get the current messages to establish cursor position
+	resp, err := svc.QueryGroupMessages(ctx, &mlsv1.QueryGroupMessagesRequest{
+		GroupId: groupId,
+		PagingInfo: &mlsv1.PagingInfo{
+			Direction: mlsv1.SortDirection_SORT_DIRECTION_ASCENDING,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Messages, numInitialMessages)
+
+	// Use cursor at position 10 (should receive messages 12-20 plus new messages)
+	cursorPosition := resp.Messages[9].GetV1().Id // 10th message
+	expectedMessagesAfterCursor := numInitialMessages - 10
+
+	collector := newMessageCollector(config.bufferSize)
+	stream := setupGroupMessageStream(t, ctx, collector)
+
+	// Start subscription with cursor
+	startGroupMessageSubscription(t, svc, []*mlsv1.SubscribeGroupMessagesRequest_Filter{
+		{
+			GroupId:  groupId,
+			IdCursor: cursorPosition,
+		},
+	}, stream)
+
+	// Allow subscription to start and process historical messages
+	time.Sleep(200 * time.Millisecond)
+
+	// Send additional messages
+	numNewMessages := 5
+	populateGroupMessages(t, ctx, svc, groupId, numNewMessages, "new")
+
+	expectedTotalMessages := expectedMessagesAfterCursor + numNewMessages
+
+	// Wait for all expected messages
+	err = collector.waitForCount(expectedTotalMessages, config.timeout)
+	require.NoError(t, err, "Should receive all messages after cursor within timeout")
+
+	// Validate results
+	messages := collector.getAllMessages()
+	assert.GreaterOrEqual(
+		t,
+		len(messages),
+		expectedTotalMessages,
+		"Should receive all messages after cursor",
+	)
+	validateMessagesAfterCursor(t, messages, cursorPosition)
+	validateMessageOrdering(t, messages)
+}
+
+// TestGroupMessageStreaming_RaceConditionHandling tests various race conditions
+func TestGroupMessageStreaming_RaceConditionHandling(t *testing.T) {
+	ctx := context.Background()
+	svc, _, validationSvc, cleanup := newTestService(t, ctx)
+	defer cleanup()
+
+	groupId := []byte(test.RandomString(32))
+	mockValidateGroupMessages(validationSvc, groupId)
+
+	// Test scenario: Start subscription, send messages, then start another subscription
+	// Both should receive the same messages in order
+
+	var receivedMessages1 []*mlsv1.GroupMessage
+	var receivedMessages2 []*mlsv1.GroupMessage
+	var mu1, mu2 sync.Mutex
+
+	stream1 := mocks.NewMockMlsApi_SubscribeGroupMessagesServer(t)
+	stream1.EXPECT().SendHeader(metadata.New(map[string]string{"subscribed": "true"})).Return(nil)
+	stream1.EXPECT().
+		Send(mock.AnythingOfType("*apiv1.GroupMessage")).
+		Run(func(msg *mlsv1.GroupMessage) {
+			mu1.Lock()
+			receivedMessages1 = append(receivedMessages1, msg)
+			mu1.Unlock()
+		}).
+		Return(nil).
+		Maybe()
+	stream1.EXPECT().Context().Return(ctx)
+
+	stream2 := mocks.NewMockMlsApi_SubscribeGroupMessagesServer(t)
+	stream2.EXPECT().SendHeader(metadata.New(map[string]string{"subscribed": "true"})).Return(nil)
+	stream2.EXPECT().
+		Send(mock.AnythingOfType("*apiv1.GroupMessage")).
+		Run(func(msg *mlsv1.GroupMessage) {
+			mu2.Lock()
+			receivedMessages2 = append(receivedMessages2, msg)
+			mu2.Unlock()
+		}).
+		Return(nil).
+		Maybe()
+	stream2.EXPECT().Context().Return(ctx)
+
+	// Start first subscription
+	startGroupMessageSubscription(t, svc, []*mlsv1.SubscribeGroupMessagesRequest_Filter{
+		{GroupId: groupId},
+	}, stream1)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Send some messages
+	numMessages := 10
+	populateGroupMessages(t, ctx, svc, groupId, numMessages, "race_test")
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Start second subscription (should receive all messages from the beginning)
+	startGroupMessageSubscription(t, svc, []*mlsv1.SubscribeGroupMessagesRequest_Filter{
+		{GroupId: groupId},
+	}, stream2)
+
+	// Wait for messages to be processed
+	time.Sleep(2 * time.Second)
+
+	// Verify both subscriptions received messages in order
+	mu1.Lock()
+	msgs1 := make([]*mlsv1.GroupMessage, len(receivedMessages1))
+	copy(msgs1, receivedMessages1)
+	mu1.Unlock()
+
+	mu2.Lock()
+	msgs2 := make([]*mlsv1.GroupMessage, len(receivedMessages2))
+	copy(msgs2, receivedMessages2)
+	mu2.Unlock()
+
+	assert.GreaterOrEqual(
+		t,
+		len(msgs1),
+		numMessages,
+		"First subscription should receive all messages",
+	)
+	assert.GreaterOrEqual(
+		t,
+		len(msgs2),
+		numMessages,
+		"Second subscription should receive all messages",
+	)
+
+	// Verify ordering in both subscriptions
+	validateMessageOrdering(t, msgs1)
+	validateMessageOrdering(t, msgs2)
+}
+
+// TestWelcomeMessageStreaming_OrderingWithConcurrentWrites tests Welcome message ordering with concurrent writes
+func TestWelcomeMessageStreaming_OrderingWithConcurrentWrites(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _, cleanup := newTestService(t, ctx)
+	defer cleanup()
+
+	config := defaultTestConfig()
+	installationKey := []byte(test.RandomString(32))
+	hpkePublicKey := []byte(test.RandomString(32))
+
+	collector := newWelcomeMessageCollector(config.bufferSize)
+	stream := setupWelcomeMessageStream(t, ctx, collector)
+
+	// Start subscription
+	startWelcomeMessageSubscription(t, svc, []*mlsv1.SubscribeWelcomeMessagesRequest_Filter{
+		{InstallationKey: installationKey},
+	}, stream)
+
+	// Send welcome messages concurrently
+	numGoroutines := 5
+	messagesPerGoroutine := 8
+	totalMessages := numGoroutines * messagesPerGoroutine
+
+	sendWelcomeMessages(
+		t,
+		ctx,
+		svc,
+		installationKey,
+		hpkePublicKey,
+		numGoroutines,
+		messagesPerGoroutine,
+		"welcome",
+	)
+
+	// Wait for all messages
+	err := collector.waitForCount(totalMessages, config.timeout)
+	require.NoError(t, err, "Should receive all welcome messages within timeout")
+
+	// Validate results
+	messages := collector.getAllMessages()
+	assert.GreaterOrEqual(t, len(messages), totalMessages, "Should receive all welcome messages")
+	validateWelcomeMessageOrdering(t, messages)
+	validateWelcomeMessageNoDuplicates(t, messages)
+
+	for _, welcomeMessage := range messages {
+		require.NotZero(t, welcomeMessage.GetV1().WelcomeMetadata)
+		require.Equal(
+			t,
+			welcomeMessage.GetV1().WrapperAlgorithm,
+			messageContentsProto.WelcomeWrapperAlgorithm_WELCOME_WRAPPER_ALGORITHM_XWING_MLKEM_768_DRAFT_6,
+		)
+	}
+}
+
+// TestWelcomeMessageStreaming_CursorConsistency tests cursor behavior for welcome messages
+func TestWelcomeMessageStreaming_CursorConsistency(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _, cleanup := newTestService(t, ctx)
+	defer cleanup()
+
+	config := defaultTestConfig()
+	installationKey := []byte(test.RandomString(32))
+	hpkePublicKey := []byte(test.RandomString(32))
+
+	// Pre-populate with welcome messages
+	numInitialMessages := 15
+	populateWelcomeMessages(
+		t,
+		ctx,
+		svc,
+		installationKey,
+		hpkePublicKey,
+		numInitialMessages,
+		"initial_welcome",
+	)
+
+	// Get current messages to establish cursor
+	resp, err := svc.QueryWelcomeMessages(ctx, &mlsv1.QueryWelcomeMessagesRequest{
+		InstallationKey: installationKey,
+		PagingInfo: &mlsv1.PagingInfo{
+			Direction: mlsv1.SortDirection_SORT_DIRECTION_ASCENDING,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Messages, numInitialMessages)
+
+	// Use cursor at position 5 (should receive messages 6-15 plus new messages)
+	cursorPosition := resp.Messages[4].GetV1().Id
+	expectedMessagesAfterCursor := numInitialMessages - 5
+
+	collector := newWelcomeMessageCollector(config.bufferSize)
+	stream := setupWelcomeMessageStream(t, ctx, collector)
+
+	// Start subscription with cursor
+	startWelcomeMessageSubscription(t, svc, []*mlsv1.SubscribeWelcomeMessagesRequest_Filter{
+		{
+			InstallationKey: installationKey,
+			IdCursor:        cursorPosition,
+		},
+	}, stream)
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Send additional welcome messages
+	numNewMessages := 7
+	populateWelcomeMessages(
+		t,
+		ctx,
+		svc,
+		installationKey,
+		hpkePublicKey,
+		numNewMessages,
+		"new_welcome",
+	)
+
+	expectedTotalMessages := expectedMessagesAfterCursor + numNewMessages
+
+	// Wait for all expected messages
+	err = collector.waitForCount(expectedTotalMessages, config.timeout)
+	require.NoError(t, err, "Should receive all welcome messages after cursor within timeout")
+
+	// Validate results
+	messages := collector.getAllMessages()
+	assert.GreaterOrEqual(
+		t,
+		len(messages),
+		expectedTotalMessages,
+		"Should receive all welcome messages after cursor",
+	)
+	validateWelcomeMessagesAfterCursor(t, messages, cursorPosition)
+	validateWelcomeMessageOrdering(t, messages)
+}
+
+// TestStreaming_ErrorHandling tests various error scenarios
+func TestStreaming_ErrorHandling(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _, cleanup := newTestService(t, ctx)
+	defer cleanup()
+
+	t.Run("GroupMessages_InvalidGroupId", func(t *testing.T) {
+		stream := mocks.NewMockMlsApi_SubscribeGroupMessagesServer(t)
+		stream.EXPECT().
+			SendHeader(metadata.New(map[string]string{"subscribed": "true"})).
+			Return(nil)
+		stream.EXPECT().Context().Return(ctx)
+
+		err := svc.SubscribeGroupMessages(&mlsv1.SubscribeGroupMessagesRequest{
+			Filters: []*mlsv1.SubscribeGroupMessagesRequest_Filter{
+				{
+					GroupId: nil, // Invalid group ID
+				},
+			},
+		}, stream)
+
+		// Should return an error for this invalid request
+		assert.Error(t, err)
+	})
+
+	t.Run("WelcomeMessages_InvalidInstallationKey", func(t *testing.T) {
+		stream := mocks.NewMockMlsApi_SubscribeWelcomeMessagesServer(t)
+		stream.EXPECT().
+			SendHeader(metadata.New(map[string]string{"subscribed": "true"})).
+			Return(nil)
+		stream.EXPECT().Context().Return(ctx)
+
+		err := svc.SubscribeWelcomeMessages(&mlsv1.SubscribeWelcomeMessagesRequest{
+			Filters: []*mlsv1.SubscribeWelcomeMessagesRequest_Filter{
+				{
+					InstallationKey: nil, // Invalid installation key
+				},
+			},
+		}, stream)
+
+		// Should return an error here
+		assert.Error(t, err)
+	})
+
+	t.Run("GroupMessages_ContextCancellation", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(ctx)
+
+		stream := mocks.NewMockMlsApi_SubscribeGroupMessagesServer(t)
+		stream.EXPECT().
+			SendHeader(metadata.New(map[string]string{"subscribed": "true"})).
+			Return(nil)
+		stream.EXPECT().Context().Return(cancelCtx)
+
+		testGroupId := []byte(test.RandomString(32))
+
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			cancel() // Cancel context after subscription starts
+		}()
+
+		err := svc.SubscribeGroupMessages(&mlsv1.SubscribeGroupMessagesRequest{
+			Filters: []*mlsv1.SubscribeGroupMessagesRequest_Filter{
+				{
+					GroupId: testGroupId,
+				},
+			},
+		}, stream)
+
+		// Should return without error when context is cancelled
+		assert.NoError(t, err)
+	})
+
+	t.Run("WelcomeMessages_ContextCancellation", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(ctx)
+
+		stream := mocks.NewMockMlsApi_SubscribeWelcomeMessagesServer(t)
+		stream.EXPECT().
+			SendHeader(metadata.New(map[string]string{"subscribed": "true"})).
+			Return(nil)
+		stream.EXPECT().Context().Return(cancelCtx)
+
+		installationKey := []byte(test.RandomString(32))
+
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			cancel() // Cancel context after subscription starts
+		}()
+
+		err := svc.SubscribeWelcomeMessages(&mlsv1.SubscribeWelcomeMessagesRequest{
+			Filters: []*mlsv1.SubscribeWelcomeMessagesRequest_Filter{
+				{
+					InstallationKey: installationKey,
+				},
+			},
+		}, stream)
+
+		// Should return without error when context is cancelled
+		assert.NoError(t, err)
+	})
+}
+
+// TestStreaming_MultipleFilters tests subscriptions with multiple filters
+func TestStreaming_MultipleFilters(t *testing.T) {
+	ctx := context.Background()
+	svc, _, validationSvc, cleanup := newTestService(t, ctx)
+	defer cleanup()
+
+	config := defaultTestConfig()
+
+	// Create multiple group IDs
+	groupId1 := []byte(test.RandomString(32))
+	groupId2 := []byte(test.RandomString(32))
+	groupId3 := []byte(test.RandomString(32))
+
+	collector := newMessageCollector(config.bufferSize)
+	stream := setupGroupMessageStream(t, ctx, collector)
+
+	// Start subscription with multiple filters
+	startGroupMessageSubscription(t, svc, []*mlsv1.SubscribeGroupMessagesRequest_Filter{
+		{GroupId: groupId1},
+		{GroupId: groupId2},
+		{GroupId: groupId3},
+	}, stream)
+
+	time.Sleep(config.subscriptionDelay)
+
+	// Send messages to different groups
+	groupIds := [][]byte{groupId1, groupId2, groupId3}
+	messagesPerGroup := 5
+	totalMessages := len(groupIds) * messagesPerGroup
+
+	for i, groupId := range groupIds {
+		validationSvc.ExpectedCalls = nil // Clear all previous mocks
+		mockValidateGroupMessages(validationSvc, groupId)
+		populateGroupMessages(
+			t,
+			ctx,
+			svc,
+			groupId,
+			messagesPerGroup,
+			fmt.Sprintf("group_%d_msg", i),
+		)
+	}
+
+	// Wait for all messages
+	err := collector.waitForCount(totalMessages, config.timeout)
+	require.NoError(t, err, "Should receive messages from all groups within timeout")
+
+	// Validate results
+	messages := collector.getAllMessages()
+	assert.GreaterOrEqual(
+		t,
+		len(messages),
+		totalMessages,
+		"Should receive messages from all groups",
+	)
+
+	// Verify messages from each group are represented
+	groupCounts := make(map[string]int)
+	for _, msg := range messages {
+		groupId := string(msg.GetV1().GroupId)
+		groupCounts[groupId]++
+	}
+
+	assert.Equal(t, len(groupIds), len(groupCounts), "Should receive messages from all groups")
+	for groupId, count := range groupCounts {
+		assert.GreaterOrEqual(t, count, messagesPerGroup,
+			"Should receive all messages from group %s", groupId)
+	}
+
+	// Verify overall ordering (messages should be in sequence_id order)
+	validateMessageOrdering(t, messages)
+}
+
+// TestStreaming_HighThroughput tests the streaming under high message volume
+func TestStreaming_HighThroughput(t *testing.T) {
+	ctx := context.Background()
+	svc, _, validationSvc, cleanup := newTestService(t, ctx)
+	defer cleanup()
+
+	config := testConfig{
+		timeout:           15 * time.Second,
+		subscriptionDelay: 100 * time.Millisecond,
+		bufferSize:        1000,
+	}
+
+	groupId := []byte(test.RandomString(32))
+	mockValidateGroupMessages(validationSvc, groupId)
+
+	collector := newMessageCollector(config.bufferSize)
+	stream := setupGroupMessageStream(t, ctx, collector)
+
+	// Start subscription
+	startGroupMessageSubscription(t, svc, []*mlsv1.SubscribeGroupMessagesRequest_Filter{
+		{GroupId: groupId},
+	}, stream)
+
+	time.Sleep(config.subscriptionDelay)
+
+	// Send a large number of messages with high concurrency
+	numGoroutines := 20
+	messagesPerGoroutine := 25
+	totalMessages := numGoroutines * messagesPerGoroutine
+
+	var wg sync.WaitGroup
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(goroutineId int) {
+			defer wg.Done()
+			for j := 0; j < messagesPerGoroutine; j++ {
+				msgData := fmt.Sprintf("high_throughput_%d_%d", goroutineId, j)
+				_, err := svc.SendGroupMessages(ctx, &mlsv1.SendGroupMessagesRequest{
+					Messages: []*mlsv1.GroupMessageInput{
+						{
+							Version: &mlsv1.GroupMessageInput_V1_{
+								V1: &mlsv1.GroupMessageInput_V1{
+									Data:       []byte(msgData),
+									SenderHmac: []byte(fmt.Sprintf("hmac_%d_%d", goroutineId, j)),
+									ShouldPush: true,
+								},
+							},
+						},
+					},
+				})
+				require.NoError(t, err)
+
+				// Add some randomness to timing
+				time.Sleep(time.Duration(rand.Intn(5)) * time.Millisecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Wait for all messages
+	err := collector.waitForCount(totalMessages, config.timeout)
+	require.NoError(t, err, "Should receive all high throughput messages within timeout")
+
+	// Validate results
+	messages := collector.getAllMessages()
+	assert.GreaterOrEqual(
+		t,
+		len(messages),
+		totalMessages,
+		"Should receive all high throughput messages",
+	)
+
+	// Verify messages are in order and no duplicates
+	seenIds := make(map[uint64]bool)
+	for i, msg := range messages {
+		id := msg.GetV1().Id
+		assert.False(t, seenIds[id], "Should not have duplicate messages in high throughput test")
+		seenIds[id] = true
+
+		if i > 0 {
+			assert.Greater(t, id, messages[i-1].GetV1().Id,
+				"Messages should be in ascending order even under high throughput")
+		}
+	}
+}
+
+// TestStreaming_MessageIntegrity tests that message content is preserved correctly
+func TestStreaming_MessageIntegrity(t *testing.T) {
+	ctx := context.Background()
+	svc, _, validationSvc, cleanup := newTestService(t, ctx)
+	defer cleanup()
+
+	config := defaultTestConfig()
+	groupId := []byte(test.RandomString(32))
+	mockValidateGroupMessages(validationSvc, groupId)
+
+	// Create messages with various data patterns
+	testMessages := []struct {
+		data       string
+		senderHmac string
+		shouldPush bool
+	}{
+		{"simple_message", "hmac1", true},
+		{"message_with_unicode_🚀", "hmac2", false},
+		{"very_long_message_" + string(make([]byte, 1000)), "hmac4", true}, // Large message
+		{"binary_data_\x00\x01\x02\x03", "hmac5", false},                   // Binary data
+	}
+
+	collector := newMessageCollector(len(testMessages))
+	stream := setupGroupMessageStream(t, ctx, collector)
+
+	// Start subscription
+	startGroupMessageSubscription(t, svc, []*mlsv1.SubscribeGroupMessagesRequest_Filter{
+		{GroupId: groupId},
+	}, stream)
+
+	time.Sleep(config.subscriptionDelay)
+
+	// Send test messages
+	for _, testMsg := range testMessages {
+		_, err := svc.SendGroupMessages(ctx, &mlsv1.SendGroupMessagesRequest{
+			Messages: []*mlsv1.GroupMessageInput{
+				{
+					Version: &mlsv1.GroupMessageInput_V1_{
+						V1: &mlsv1.GroupMessageInput_V1{
+							Data:       []byte(testMsg.data),
+							SenderHmac: []byte(testMsg.senderHmac),
+							ShouldPush: testMsg.shouldPush,
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	// Wait for all messages
+	err := collector.waitForCount(len(testMessages), config.timeout)
+	require.NoError(t, err, "Should receive all integrity test messages within timeout")
+
+	// Validate results
+	messages := collector.getAllMessages()
+	assert.Len(t, messages, len(testMessages), "Should receive all integrity test messages")
+
+	// Verify message content integrity
+	for i, msg := range messages {
+		expectedMsg := testMessages[i]
+		assert.Equal(t, []byte(expectedMsg.data), msg.GetV1().Data,
+			"Message data should match exactly")
+		assert.Equal(t, []byte(expectedMsg.senderHmac), msg.GetV1().SenderHmac,
+			"Sender HMAC should match exactly")
+		assert.Equal(t, expectedMsg.shouldPush, msg.GetV1().ShouldPush,
+			"Should push flag should match exactly")
+		assert.True(t, bytes.Equal(groupId, msg.GetV1().GroupId),
+			"Group ID should match exactly")
+	}
+}

--- a/pkg/mls/api/v1/worker.go
+++ b/pkg/mls/api/v1/worker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/xmtp/xmtp-node-go/pkg/subscriptions"
 	"github.com/xmtp/xmtp-node-go/pkg/topic"
 	"github.com/xmtp/xmtp-node-go/pkg/tracing"
+	"github.com/xmtp/xmtp-node-go/pkg/types"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 )
@@ -168,11 +169,13 @@ func (w *dbWorker) listenForWelcomeMessages(ctx context.Context, startID int64) 
 				welcomeMessageProto := mlsv1.WelcomeMessage{
 					Version: &mlsv1.WelcomeMessage_V1_{
 						V1: &mlsv1.WelcomeMessage_V1{
-							Id:              uint64(welcomeMessage.ID),
-							Data:            welcomeMessage.Data,
-							CreatedNs:       uint64(welcomeMessage.CreatedAt.UnixNano()),
-							InstallationKey: welcomeMessage.InstallationKey,
-							HpkePublicKey:   welcomeMessage.HpkePublicKey,
+							Id:               uint64(welcomeMessage.ID),
+							Data:             welcomeMessage.Data,
+							CreatedNs:        uint64(welcomeMessage.CreatedAt.UnixNano()),
+							InstallationKey:  welcomeMessage.InstallationKey,
+							HpkePublicKey:    welcomeMessage.HpkePublicKey,
+							WrapperAlgorithm: types.WrapperAlgorithmToProto(types.WrapperAlgorithm(welcomeMessage.WrapperAlgorithm)),
+							WelcomeMetadata:  welcomeMessage.WelcomeMetadata,
 						},
 					},
 				}

--- a/pkg/mls/store/config.go
+++ b/pkg/mls/store/config.go
@@ -2,21 +2,12 @@ package store
 
 import (
 	"time"
-
-	"github.com/uptrace/bun"
-	"go.uber.org/zap"
 )
 
 type StoreOptions struct {
-	DbConnectionString string        `long:"db-connection-string" description:"Connection string for MLS DB"`
-	ReadTimeout        time.Duration `long:"read-timeout"         description:"Timeout for reading from the database" default:"10s"`
-	WriteTimeout       time.Duration `long:"write-timeout"        description:"Timeout for writing to the database"   default:"10s"`
-	MaxOpenConns       int           `long:"max-open-conns"       description:"Maximum number of open connections"    default:"80"`
-}
-
-type Config struct {
-	Log *zap.Logger
-	DB  *bun.DB
-
-	now func() time.Time
+	DbConnectionString       string        `long:"db-connection-string"        description:"Connection string for MLS DB"`
+	DbReaderConnectionString string        `long:"reader-db-connection-string" description:"Connection string for MLS Reader DB"   env:"XMTPD_MLS_READER_DB_CONNECTION_STRING" default:""`
+	ReadTimeout              time.Duration `long:"read-timeout"                description:"Timeout for reading from the database"                                             default:"10s"`
+	WriteTimeout             time.Duration `long:"write-timeout"               description:"Timeout for writing to the database"                                               default:"10s"`
+	MaxOpenConns             int           `long:"max-open-conns"              description:"Maximum number of open connections"                                                default:"80"`
 }

--- a/pkg/mls/store/readStore.go
+++ b/pkg/mls/store/readStore.go
@@ -1,0 +1,359 @@
+package store
+
+import (
+	"context"
+	"errors"
+
+	"github.com/uptrace/bun"
+	queries "github.com/xmtp/xmtp-node-go/pkg/mls/store/queries"
+	identity "github.com/xmtp/xmtp-node-go/pkg/proto/identity/api/v1"
+	"github.com/xmtp/xmtp-node-go/pkg/proto/identity/associations"
+	mlsv1 "github.com/xmtp/xmtp-node-go/pkg/proto/mls/api/v1"
+	"github.com/xmtp/xmtp-node-go/pkg/proto/mls/message_contents"
+	"github.com/xmtp/xmtp-node-go/pkg/types"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+)
+
+type ReadStore struct {
+	log     *zap.Logger
+	queries *queries.Queries
+}
+
+func NewReadStore(log *zap.Logger, db *bun.DB) *ReadStore {
+	return &ReadStore{
+		log:     log.Named("read-mlsstore"),
+		queries: queries.New(db.DB),
+	}
+}
+
+func (s *ReadStore) Queries() *queries.Queries {
+	return s.queries
+}
+
+func (s *ReadStore) GetInboxIds(
+	ctx context.Context,
+	req *identity.GetInboxIdsRequest,
+) (*identity.GetInboxIdsResponse, error) {
+	identifiers := []string{}
+	for _, request := range req.Requests {
+		identifiers = append(identifiers, request.GetIdentifier())
+	}
+
+	addressLogEntries, err := s.queries.GetAddressLogs(ctx, identifiers)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]*identity.GetInboxIdsResponse_Response, len(identifiers))
+
+	for index, identifier := range identifiers {
+		resp := identity.GetInboxIdsResponse_Response{}
+		resp.Identifier = identifier
+
+		for _, logEntry := range addressLogEntries {
+			if logEntry.Address == identifier {
+				inboxId := logEntry.InboxID
+				resp.InboxId = &inboxId
+			}
+		}
+		out[index] = &resp
+	}
+
+	return &identity.GetInboxIdsResponse{
+		Responses: out,
+	}, nil
+}
+
+func (s *ReadStore) GetInboxLogs(
+	ctx context.Context,
+	batched_req *identity.GetIdentityUpdatesRequest,
+) (*identity.GetIdentityUpdatesResponse, error) {
+	reqs := batched_req.GetRequests()
+
+	filters := make(queries.InboxLogFilterList, len(reqs))
+	for i, req := range reqs {
+		filters[i] = queries.InboxLogFilter{
+			InboxId:    req.InboxId, // InboxLogFilters take inbox_id as text and decode it inside Postgres, since the filters are JSON
+			SequenceId: int64(req.SequenceId),
+		}
+	}
+	filterBytes, err := filters.ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	results, err := s.queries.GetInboxLogFiltered(ctx, filterBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Organize the results by inbox ID
+	resultMap := make(map[string][]queries.GetInboxLogFilteredRow)
+	for _, result := range results {
+		inboxId := result.InboxID
+		resultMap[inboxId] = append(resultMap[inboxId], result)
+	}
+
+	resps := make([]*identity.GetIdentityUpdatesResponse_Response, len(reqs))
+	for i, req := range reqs {
+		logEntries := resultMap[req.InboxId]
+		updates := make([]*identity.GetIdentityUpdatesResponse_IdentityUpdateLog, len(logEntries))
+		for j, entry := range logEntries {
+			identity_update := &associations.IdentityUpdate{}
+			if err := proto.Unmarshal(entry.IdentityUpdateProto, identity_update); err != nil {
+				return nil, err
+			}
+			updates[j] = &identity.GetIdentityUpdatesResponse_IdentityUpdateLog{
+				SequenceId:        uint64(entry.SequenceID),
+				ServerTimestampNs: uint64(entry.ServerTimestampNs),
+				Update:            identity_update,
+			}
+		}
+		resps[i] = &identity.GetIdentityUpdatesResponse_Response{
+			InboxId: req.InboxId,
+			Updates: updates,
+		}
+	}
+
+	return &identity.GetIdentityUpdatesResponse{
+		Responses: resps,
+	}, nil
+}
+
+func (s *ReadStore) FetchKeyPackages(
+	ctx context.Context,
+	installationIds [][]byte,
+) ([]queries.FetchKeyPackagesRow, error) {
+	return s.queries.FetchKeyPackages(ctx, installationIds)
+}
+
+func (s *ReadStore) QueryGroupMessagesV1(
+	ctx context.Context,
+	req *mlsv1.QueryGroupMessagesRequest,
+) (*mlsv1.QueryGroupMessagesResponse, error) {
+	if len(req.GroupId) == 0 {
+		return nil, errors.New("group is required")
+	}
+
+	sortDesc := true
+	var idCursor int64
+	var err error
+	var messages []queries.GroupMessage
+	pageSize := int32(maxPageSize)
+
+	if req.PagingInfo != nil &&
+		req.PagingInfo.Direction == mlsv1.SortDirection_SORT_DIRECTION_ASCENDING {
+		sortDesc = false
+	}
+
+	if req.PagingInfo != nil && req.PagingInfo.Limit > 0 && req.PagingInfo.Limit <= maxPageSize {
+		pageSize = int32(req.PagingInfo.Limit)
+	}
+
+	if req.PagingInfo != nil && req.PagingInfo.IdCursor != 0 {
+		idCursor = int64(req.PagingInfo.IdCursor)
+	}
+
+	if idCursor > 0 {
+		if sortDesc {
+			messages, err = s.queries.QueryGroupMessagesWithCursorDesc(
+				ctx,
+				queries.QueryGroupMessagesWithCursorDescParams{
+					GroupID: req.GroupId,
+					Cursor:  idCursor,
+					Numrows: pageSize,
+				},
+			)
+		} else {
+			messages, err = s.queries.QueryGroupMessagesWithCursorAsc(ctx, queries.QueryGroupMessagesWithCursorAscParams{
+				GroupID: req.GroupId,
+				Cursor:  idCursor,
+				Numrows: pageSize,
+			})
+		}
+	} else {
+		messages, err = s.queries.QueryGroupMessages(ctx, queries.QueryGroupMessagesParams{
+			GroupID:  req.GroupId,
+			Numrows:  pageSize,
+			SortDesc: sortDesc,
+		})
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]*mlsv1.GroupMessage, len(messages))
+	for idx, msg := range messages {
+		out[idx] = &mlsv1.GroupMessage{
+			Version: &mlsv1.GroupMessage_V1_{
+				V1: &mlsv1.GroupMessage_V1{
+					Id:         uint64(msg.ID),
+					CreatedNs:  uint64(msg.CreatedAt.UnixNano()),
+					GroupId:    msg.GroupID,
+					Data:       msg.Data,
+					ShouldPush: msg.ShouldPush.Bool,
+					SenderHmac: msg.SenderHmac,
+				},
+			},
+		}
+	}
+
+	direction := mlsv1.SortDirection_SORT_DIRECTION_ASCENDING
+	if sortDesc {
+		direction = mlsv1.SortDirection_SORT_DIRECTION_DESCENDING
+	}
+
+	pagingInfo := &mlsv1.PagingInfo{Limit: uint32(pageSize), IdCursor: 0, Direction: direction}
+	if len(messages) >= int(pageSize) {
+		lastMsg := messages[len(messages)-1]
+		pagingInfo.IdCursor = uint64(lastMsg.ID)
+	}
+
+	return &mlsv1.QueryGroupMessagesResponse{
+		Messages:   out,
+		PagingInfo: pagingInfo,
+	}, nil
+}
+
+func (s *ReadStore) QueryWelcomeMessagesV1(
+	ctx context.Context,
+	req *mlsv1.QueryWelcomeMessagesRequest,
+) (*mlsv1.QueryWelcomeMessagesResponse, error) {
+	if len(req.InstallationKey) == 0 {
+		return nil, errors.New("installation is required")
+	}
+
+	sortDesc := true
+	direction := mlsv1.SortDirection_SORT_DIRECTION_DESCENDING
+	pageSize := int32(maxPageSize)
+	var idCursor int64
+	var err error
+	var messages []queries.WelcomeMessage
+
+	if req.PagingInfo != nil &&
+		req.PagingInfo.Direction == mlsv1.SortDirection_SORT_DIRECTION_ASCENDING {
+		sortDesc = false
+		direction = mlsv1.SortDirection_SORT_DIRECTION_ASCENDING
+	}
+
+	if req.PagingInfo != nil && req.PagingInfo.Limit > 0 && req.PagingInfo.Limit <= maxPageSize {
+		pageSize = int32(req.PagingInfo.Limit)
+	}
+
+	if req.PagingInfo != nil && req.PagingInfo.IdCursor != 0 {
+		idCursor = int64(req.PagingInfo.IdCursor)
+	}
+
+	if idCursor > 0 {
+		if sortDesc {
+			messages, err = s.queries.QueryWelcomeMessagesWithCursorDesc(
+				ctx,
+				queries.QueryWelcomeMessagesWithCursorDescParams{
+					InstallationKey: req.InstallationKey,
+					Cursor:          idCursor,
+					Numrows:         pageSize,
+				},
+			)
+		} else {
+			messages, err = s.queries.QueryWelcomeMessagesWithCursorAsc(ctx, queries.QueryWelcomeMessagesWithCursorAscParams{
+				InstallationKey: req.InstallationKey,
+				Cursor:          idCursor,
+				Numrows:         pageSize,
+			})
+		}
+	} else {
+		messages, err = s.queries.QueryWelcomeMessages(ctx, queries.QueryWelcomeMessagesParams{
+			InstallationKey: req.InstallationKey,
+			Numrows:         pageSize,
+			SortDesc:        sortDesc,
+		})
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]*mlsv1.WelcomeMessage, len(messages))
+	for idx, msg := range messages {
+		out[idx] = &mlsv1.WelcomeMessage{
+			Version: &mlsv1.WelcomeMessage_V1_{
+				V1: &mlsv1.WelcomeMessage_V1{
+					Id:              uint64(msg.ID),
+					CreatedNs:       uint64(msg.CreatedAt.UnixNano()),
+					Data:            msg.Data,
+					InstallationKey: msg.InstallationKey,
+					HpkePublicKey:   msg.HpkePublicKey,
+					WrapperAlgorithm: types.WrapperAlgorithmToProto(
+						types.WrapperAlgorithm(msg.WrapperAlgorithm),
+					),
+					WelcomeMetadata: msg.WelcomeMetadata,
+				},
+			},
+		}
+	}
+
+	pagingInfo := &mlsv1.PagingInfo{Limit: uint32(pageSize), IdCursor: 0, Direction: direction}
+	if len(messages) >= int(pageSize) {
+		lastMsg := messages[len(messages)-1]
+		pagingInfo.IdCursor = uint64(lastMsg.ID)
+	}
+
+	return &mlsv1.QueryWelcomeMessagesResponse{
+		Messages:   out,
+		PagingInfo: pagingInfo,
+	}, nil
+}
+
+func (s *ReadStore) QueryCommitLog(
+	ctx context.Context,
+	req *mlsv1.QueryCommitLogRequest,
+) (*mlsv1.QueryCommitLogResponse, error) {
+	if len(req.GetGroupId()) == 0 {
+		return nil, errors.New("group is required")
+	}
+	if req.GetPagingInfo().GetDirection() == mlsv1.SortDirection_SORT_DIRECTION_DESCENDING {
+		return nil, errors.New("descending direction is not supported")
+	}
+	pageSize := int32(req.GetPagingInfo().GetLimit())
+	if pageSize <= 0 || pageSize > maxPageSize {
+		pageSize = maxPageSize
+	}
+	idCursor := int64(req.GetPagingInfo().GetIdCursor())
+
+	entries, err := s.queries.QueryCommitLog(ctx, queries.QueryCommitLogParams{
+		GroupID: req.GroupId,
+		Cursor:  idCursor,
+		Numrows: pageSize,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]*message_contents.CommitLogEntry, len(entries))
+	for idx, entry := range entries {
+		out[idx] = &message_contents.CommitLogEntry{
+			SequenceId:              uint64(entry.ID),
+			EncryptedCommitLogEntry: entry.EncryptedEntry,
+		}
+	}
+
+	pagingInfo := &mlsv1.PagingInfo{
+		Limit:     uint32(pageSize),
+		IdCursor:  0,
+		Direction: mlsv1.SortDirection_SORT_DIRECTION_ASCENDING,
+	}
+	// It is strange behavior, but we must follow the semantics of other queries in v3 - only setting the IdCursor
+	// to a non-zero value if we have a full page of results
+	if len(entries) >= int(pageSize) {
+		lastEntry := entries[len(entries)-1]
+		pagingInfo.IdCursor = uint64(lastEntry.ID)
+	}
+
+	return &mlsv1.QueryCommitLogResponse{
+		GroupId:          req.GroupId,
+		CommitLogEntries: out,
+		PagingInfo:       pagingInfo,
+	}, nil
+}

--- a/pkg/mls/store/store.go
+++ b/pkg/mls/store/store.go
@@ -18,7 +18,6 @@ import (
 	identity "github.com/xmtp/xmtp-node-go/pkg/proto/identity/api/v1"
 	"github.com/xmtp/xmtp-node-go/pkg/proto/identity/associations"
 	mlsv1 "github.com/xmtp/xmtp-node-go/pkg/proto/mls/api/v1"
-	"github.com/xmtp/xmtp-node-go/pkg/proto/mls/message_contents"
 	"github.com/xmtp/xmtp-node-go/pkg/types"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -27,18 +26,15 @@ import (
 const maxPageSize = 100
 
 type Store struct {
-	config  Config
-	log     *zap.Logger
-	db      *bun.DB
-	queries *queries.Queries
+	log       *zap.Logger
+	db        *bun.DB
+	queries   *queries.Queries
+	readstore *ReadStore
 }
 
-type IdentityStore interface {
-	PublishIdentityUpdate(
-		ctx context.Context,
-		req *identity.PublishIdentityUpdateRequest,
-		validationService mlsvalidate.MLSValidationService,
-	) (*identity.PublishIdentityUpdateResponse, error)
+// The ReadMlsStore interface is used for all queries, and will work whether connected to the primary DB or
+// a read replica
+type ReadMlsStore interface {
 	GetInboxLogs(
 		ctx context.Context,
 		req *identity.GetIdentityUpdatesRequest,
@@ -47,16 +43,35 @@ type IdentityStore interface {
 		ctx context.Context,
 		req *identity.GetInboxIdsRequest,
 	) (*identity.GetInboxIdsResponse, error)
-}
-
-type MlsStore interface {
-	IdentityStore
-
-	CreateOrUpdateInstallation(ctx context.Context, installationId []byte, keyPackage []byte) error
 	FetchKeyPackages(
 		ctx context.Context,
 		installationIds [][]byte,
 	) ([]queries.FetchKeyPackagesRow, error)
+	QueryGroupMessagesV1(
+		ctx context.Context,
+		query *mlsv1.QueryGroupMessagesRequest,
+	) (*mlsv1.QueryGroupMessagesResponse, error)
+	QueryWelcomeMessagesV1(
+		ctx context.Context,
+		query *mlsv1.QueryWelcomeMessagesRequest,
+	) (*mlsv1.QueryWelcomeMessagesResponse, error)
+	QueryCommitLog(
+		ctx context.Context,
+		query *mlsv1.QueryCommitLogRequest,
+	) (*mlsv1.QueryCommitLogResponse, error)
+	Queries() *queries.Queries
+}
+
+// The ReadWriteMlsStore is a superset of the ReadMlsStore interface and is used for all writes.
+// It must be connected to the primary DB, and will use the primary for both reads and writes.
+type ReadWriteMlsStore interface {
+	ReadMlsStore
+	CreateOrUpdateInstallation(ctx context.Context, installationId []byte, keyPackage []byte) error
+	PublishIdentityUpdate(
+		ctx context.Context,
+		req *identity.PublishIdentityUpdateRequest,
+		validationService mlsvalidate.MLSValidationService,
+	) (*identity.PublishIdentityUpdateResponse, error)
 	InsertGroupMessage(
 		ctx context.Context,
 		groupId []byte,
@@ -73,39 +88,20 @@ type MlsStore interface {
 		algorithm types.WrapperAlgorithm,
 		welcomeMetadata []byte,
 	) (*queries.WelcomeMessage, error)
-	QueryGroupMessagesV1(
-		ctx context.Context,
-		query *mlsv1.QueryGroupMessagesRequest,
-	) (*mlsv1.QueryGroupMessagesResponse, error)
-	QueryWelcomeMessagesV1(
-		ctx context.Context,
-		query *mlsv1.QueryWelcomeMessagesRequest,
-	) (*mlsv1.QueryWelcomeMessagesResponse, error)
-	QueryCommitLog(
-		ctx context.Context,
-		query *mlsv1.QueryCommitLogRequest,
-	) (*mlsv1.QueryCommitLogResponse, error)
 	InsertCommitLog(
 		ctx context.Context,
 		groupId []byte,
 		encrypted_entry []byte,
 	) (queries.CommitLog, error)
-	Queries() *queries.Queries
 }
 
-var _ MlsStore = (*Store)(nil)
-
-func New(ctx context.Context, config Config) (*Store, error) {
-	if config.now == nil {
-		config.now = func() time.Time {
-			return time.Now().UTC()
-		}
-	}
+func New(ctx context.Context, log *zap.Logger, db *bun.DB) (*Store, error) {
 	s := &Store{
-		log:     config.Log.Named("mlsstore"),
-		db:      config.DB,
-		config:  config,
-		queries: queries.New(config.DB.DB),
+		log:     log.Named("mlsstore"),
+		db:      db,
+		queries: queries.New(db.DB),
+		// Create the read store with the same database connection as the write store
+		readstore: NewReadStore(log, db),
 	}
 
 	if err := s.migrate(ctx); err != nil {
@@ -117,40 +113,6 @@ func New(ctx context.Context, config Config) (*Store, error) {
 
 func (s *Store) Queries() *queries.Queries {
 	return s.queries
-}
-
-func (s *Store) GetInboxIds(
-	ctx context.Context,
-	req *identity.GetInboxIdsRequest,
-) (*identity.GetInboxIdsResponse, error) {
-	addresses := []string{}
-	for _, request := range req.Requests {
-		addresses = append(addresses, request.GetIdentifier())
-	}
-
-	addressLogEntries, err := s.queries.GetAddressLogs(ctx, addresses)
-	if err != nil {
-		return nil, err
-	}
-
-	out := make([]*identity.GetInboxIdsResponse_Response, len(addresses))
-
-	for index, address := range addresses {
-		resp := identity.GetInboxIdsResponse_Response{}
-		resp.Identifier = address
-
-		for _, logEntry := range addressLogEntries {
-			if logEntry.Address == address {
-				inboxId := logEntry.InboxID
-				resp.InboxId = &inboxId
-			}
-		}
-		out[index] = &resp
-	}
-
-	return &identity.GetInboxIdsResponse{
-		Responses: out,
-	}, nil
 }
 
 func (s *Store) PublishIdentityUpdate(
@@ -254,62 +216,6 @@ func (s *Store) PublishIdentityUpdate(
 	return &identity.PublishIdentityUpdateResponse{}, nil
 }
 
-func (s *Store) GetInboxLogs(
-	ctx context.Context,
-	batched_req *identity.GetIdentityUpdatesRequest,
-) (*identity.GetIdentityUpdatesResponse, error) {
-	reqs := batched_req.GetRequests()
-
-	filters := make(queries.InboxLogFilterList, len(reqs))
-	for i, req := range reqs {
-		filters[i] = queries.InboxLogFilter{
-			InboxId:    req.InboxId, // InboxLogFilters take inbox_id as text and decode it inside Postgres, since the filters are JSON
-			SequenceId: int64(req.SequenceId),
-		}
-	}
-	filterBytes, err := filters.ToSql()
-	if err != nil {
-		return nil, err
-	}
-
-	results, err := s.queries.GetInboxLogFiltered(ctx, filterBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	// Organize the results by inbox ID
-	resultMap := make(map[string][]queries.GetInboxLogFilteredRow)
-	for _, result := range results {
-		inboxId := result.InboxID
-		resultMap[inboxId] = append(resultMap[inboxId], result)
-	}
-
-	resps := make([]*identity.GetIdentityUpdatesResponse_Response, len(reqs))
-	for i, req := range reqs {
-		logEntries := resultMap[req.InboxId]
-		updates := make([]*identity.GetIdentityUpdatesResponse_IdentityUpdateLog, len(logEntries))
-		for j, entry := range logEntries {
-			identity_update := &associations.IdentityUpdate{}
-			if err := proto.Unmarshal(entry.IdentityUpdateProto, identity_update); err != nil {
-				return nil, err
-			}
-			updates[j] = &identity.GetIdentityUpdatesResponse_IdentityUpdateLog{
-				SequenceId:        uint64(entry.SequenceID),
-				ServerTimestampNs: uint64(entry.ServerTimestampNs),
-				Update:            identity_update,
-			}
-		}
-		resps[i] = &identity.GetIdentityUpdatesResponse_Response{
-			InboxId: req.InboxId,
-			Updates: updates,
-		}
-	}
-
-	return &identity.GetIdentityUpdatesResponse{
-		Responses: resps,
-	}, nil
-}
-
 // Creates the installation and last resort key package
 func (s *Store) CreateOrUpdateInstallation(
 	ctx context.Context,
@@ -324,13 +230,6 @@ func (s *Store) CreateOrUpdateInstallation(
 		UpdatedAt:  now,
 		KeyPackage: keyPackage,
 	})
-}
-
-func (s *Store) FetchKeyPackages(
-	ctx context.Context,
-	installationIds [][]byte,
-) ([]queries.FetchKeyPackagesRow, error) {
-	return s.queries.FetchKeyPackages(ctx, installationIds)
 }
 
 func (s *Store) InsertGroupMessage(
@@ -387,234 +286,39 @@ func (s *Store) InsertWelcomeMessage(
 	return &message, nil
 }
 
+func (s *Store) GetInboxIds(
+	ctx context.Context,
+	req *identity.GetInboxIdsRequest,
+) (*identity.GetInboxIdsResponse, error) {
+	return s.readstore.GetInboxIds(ctx, req)
+}
+
+func (s *Store) GetInboxLogs(
+	ctx context.Context,
+	batched_req *identity.GetIdentityUpdatesRequest,
+) (*identity.GetIdentityUpdatesResponse, error) {
+	return s.readstore.GetInboxLogs(ctx, batched_req)
+}
+
+func (s *Store) FetchKeyPackages(
+	ctx context.Context,
+	installationIds [][]byte,
+) ([]queries.FetchKeyPackagesRow, error) {
+	return s.readstore.FetchKeyPackages(ctx, installationIds)
+}
+
 func (s *Store) QueryGroupMessagesV1(
 	ctx context.Context,
 	req *mlsv1.QueryGroupMessagesRequest,
 ) (*mlsv1.QueryGroupMessagesResponse, error) {
-	if len(req.GroupId) == 0 {
-		return nil, errors.New("group is required")
-	}
-
-	sortDesc := true
-	var idCursor int64
-	var err error
-	var messages []queries.GroupMessage
-	pageSize := int32(maxPageSize)
-
-	if req.PagingInfo != nil &&
-		req.PagingInfo.Direction == mlsv1.SortDirection_SORT_DIRECTION_ASCENDING {
-		sortDesc = false
-	}
-
-	if req.PagingInfo != nil && req.PagingInfo.Limit > 0 && req.PagingInfo.Limit <= maxPageSize {
-		pageSize = int32(req.PagingInfo.Limit)
-	}
-
-	if req.PagingInfo != nil && req.PagingInfo.IdCursor != 0 {
-		idCursor = int64(req.PagingInfo.IdCursor)
-	}
-
-	if idCursor > 0 {
-		if sortDesc {
-			messages, err = s.queries.QueryGroupMessagesWithCursorDesc(
-				ctx,
-				queries.QueryGroupMessagesWithCursorDescParams{
-					GroupID: req.GroupId,
-					Cursor:  idCursor,
-					Numrows: pageSize,
-				},
-			)
-		} else {
-			messages, err = s.queries.QueryGroupMessagesWithCursorAsc(ctx, queries.QueryGroupMessagesWithCursorAscParams{
-				GroupID: req.GroupId,
-				Cursor:  idCursor,
-				Numrows: pageSize,
-			})
-		}
-	} else {
-		messages, err = s.queries.QueryGroupMessages(ctx, queries.QueryGroupMessagesParams{
-			GroupID:  req.GroupId,
-			Numrows:  pageSize,
-			SortDesc: sortDesc,
-		})
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	out := make([]*mlsv1.GroupMessage, len(messages))
-	for idx, msg := range messages {
-		out[idx] = &mlsv1.GroupMessage{
-			Version: &mlsv1.GroupMessage_V1_{
-				V1: &mlsv1.GroupMessage_V1{
-					Id:         uint64(msg.ID),
-					CreatedNs:  uint64(msg.CreatedAt.UnixNano()),
-					GroupId:    msg.GroupID,
-					Data:       msg.Data,
-					ShouldPush: msg.ShouldPush.Bool,
-					SenderHmac: msg.SenderHmac,
-				},
-			},
-		}
-	}
-
-	direction := mlsv1.SortDirection_SORT_DIRECTION_ASCENDING
-	if sortDesc {
-		direction = mlsv1.SortDirection_SORT_DIRECTION_DESCENDING
-	}
-
-	pagingInfo := &mlsv1.PagingInfo{Limit: uint32(pageSize), IdCursor: 0, Direction: direction}
-	if len(messages) >= int(pageSize) {
-		lastMsg := messages[len(messages)-1]
-		pagingInfo.IdCursor = uint64(lastMsg.ID)
-	}
-
-	return &mlsv1.QueryGroupMessagesResponse{
-		Messages:   out,
-		PagingInfo: pagingInfo,
-	}, nil
+	return s.readstore.QueryGroupMessagesV1(ctx, req)
 }
 
 func (s *Store) QueryWelcomeMessagesV1(
 	ctx context.Context,
 	req *mlsv1.QueryWelcomeMessagesRequest,
 ) (*mlsv1.QueryWelcomeMessagesResponse, error) {
-	if len(req.InstallationKey) == 0 {
-		return nil, errors.New("installation is required")
-	}
-
-	sortDesc := true
-	direction := mlsv1.SortDirection_SORT_DIRECTION_DESCENDING
-	pageSize := int32(maxPageSize)
-	var idCursor int64
-	var err error
-	var messages []queries.WelcomeMessage
-
-	if req.PagingInfo != nil &&
-		req.PagingInfo.Direction == mlsv1.SortDirection_SORT_DIRECTION_ASCENDING {
-		sortDesc = false
-		direction = mlsv1.SortDirection_SORT_DIRECTION_ASCENDING
-	}
-
-	if req.PagingInfo != nil && req.PagingInfo.Limit > 0 && req.PagingInfo.Limit <= maxPageSize {
-		pageSize = int32(req.PagingInfo.Limit)
-	}
-
-	if req.PagingInfo != nil && req.PagingInfo.IdCursor != 0 {
-		idCursor = int64(req.PagingInfo.IdCursor)
-	}
-
-	if idCursor > 0 {
-		if sortDesc {
-			messages, err = s.queries.QueryWelcomeMessagesWithCursorDesc(
-				ctx,
-				queries.QueryWelcomeMessagesWithCursorDescParams{
-					InstallationKey: req.InstallationKey,
-					Cursor:          idCursor,
-					Numrows:         pageSize,
-				},
-			)
-		} else {
-			messages, err = s.queries.QueryWelcomeMessagesWithCursorAsc(ctx, queries.QueryWelcomeMessagesWithCursorAscParams{
-				InstallationKey: req.InstallationKey,
-				Cursor:          idCursor,
-				Numrows:         pageSize,
-			})
-		}
-	} else {
-		messages, err = s.queries.QueryWelcomeMessages(ctx, queries.QueryWelcomeMessagesParams{
-			InstallationKey: req.InstallationKey,
-			Numrows:         pageSize,
-			SortDesc:        sortDesc,
-		})
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	out := make([]*mlsv1.WelcomeMessage, len(messages))
-	for idx, msg := range messages {
-		out[idx] = &mlsv1.WelcomeMessage{
-			Version: &mlsv1.WelcomeMessage_V1_{
-				V1: &mlsv1.WelcomeMessage_V1{
-					Id:              uint64(msg.ID),
-					CreatedNs:       uint64(msg.CreatedAt.UnixNano()),
-					Data:            msg.Data,
-					InstallationKey: msg.InstallationKey,
-					HpkePublicKey:   msg.HpkePublicKey,
-					WrapperAlgorithm: types.WrapperAlgorithmToProto(
-						types.WrapperAlgorithm(msg.WrapperAlgorithm),
-					),
-					WelcomeMetadata: msg.WelcomeMetadata,
-				},
-			},
-		}
-	}
-
-	pagingInfo := &mlsv1.PagingInfo{Limit: uint32(pageSize), IdCursor: 0, Direction: direction}
-	if len(messages) >= int(pageSize) {
-		lastMsg := messages[len(messages)-1]
-		pagingInfo.IdCursor = uint64(lastMsg.ID)
-	}
-
-	return &mlsv1.QueryWelcomeMessagesResponse{
-		Messages:   out,
-		PagingInfo: pagingInfo,
-	}, nil
-}
-
-func (s *Store) QueryCommitLog(
-	ctx context.Context,
-	req *mlsv1.QueryCommitLogRequest,
-) (*mlsv1.QueryCommitLogResponse, error) {
-	if len(req.GetGroupId()) == 0 {
-		return nil, errors.New("group is required")
-	}
-	if req.GetPagingInfo().GetDirection() == mlsv1.SortDirection_SORT_DIRECTION_DESCENDING {
-		return nil, errors.New("descending direction is not supported")
-	}
-	pageSize := int32(req.GetPagingInfo().GetLimit())
-	if pageSize <= 0 || pageSize > maxPageSize {
-		pageSize = maxPageSize
-	}
-	idCursor := int64(req.GetPagingInfo().GetIdCursor())
-
-	entries, err := s.queries.QueryCommitLog(ctx, queries.QueryCommitLogParams{
-		GroupID: req.GroupId,
-		Cursor:  idCursor,
-		Numrows: pageSize,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	out := make([]*message_contents.CommitLogEntry, len(entries))
-	for idx, entry := range entries {
-		out[idx] = &message_contents.CommitLogEntry{
-			SequenceId:              uint64(entry.ID),
-			EncryptedCommitLogEntry: entry.EncryptedEntry,
-		}
-	}
-
-	pagingInfo := &mlsv1.PagingInfo{
-		Limit:     uint32(pageSize),
-		IdCursor:  0,
-		Direction: mlsv1.SortDirection_SORT_DIRECTION_ASCENDING,
-	}
-	// It is strange behavior, but we must follow the semantics of other queries in v3 - only setting the IdCursor
-	// to a non-zero value if we have a full page of results
-	if len(entries) >= int(pageSize) {
-		lastEntry := entries[len(entries)-1]
-		pagingInfo.IdCursor = uint64(lastEntry.ID)
-	}
-
-	return &mlsv1.QueryCommitLogResponse{
-		GroupId:          req.GroupId,
-		CommitLogEntries: out,
-		PagingInfo:       pagingInfo,
-	}, nil
+	return s.readstore.QueryWelcomeMessagesV1(ctx, req)
 }
 
 func (s *Store) InsertCommitLog(
@@ -717,4 +421,11 @@ func (s *Store) RunInRepeatableReadTx(
 		}
 	}
 	return err
+}
+
+func (s *Store) QueryCommitLog(
+	ctx context.Context,
+	query *mlsv1.QueryCommitLogRequest,
+) (*mlsv1.QueryCommitLogResponse, error) {
+	return s.readstore.QueryCommitLog(ctx, query)
 }

--- a/pkg/mls/store/store_test.go
+++ b/pkg/mls/store/store_test.go
@@ -28,12 +28,8 @@ func NewTestStore(t *testing.T) (*Store, func()) {
 	log := testutils.NewLog(t)
 	db, _, dbCleanup := testutils.NewMLSDB(t)
 	ctx := context.Background()
-	c := Config{
-		Log: log,
-		DB:  db,
-	}
 
-	store, err := New(ctx, c)
+	store, err := New(ctx, log, db)
 	require.NoError(t, err)
 
 	return store, dbCleanup


### PR DESCRIPTION
### TL;DR

Added read/write separation for MLS database operations to support read replicas. This should substantially improve performance in dev/prod, since subscriptions that fetch historical data can be quite expensive.

### What changed?

- Created a new `ReadMlsStore` interface for read-only operations
- Created a new `ReadWriteMlsStore` interface that extends `ReadMlsStore` with write operations
- Implemented a separate `ReadStore` struct that handles read-only operations
- Modified the existing `Store` struct to delegate read operations to the `ReadStore`
- Added configuration option for a separate reader database connection string
- Updated service constructors to accept both read and write store interfaces

### How to test?

1. Configure a read replica database by setting the `--reader-db-connection-string` flag
2. Verify that read operations are directed to the read replica while write operations go to the primary database
3. Test with a single database by leaving `reader-db-connection-string` empty, which will use the same connection for both reads and writes

### Why make this change?

This change enables the use of database read replicas to improve performance and scalability. By separating read and write operations, the system can distribute database load more efficiently, with write operations going to the primary database and read operations being handled by read replicas. This is particularly beneficial for deployments with high read volumes, as it reduces the load on the primary database and improves overall system performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for separate read-only and read-write database connections for MLS data, enabling improved scalability and potential use of read replicas.
  * Added a dedicated read-only store for MLS queries, enhancing performance and flexibility for data retrieval operations.
  * Added comprehensive tests for streaming group and welcome messages, verifying message ordering, concurrency, filtering, and error handling.

* **Refactor**
  * Separated read and write operations into distinct interfaces and components across the MLS service and related modules.
  * Updated configuration and initialization to support both read-only and read-write database connections.
  * Refactored MLS store to delegate queries to a read-only store component, simplifying query handling and enabling distinct read DB usage.

* **Bug Fixes**
  * Improved error handling and paging in MLS data queries.
  * Enhanced concurrency handling and error propagation in welcome message streaming.

* **Chores**
  * Updated tests and internal setup to align with the new read/write separation.
  * Modified CI workflow to always push Docker images on build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->