### PR TITLE
Parametrize batch size for pruner and 10x default

### DIFF
--- a/pkg/mls/store/queries.sql
+++ b/pkg/mls/store/queries.sql
@@ -249,7 +249,7 @@ WITH to_delete AS (
     FROM welcome_messages
     WHERE created_at < NOW() - make_interval(days := @age_days)
     ORDER BY id
-    LIMIT 1000
+    LIMIT @batch_size
     FOR UPDATE SKIP LOCKED
             )
 DELETE FROM welcome_messages wm

--- a/pkg/prune/prune.go
+++ b/pkg/prune/prune.go
@@ -36,6 +36,7 @@ func (e *Executor) Run() error {
 	start := time.Now()
 
 	pruners := []Pruner{
+		NewWelcomePruner(e.log, querier, e.config.BatchSize),
 		&WelcomePruner{log: e.log, querier: querier},
 	}
 

--- a/pkg/prune/prune.go
+++ b/pkg/prune/prune.go
@@ -37,7 +37,6 @@ func (e *Executor) Run() error {
 
 	pruners := []Pruner{
 		NewWelcomePruner(e.log, querier, e.config.BatchSize),
-		&WelcomePruner{log: e.log, querier: querier},
 	}
 
 	if e.config.CountDeletable {

--- a/pkg/server/logger.go
+++ b/pkg/server/logger.go
@@ -20,13 +20,14 @@ func BuildLogger(options LogOptions, named string) (*zap.Logger, *zap.Config, er
 		OutputPaths:      []string{"stdout"},
 		ErrorOutputPaths: []string{"stderr"},
 		EncoderConfig: zapcore.EncoderConfig{
-			MessageKey:   "message",
-			LevelKey:     "level",
-			EncodeLevel:  zapcore.CapitalLevelEncoder,
-			TimeKey:      "time",
-			EncodeTime:   zapcore.ISO8601TimeEncoder,
-			NameKey:      "caller",
-			EncodeCaller: zapcore.ShortCallerEncoder,
+			MessageKey:     "message",
+			LevelKey:       "level",
+			EncodeLevel:    zapcore.CapitalLevelEncoder,
+			TimeKey:        "time",
+			EncodeTime:     zapcore.ISO8601TimeEncoder,
+			NameKey:        "caller",
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+			EncodeDuration: zapcore.StringDurationEncoder,
 		},
 	}
 	log, err := cfg.Build()

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -45,9 +45,10 @@ type AuthzOptions struct {
 }
 
 type PruneConfig struct {
-	MaxCycles      int  `long:"max-prune-cycles" description:"Maximum pruning cycles"                   default:"10"`
-	CountDeletable bool `long:"count-deletable"  description:"Attempt to count all deletable envelopes"`
-	DryRun         bool `long:"dry-run"          description:"Dry run mode"`
+	MaxCycles      int   `long:"max-prune-cycles" description:"Maximum pruning cycles"                   default:"10"`
+	BatchSize      int32 `long:"batch-size"       description:"Batch size"                               default:"10000"`
+	CountDeletable bool  `long:"count-deletable"  description:"Attempt to count all deletable envelopes"`
+	DryRun         bool  `long:"dry-run"          description:"Dry run mode"`
 }
 
 type PruneOptions struct {


### PR DESCRIPTION
_Macroscope is automatically generating a new summary of this pull request including the latest commits..._

<picture>
<source media="(prefers-color-scheme: dark)" srcset="https://prasso.ai/static/prassoai-pr-loader-small-dark-no-text.gif">
<img src="https://prasso.ai/static/prassoai-pr-loader-small-light-no-text.gif" alt="_Macroscope is automatically generating a new summary of this pull request including the latest commits..._">
</picture>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable batch size option for pruning old welcome messages, allowing users to control how many messages are deleted per cycle.
  * Batch size for pruning can now be set via configuration with a default value of 10,000.

* **Improvements**
  * Log entries now display durations as strings for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->