### PR TITLE
Do a proper delete of gen protos and re-run with newest (V3)

### DIFF
--- a/dev/gen/protos
+++ b/dev/gen/protos
@@ -8,7 +8,7 @@ cd "${repo_root}" || exit
 BRANCH=${PROTO_BRANCH:-main}
 echo "Generating protos from branch ${BRANCH}..."
 
-rm -rf pkg/proto/**/*.pb.go pkg/proto/**/*.pb.gw.go pkg/proto/**/*.swagger.json
+find pkg/proto -type f \( -name "*.pb.go" -o -name "*.pb.gw.go" -o -name "*.swagger.json" \) -exec rm -f {} +
 if ! buf generate https://github.com/xmtp/proto.git#subdir=proto,branch="${BRANCH}"; then
     echo "Failed to generate protobuf definitions"
     exit 1


### PR DESCRIPTION
### Update generated MLS protos to V3 and change `dev/gen/protos` to delete matched artifacts via `find` within `pkg/proto`
This change regenerates MLS protobufs to V3 and switches the cleanup logic to use `find` for targeted deletion of generated artifacts.

- Replace recursive `rm` and globs with a `find`-based deletion in [dev/gen/protos](https://github.com/xmtp/xmtp-node-go/pull/526/files#diff-21a923909b3197fa23f97144efacd0dadf69b75d25da824c92d566842cd2db38) limited to `pkg/proto/*.pb.go`, `*.pb.gw.go`, and `*.swagger.json`.
- Add `ReaddInstallationsData` and `ReaddInstallationsData_V1`, deprecate two oneof variants, and increase message count from 21 to 23 in [intents.pb.go](https://github.com/xmtp/xmtp-node-go/pull/526/files#diff-a3e283c67f4c0eb4d8bf1f0db6ceabcc9acbcf7a3026b79e3ce1fa4018e80f66).
- Remove `PlaintextEnvelope_V2_ReaddRequest` and its accessor, and drop the out_of_band dependency in [content.pb.go](https://github.com/xmtp/xmtp-node-go/pull/526/files#diff-ec26b2d8741496536d697de0ba49294ef6f6a364140ccc1f5cf8d8b100371c7e).
- Add `CONVERSATION_TYPE_ONESHOT` and `oneshot_message` to `GroupMetadataV1` in [group_metadata.pb.go](https://github.com/xmtp/xmtp-node-go/pull/526/files#diff-a720c4b50fbca936ef4366a72f3dcface211a87c76d62049599c02c5c1d27cff).
- Remove `commit_log_signer` from `GroupMutableMetadataV1` in [group_mutable_metadata.pb.go](https://github.com/xmtp/xmtp-node-go/pull/526/files#diff-767cacf885c47f9e374d05d06723d2264413c9395fba7d244803a34db207ae66).
- Delete generated files [out_of_band.pb.go](https://github.com/xmtp/xmtp-node-go/pull/526/files#diff-ae46cd42e27a99361798e7078083a92b42e7eed7458ca7d09cd4929c92207551) and Swagger specs: [association.swagger.json](https://github.com/xmtp/xmtp-node-go/pull/526/files#diff-b8798558c6d9a705770d93c0c234e1efb8751dd4b84bd432a4fd6e36061f5207), [credential.swagger.json](https://github.com/xmtp/xmtp-node-go/pull/526/files#diff-d483f1200f1f8ed44691bf9d740fdfea6962e08ac403d3b6fde13937274a2ff7), [encryption.swagger.json](https://github.com/xmtp/xmtp-node-go/pull/526/files#diff-143b53ad4cb531b7d2b354dfb63381c27574041fd93d65925ad08dbf0ef62ab1), and [out_of_band.swagger.json](https://github.com/xmtp/xmtp-node-go/pull/526/files#diff-0cfdae9e0a2cd7a92404f9e1ba0285bd63f4c4a26cfb49706c62658d5d6592e9).

#### 📍Where to Start
Start with the cleanup script changes in [dev/gen/protos](https://github.com/xmtp/xmtp-node-go/pull/526/files#diff-21a923909b3197fa23f97144efacd0dadf69b75d25da824c92d566842cd2db38), then review generated proto updates beginning at [pkg/proto/mls/database/intents.pb.go](https://github.com/xmtp/xmtp-node-go/pull/526/files#diff-a3e283c67f4c0eb4d8bf1f0db6ceabcc9acbcf7a3026b79e3ce1fa4018e80f66) to follow message additions and deprecations.

----

_[Macroscope](https://app.macroscope.com) summarized 40ec304._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Removed deprecated OpenAPI/Swagger v2 documentation for multiple message content types with no defined endpoints.
  - Corrected the displayed title of the “oneshot” API spec for accuracy.
- Chores
  - Cleaned up obsolete API documentation artifacts to reduce clutter.

No functional changes to the product experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->