### PR TITLE
Add more logging for identity endpoints

### DIFF
--- a/pkg/identity/api/v1/identity_service.go
+++ b/pkg/identity/api/v1/identity_service.go
@@ -96,7 +96,12 @@ func (s *Service) PublishIdentityUpdate(
 		)
 	}
 
-	return s.store.PublishIdentityUpdate(ctx, req, s.validationService)
+	res, err := s.store.PublishIdentityUpdate(ctx, req, s.validationService)
+	if err != nil {
+		s.log.Error("error publishing identity update", zap.Error(err))
+		return nil, err
+	}
+	return res, nil
 }
 
 func (s *Service) GetIdentityUpdates(
@@ -108,7 +113,12 @@ func (s *Service) GetIdentityUpdates(
 		1. Query the inbox_log table for the inbox_id, ordering by sequence_id
 		2. Return all of the entries
 	*/
-	return s.store.GetInboxLogs(ctx, req)
+	res, err := s.store.GetInboxLogs(ctx, req)
+	if err != nil {
+		s.log.Error("error getting inbox logs", zap.Error(err))
+		return nil, err
+	}
+	return res, nil
 }
 
 func (s *Service) GetInboxIds(
@@ -121,12 +131,22 @@ func (s *Service) GetInboxIds(
 		   for the address where revocation_sequence_id is lower or NULL
 		2. Return the value of the 'inbox_id' column
 	*/
-	return s.store.GetInboxIds(ctx, req)
+	res, err := s.store.GetInboxIds(ctx, req)
+	if err != nil {
+		s.log.Error("error getting inbox ids", zap.Error(err))
+		return nil, err
+	}
+	return res, nil
 }
 
 func (s *Service) VerifySmartContractWalletSignatures(
 	ctx context.Context,
 	req *identityV1.VerifySmartContractWalletSignaturesRequest,
 ) (*identityV1.VerifySmartContractWalletSignaturesResponse, error) {
-	return s.validationService.VerifySmartContractWalletSignatures(ctx, req)
+	res, err := s.validationService.VerifySmartContractWalletSignatures(ctx, req)
+	if err != nil {
+		s.log.Error("error verifying smart contract wallet signatures", zap.Error(err))
+		return nil, err
+	}
+	return res, nil
 }


### PR DESCRIPTION
### TL;DR

Added error logging to identity service methods.

### What changed?

Enhanced error handling in the identity service by adding explicit error logging with zap. Modified the following methods to log errors before returning them to the caller:
- `PublishIdentityUpdate`
- `GetIdentityUpdates`
- `GetInboxIds`
- `VerifySmartContractWalletSignatures`

Each method now logs the specific error with context about which operation failed.

### How to test?

1. Trigger error conditions in each of the modified methods
2. Verify that appropriate error logs appear with the correct context message
3. Confirm that error responses are still properly returned to clients

### Why make this change?

This change improves observability by ensuring errors in the identity service are properly logged before being returned to the caller. This will make debugging issues easier by providing more context in logs when operations fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and logging across identity update operations, inbox retrieval, and smart contract wallet verification processes to improve system stability and provide clearer error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->