### PR TITLE
Only merge to prod from main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,12 @@ on:
   push:
     branches:
       - main
+      - dev
 jobs:
   deploy:
-    concurrency: main
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
@@ -28,7 +31,11 @@ jobs:
       - name: Push
         id: push
         run: |
-          export DOCKER_IMAGE_TAG=latest
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            export DOCKER_IMAGE_TAG=latest
+          else
+            export DOCKER_IMAGE_TAG=dev
+          fi
           IMAGE_TO_DEPLOY=xmtp/node-go@$(dev/docker/build)
           echo Successfully pushed $IMAGE_TO_DEPLOY
           echo "docker_image=${IMAGE_TO_DEPLOY}" >> $GITHUB_OUTPUT
@@ -36,6 +43,7 @@ jobs:
       - name: Deploy (dev)
         uses: xmtp-labs/terraform-deployer@v1
         timeout-minutes: 45
+        if: github.ref == 'refs/heads/dev'
         with:
           timeout: 45m
           terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
@@ -48,6 +56,7 @@ jobs:
       - name: Deploy (production)
         uses: xmtp-labs/terraform-deployer@v1
         timeout-minutes: 45
+        if: github.ref == 'refs/heads/main'
         with:
           timeout: 45m
           terraform-token: ${{ secrets.TERRAFORM_TOKEN }}


### PR DESCRIPTION
### TL;DR

Added support for deploying from the `dev` branch in addition to the `main` branch.

### What changed?

- Added `dev` branch to the list of branches that trigger the deployment workflow
- Added conditional checks to ensure the appropriate deployment step runs based on the branch:
  - The "Deploy (dev)" step now only runs when the workflow is triggered from the `dev` branch
  - The "Deploy (production)" step now only runs when the workflow is triggered from the `main` branch

### How to test?

1. Push changes to the `dev` branch and verify that only the dev deployment runs
2. Push changes to the `main` branch and verify that only the production deployment runs

### Why make this change?

This change enables a more structured deployment process by allowing separate deployments for development and production environments. It provides a way to test changes in a development environment before promoting them to production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Deployment workflow now supports both `main` and `dev` branches, with branch-specific Docker image tagging and deployment steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->