### PR TITLE
CD Deploy Node-go to TF DEV

### DIFF
--- a/.github/workflows/build-node-go.yml
+++ b/.github/workflows/build-node-go.yml
@@ -86,23 +86,22 @@ jobs:
         id: set_xmtpd_digest
         run: echo "digest=${{ steps.push.outputs.digest }}" >> $GITHUB_OUTPUT
 
-# TODO(mkysel): figure out deploy once we are ready
-#  deploy:
-#    name: Deploy new images to infra
-#    runs-on: ubuntu-latest
-#    needs: push_to_registry
-#    if: github.ref == 'refs/heads/main'
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v4
-#      - name: Deploy Testnet
-#        uses: xmtp-labs/terraform-deployer@v1
-#        timeout-minutes: 45
-#        with:
-#          timeout: 45m
-#          terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
-#          terraform-org: xmtp
-#          terraform-workspace: testnet-staging
-#          variable-name: xmtpd_server_docker_image
-#          variable-value: "ghcr.io/xmtp/xmtpd@${{ needs.push_to_registry.outputs.xmtpd_digest }}"
-#          variable-value-required-prefix: "ghcr.io/xmtp/xmtpd@sha256:"
+  deploy:
+    name: Deploy new images to infra
+    runs-on: ubuntu-latest
+    needs: push_to_registry
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Deploy Dev
+        uses: xmtp-labs/terraform-deployer@v1
+        timeout-minutes: 45
+        with:
+          timeout: 45m
+          terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
+          terraform-org: xmtp
+          terraform-workspace: dev
+          variable-name: xmtp_node_image
+          variable-value: "ghcr.io/xmtp/node-go@${{ needs.push_to_registry.outputs.xmtpd_digest }}"
+          variable-value-required-prefix: "ghcr.io/xmtp/node-go@sha256:"


### PR DESCRIPTION
### Enable automatic deployment of node-go Docker images to TF DEV environment in GitHub workflow
The GitHub workflow [build-node-go.yml](https://github.com/xmtp/xmtp-node-go/pull/471/files#diff-e3a5d88d254b23911cc21109d780bd3ac7d6f48bab824d3e5aceb7985671b61a) activates a previously commented-out `deploy` job that automatically deploys new Docker images to infrastructure when changes are pushed to the main branch. The deployment configuration changes the target environment from `Testnet` to `Dev`, updates the terraform workspace from `testnet-staging` to `dev`, changes the variable name from `xmtpd_server_docker_image` to `xmtp_node_image`, and updates the Docker image path from `ghcr.io/xmtp/xmtpd` to `ghcr.io/xmtp/node-go`.

#### 📍Where to Start
Start with the uncommented `deploy` job in [build-node-go.yml](https://github.com/xmtp/xmtp-node-go/pull/471/files#diff-e3a5d88d254b23911cc21109d780bd3ac7d6f48bab824d3e5aceb7985671b61a).

----

_[Macroscope](https://app.macroscope.com) summarized 46f016a._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reactivated and updated the automated deployment process for the development environment. Deployments now use the latest Docker image and are triggered automatically from the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->