### PR TITLE
Fix dev/up and dev/run

### DIFF
--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -1,4 +1,10 @@
 services:
+  validation:
+    image: ghcr.io/xmtp/mls-validation-service:main
+    platform: linux/amd64
+    ports:
+      - 60051:50051
+
   message-db:
     image: postgres:13
     environment:

--- a/dev/psql
+++ b/dev/psql
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+PGPASSWORD=xmtp psql --host=localhost --port=7654 -U postgres

--- a/dev/run
+++ b/dev/run
@@ -11,11 +11,12 @@ go run cmd/xmtpd/main.go \
     --metrics \
     --metrics-period 5s \
     --store.enable \
+    --api.enable-mls \
     --store.db-connection-string "${MESSAGE_DB_DSN}" \
     --store.reader-db-connection-string "${MESSAGE_DB_DSN}" \
     --store.metrics-period 5s \
     --mls-store.db-connection-string "${MLS_DB_DSN}" \
-    --mls-validation.grpc-address=validation:50051 \
+    --mls-validation.grpc-address=localhost:60051 \
     --authz-db-connection-string "${AUTHZ_DB_DSN}" \
     --go-profiling \
     "$@"

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/xmtp/go-msgio v0.2.1-0.20220510223757-25a701b79cd3
 	github.com/yoheimuta/protolint v0.39.0
 	go.uber.org/zap v1.24.0
+	golang.org/x/sync v0.3.0
 	google.golang.org/genproto v0.0.0-20230223222841-637eb2293923
 	google.golang.org/grpc v1.53.0
 	google.golang.org/protobuf v1.31.0
@@ -43,7 +44,6 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
-	golang.org/x/sync v0.3.0 // indirect
 )
 
 require (


### PR DESCRIPTION
### Fix dev/up and dev/run by adding MLS validation service to Docker Compose and updating run script configuration
- Adds `validation` service to [docker-compose.yml](https://github.com/xmtp/xmtp-node-go/pull/468/files#diff-6a25daaa729d7279e0cda8eb92399f1a82d4a91f961e1955bb5745e9c99f3c6e) using `ghcr.io/xmtp/mls-validation-service:main` image with port mapping from host 60051 to container 50051
- Modifies [dev/run](https://github.com/xmtp/xmtp-node-go/pull/468/files#diff-71d92c070793d886ac0d3b56c477078f018800dc6167bb8065c2f221b9879e84) script to enable `--api.enable-mls` flag and changes `--mls-validation.grpc-address` from `validation:50051` to `localhost:60051`
- Creates [dev/psql](https://github.com/xmtp/xmtp-node-go/pull/468/files#diff-b81eb6d57200a253dd51726a4ef65a790ff75205f6e270a3cc005f78df58bfb8) utility script for PostgreSQL database connection with predefined credentials
- Changes `golang.org/x/sync v0.3.0` from indirect to direct dependency in [go.mod](https://github.com/xmtp/xmtp-node-go/pull/468/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6)

#### 📍Where to Start
Start with the [dev/run](https://github.com/xmtp/xmtp-node-go/pull/468/files#diff-71d92c070793d886ac0d3b56c477078f018800dc6167bb8065c2f221b9879e84) script to understand the command-line flag changes and MLS validation service address update.

----

_[Macroscope](https://app.macroscope.com) summarized 0fc87d9._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new validation service to the Docker Compose setup, enabling additional validation capabilities.
  * Introduced a convenient script for connecting to the local PostgreSQL database.

* **Enhancements**
  * Updated application startup configuration to enable MLS API functionality and adjust validation service connection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->