### PR TITLE
Fix invalid option

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -28,7 +28,7 @@ type Options struct {
 	Authn             AuthnOptions `                                                                                                     group:"API Authentication Options" namespace:"authn"`
 	MaxMsgSize        int          `long:"max-msg-size"        description:"Max message size in bytes (default 50MB)" default:"52428800"`
 	EnableMLS         bool         `long:"enable-mls"          description:"Enable the MLS server"`
-	DisableMLSPublish bool         `long:"disable-mls-publish" description:"Disable MLS publish"                      default:"false"`
+	DisableMLSPublish bool         `long:"disable-mls-publish" description:"Disable MLS publish"`
 }
 
 type Config struct {


### PR DESCRIPTION
### TL;DR

Removed the default value for the `disable-mls-publish` flag in the API configuration.

### What changed?

Removed the explicit `default:"false"` setting from the `DisableMLSPublish` boolean option in the API configuration. Since boolean values in Go default to `false` when not specified, this change removes redundant configuration while maintaining the same behavior.

### How to test?

1. Verify that the MLS publish functionality works as expected when the flag is not specified
2. Confirm that setting `--disable-mls-publish` still properly disables MLS publishing

### Why make this change?

This change improves code clarity by removing a redundant default value specification. Since Go booleans already default to `false`, explicitly setting the default to `false` was unnecessary and could be confusing to readers of the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated command-line flag metadata by removing the explicit default value for an option related to publishing. No changes to the actual behavior or logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->