### PR TITLE
More performant DB migration for wrapper_algorithm column

### DIFF
--- a/pkg/migrations/mls/20250409031523_add-welcome-encryption.up.sql
+++ b/pkg/migrations/mls/20250409031523_add-welcome-encryption.up.sql
@@ -1,27 +1,8 @@
 SET statement_timeout = 0;
 
--- Do a multi-step process to add the column, set default for existing rows, and make the column non-nullable
 --bun:split
--- Add the column allowing nulls
 ALTER TABLE welcome_messages
-	ADD COLUMN wrapper_algorithm SMALLINT;
-
---bun:split
--- Set the default value for the new column
-ALTER TABLE welcome_messages
-	ALTER COLUMN wrapper_algorithm SET DEFAULT 0;
-
---bun:split
--- Set all the existing rows to the default value
-UPDATE
-	welcome_messages
-SET
-	wrapper_algorithm = 0;
-
---bun:split
--- Make the column non-nullable
-ALTER TABLE welcome_messages
-	ALTER COLUMN wrapper_algorithm SET NOT NULL;
+	ADD COLUMN wrapper_algorithm SMALLINT NOT NULL DEFAULT 0;
 
 --bun:split
 CREATE OR REPLACE FUNCTION insert_welcome_message_v2(installation_key BYTEA, data BYTEA, installation_key_data_hash BYTEA, hpke_public_key BYTEA, wrapper_algorithm SMALLINT)


### PR DESCRIPTION
```
UPDATE
	welcome_messages
SET
	wrapper_algorithm = 0;
```

Updates every row in the DB, and times out on the dev network. The alternative in this PR allows Postgres to internally optimize away the writes (runs instantly).

I've manually applied the migration on the dev network, and the migration is marked as applied on dev and prod, so landing this PR shouldn't change anything in practice.