### PR TITLE
Default to WrapperAlgorithm(0)

### DIFF
--- a/pkg/migrations/mls/20250409031523_add-welcome-encryption.up.sql
+++ b/pkg/migrations/mls/20250409031523_add-welcome-encryption.up.sql
@@ -12,13 +12,6 @@ ALTER TABLE welcome_messages
 	ALTER COLUMN wrapper_algorithm SET DEFAULT 0;
 
 --bun:split
--- Set all the existing rows to the default value
-UPDATE
-	welcome_messages
-SET
-	wrapper_algorithm = 0;
-
---bun:split
 -- Make the column non-nullable
 ALTER TABLE welcome_messages
 	ALTER COLUMN wrapper_algorithm SET NOT NULL;

--- a/pkg/mls/api/v1/service.go
+++ b/pkg/mls/api/v1/service.go
@@ -295,7 +295,13 @@ func (s *Service) SendWelcomeMessages(ctx context.Context, req *mlsv1.SendWelcom
 			insertSpan, insertCtx := tracer.StartSpanFromContext(ctx, "insert-welcome-message")
 			insertLogger := tracing.Link(insertSpan, log)
 			insertLogger.Info("inserting welcome message", zap.String("client_ip", ip), zap.Int("message_length", len(input.GetV1().Data)))
-			msg, err := s.store.InsertWelcomeMessage(insertCtx, input.GetV1().InstallationKey, input.GetV1().Data, input.GetV1().HpkePublicKey, types.WrapperAlgorithmFromProto(input.GetV1().WrapperAlgorithm))
+
+			wrapperAlgorithm := types.WrapperAlgorithm(0)
+			if v1 := input.GetV1(); v1 != nil {
+				wrapperAlgorithm = types.WrapperAlgorithmFromProto(v1.WrapperAlgorithm)
+			}
+
+			msg, err := s.store.InsertWelcomeMessage(insertCtx, input.GetV1().InstallationKey, input.GetV1().Data, input.GetV1().HpkePublicKey, wrapperAlgorithm)
 			insertSpan.Finish(tracing.WithError(err))
 			if err != nil {
 				if mlsstore.IsAlreadyExistsError(err) {


### PR DESCRIPTION
### Default wrapper_algorithm to 0 in welcome message processing and database migration
- Removes explicit UPDATE statement from SQL migration [20250409031523_add-welcome-encryption.up.sql](https://github.com/xmtp/xmtp-node-go/pull/454/files#diff-83b4923409ce0a00e6c9b835d0867dfcac35c69365455df19f4bad337250d6e5) that would set existing `welcome_messages` rows to `wrapper_algorithm = 0`
- Modifies `SendWelcomeMessages` method in [service.go](https://github.com/xmtp/xmtp-node-go/pull/454/files#diff-6d11ce32bdc179716d251a2646ec61f8b921f7d7eecd5e50d98b9ce1592287b4) to set default `wrapperAlgorithm` value of 0 and only use input value when v1 field exists

#### 📍Where to Start
Start with the `SendWelcomeMessages` method in [service.go](https://github.com/xmtp/xmtp-node-go/pull/454/files#diff-6d11ce32bdc179716d251a2646ec61f8b921f7d7eecd5e50d98b9ce1592287b4) to understand how the wrapper algorithm parameter is now handled with the default value.

----

_[Macroscope](https://app.macroscope.com) summarized 28c5098._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of welcome message encryption settings to prevent potential errors when processing messages with missing parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->