### PR TITLE
Missing buf for nightly protos

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,11 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
-      - name: Download buf v1.50.0
-        run: |
-          curl -sSL https://github.com/bufbuild/buf/releases/download/v1.50.0/buf-Linux-x86_64 -o /usr/local/bin/buf
-          chmod +x /usr/local/bin/buf
-
+      - uses: bufbuild/buf-setup-action@v1.50.0
       - name: Verify buf installation
         run: buf --version
       - name: Generate Protos

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
+      - name: Download buf v1.50.0
+        run: |
+          curl -sSL https://github.com/bufbuild/buf/releases/download/v1.50.0/buf-Linux-x86_64 -o /usr/local/bin/buf
+          chmod +x /usr/local/bin/buf
+
+      - name: Verify buf installation
+        run: buf --version
       - name: Generate Protos
         run: dev/gen/protos
       - name: Create Pull Request


### PR DESCRIPTION
### Add buf v1.50.0 installation steps to GitHub Actions nightly workflow to resolve missing buf dependency for proto generation
The GitHub Actions nightly workflow now includes two new steps that download and verify buf v1.50.0 before the existing proto generation step. The workflow uses `curl` to download the buf binary and runs `buf --version` to confirm successful installation in [.github/workflows/nightly.yml](https://github.com/xmtp/xmtp-node-go/pull/502/files#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6).

#### 📍Where to Start
Start with the new buf installation steps in [.github/workflows/nightly.yml](https://github.com/xmtp/xmtp-node-go/pull/502/files#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6) that were added before the 'Generate Protos' step.

----

_[Macroscope](https://app.macroscope.com) summarized 3b0cfcd._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the nightly automation workflow to ensure the required tool is installed and verified before generating protocol buffers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->