### PR TITLE
Add more logging to welcome sending

### DIFF
--- a/pkg/mls/api/v1/service.go
+++ b/pkg/mls/api/v1/service.go
@@ -359,6 +359,7 @@ func (s *Service) SendWelcomeMessages(
 						if mlsstore.IsAlreadyExistsError(err) {
 							return nil
 						}
+						log.Error("error inserting welcome message", zap.Error(err))
 						return status.Errorf(codes.Internal, "failed to insert message: %s", err)
 					}
 
@@ -376,6 +377,7 @@ func (s *Service) SendWelcomeMessages(
 						},
 					})
 					if err != nil {
+						log.Error("error publishing welcome to waku relay", zap.Error(err))
 						return err
 					}
 


### PR DESCRIPTION
### TL;DR

Added error logging for welcome message failures in MLS service.

### What changed?

Added two error log statements in the `SendWelcomeMessages` function:
1. When inserting a welcome message fails
2. When publishing a welcome message to Waku relay fails

### How to test?

1. Trigger scenarios where welcome message insertion fails
2. Trigger scenarios where publishing to Waku relay fails
3. Verify that appropriate error logs appear in the logs with the error details

### Why make this change?

Improves observability by adding explicit error logging for welcome message failures. This will help with debugging issues related to welcome message delivery in the MLS service, making it easier to identify the root cause when problems occur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved error logging for issues encountered during the sending of welcome messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->