### PR TITLE
Welcome message type prune implementation

### DIFF
--- a/pkg/prune/interface.go
+++ b/pkg/prune/interface.go
@@ -1,0 +1,8 @@
+package prune
+
+import "context"
+
+type Pruner interface {
+	Count(ctx context.Context) (int64, error)
+	PruneCycle(ctx context.Context) (int, error)
+}

--- a/pkg/prune/prune.go
+++ b/pkg/prune/prune.go
@@ -49,6 +49,11 @@ func (e *Executor) Run() error {
 
 	e.log.Info("Count of envelopes eligible for pruning", zap.Int64("count", deletableCount))
 
+	if deletableCount == 0 {
+		e.log.Info("No envelopes found for pruning")
+		return nil
+	}
+
 	if e.config.DryRun {
 		e.log.Info("Dry run mode enabled. Nothing to do")
 		return nil

--- a/pkg/prune/prune.go
+++ b/pkg/prune/prune.go
@@ -3,6 +3,7 @@ package prune
 import (
 	"context"
 	"database/sql"
+	"github.com/xmtp/xmtp-node-go/pkg/mls/store/queries"
 	"github.com/xmtp/xmtp-node-go/pkg/server"
 	"go.uber.org/zap"
 	"time"
@@ -30,13 +31,59 @@ func NewPruneExecutor(
 }
 
 func (e *Executor) Run() error {
-	// querier := queries.New(e.writerDB)
-	totalDeletionCount := 0
+	querier := queries.New(e.writerDB)
 	start := time.Now()
+
+	pruners := []Pruner{
+		&WelcomePruner{querier: querier},
+	}
+
+	var deletableCount = int64(0)
+	for _, pruner := range pruners {
+		prunerCount, err := pruner.Count(e.ctx)
+		if err != nil {
+			return err
+		}
+		deletableCount += prunerCount
+	}
+
+	e.log.Info("Count of envelopes eligible for pruning", zap.Int64("count", deletableCount))
 
 	if e.config.DryRun {
 		e.log.Info("Dry run mode enabled. Nothing to do")
 		return nil
+	}
+
+	var totalDeletionCount = 0
+
+	cyclesCompleted := 0
+
+	for {
+		if cyclesCompleted >= e.config.MaxCycles {
+			e.log.Warn("Reached maximum pruning cycles", zap.Int("maxCycles", e.config.MaxCycles))
+			break
+		}
+
+		deletedThisCycle := 0
+		for _, pruner := range pruners {
+			deleteCnt, err := pruner.PruneCycle(e.ctx)
+			if err != nil {
+				return err
+			}
+			deletedThisCycle += deleteCnt
+			totalDeletionCount += deleteCnt
+		}
+
+		if deletedThisCycle == 0 {
+			break
+		}
+
+		e.log.Info("Pruned expired envelopes batch", zap.Int("count", deletedThisCycle))
+		cyclesCompleted++
+	}
+
+	if totalDeletionCount == 0 {
+		e.log.Info("No expired envelopes found")
 	}
 
 	e.log.Info(

--- a/pkg/prune/welcomes.go
+++ b/pkg/prune/welcomes.go
@@ -1,0 +1,27 @@
+package prune
+
+import (
+	"context"
+	"github.com/xmtp/xmtp-node-go/pkg/mls/store/queries"
+)
+
+const DEFAULT_LIFETIME_OF_WELCOME_MESSAGES = 90
+
+type WelcomePruner struct {
+	querier *queries.Queries
+}
+
+func (w *WelcomePruner) Count(ctx context.Context) (int64, error) {
+	return w.querier.GetOldWelcomeMessages(ctx, DEFAULT_LIFETIME_OF_WELCOME_MESSAGES)
+}
+
+func (w *WelcomePruner) PruneCycle(ctx context.Context) (int, error) {
+	rows, err := w.querier.DeleteOldWelcomeMessagesBatch(ctx, DEFAULT_LIFETIME_OF_WELCOME_MESSAGES)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(rows), nil
+}
+
+var _ Pruner = (*WelcomePruner)(nil)


### PR DESCRIPTION
### Add welcome message metadata field and implement pruning system for welcome messages with 90-day default lifetime
- Adds `WelcomeMetadata` struct with `message_cursor` field to MLS API protocol buffer definitions and extends `WelcomeMessage_V1` and `WelcomeMessageInput_V1` to include `welcome_metadata` fields in [pkg/proto/mls/api/v1/mls.pb.go](https://github.com/xmtp/xmtp-node-go/pull/466/files#diff-5ed7751be26e2ce9bd5041cdddb78fc12094a863575aaea2b8de9ab8d47cd966)
- Modifies `MlsStore.InsertWelcomeMessage` method signature to accept `welcomeMetadata []byte` parameter and updates `QueryWelcomeMessagesV1` to return metadata in [pkg/mls/store/store.go](https://github.com/xmtp/xmtp-node-go/pull/466/files#diff-8ae91da76478f07e4469f3b427e850132f6e8cc6b048929f83c6ba9b4ddbadfd)
- Creates new SQL migration adding `welcome_metadata` BYTEA column to `welcome_messages` table and `insert_welcome_message_v4` function in [pkg/migrations/mls/20250625195628_add_welcome_metadata.up.sql](https://github.com/xmtp/xmtp-node-go/pull/466/files#diff-8582440b7b75b5d6fcc98b22ee2c4a6c89a2e361e26cefdb59b315b023b0ac50)
- Implements `Pruner` interface and `WelcomePruner` with 90-day default lifetime for pruning old welcome messages in [pkg/prune/welcomes.go](https://github.com/xmtp/xmtp-node-go/pull/466/files#diff-0181353a4bed4bda61da26f7c5a7c95249ecf75f2bf49e7bb1c0fd260b3f43b8)
- Creates new `prune` command-line tool with database connection and pruning executor in [cmd/prune/main.go](https://github.com/xmtp/xmtp-node-go/pull/466/files#diff-4039fdc6d104f56ad8d0fb6dbbbabe36a2b635478cc1def051fadd4a868aa524)
- Updates `SendWelcomeMessages` method to use `errgroup` for concurrent processing and include welcome metadata in storage and publishing in [pkg/mls/api/v1/service.go](https://github.com/xmtp/xmtp-node-go/pull/466/files#diff-6d11ce32bdc179716d251a2646ec61f8b921f7d7eecd5e50d98b9ce1592287b4)

#### 📍Where to Start
Start with the `SendWelcomeMessages` method in [pkg/mls/api/v1/service.go](https://github.com/xmtp/xmtp-node-go/pull/466/files#diff-6d11ce32bdc179716d251a2646ec61f8b921f7d7eecd5e50d98b9ce1592287b4) to understand how welcome messages are processed with the new metadata field.

----

_[Macroscope](https://app.macroscope.com) summarized e4358c2._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of old welcome messages, removing those older than 90 days in batches.
  * Included support for additional metadata in welcome messages.

* **Improvements**
  * Enhanced performance and reliability of welcome message management with new batch deletion and counting capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->