### PR TITLE
Fix segfault - defensive programming in SubscribeWelcomeMessages

### DIFF
--- a/pkg/mls/api/v1/streaming_test.go
+++ b/pkg/mls/api/v1/streaming_test.go
@@ -774,7 +774,6 @@ func TestStreaming_ErrorHandling(t *testing.T) {
 		stream.EXPECT().
 			SendHeader(metadata.New(map[string]string{"subscribed": "true"})).
 			Return(nil)
-		stream.EXPECT().Context().Return(ctx)
 
 		err := svc.SubscribeWelcomeMessages(&mlsv1.SubscribeWelcomeMessagesRequest{
 			Filters: []*mlsv1.SubscribeWelcomeMessagesRequest_Filter{


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Guard `mls.api.v1.Service.SubscribeWelcomeMessages` to prevent segfaults by validating nil requests and invalid filters in [service.go](https://github.com/xmtp/xmtp-node-go/pull/533/files#diff-6d11ce32bdc179716d251a2646ec61f8b921f7d7eecd5e50d98b9ce1592287b4)
Add request and filter validation in `mls.api.v1.Service.SubscribeWelcomeMessages`, sanitize filters, skip nil envelopes/messages during streaming, stop historical fetch when responses are empty or paging is exhausted, and adjust error logging. Update tests to use `require` assertions in [streaming_test.go](https://github.com/xmtp/xmtp-node-go/pull/533/files#diff-fcaebbde03f3a5464e73ef37940961b4ddd3aaee3fcda10aac6b1d949dabd50d).

#### 📍Where to Start
Start in the `mls.api.v1.Service.SubscribeWelcomeMessages` handler in [service.go](https://github.com/xmtp/xmtp-node-go/pull/533/files#diff-6d11ce32bdc179716d251a2646ec61f8b921f7d7eecd5e50d98b9ce1592287b4), then follow `sendToStream` and `fetchHistorical` for validation and pagination changes.

<!-- Macroscope's changelog starts here -->
#### Changes since #533 opened

- Modified `Service.SubscribeWelcomeMessages` grpc handler to add early validation and rework filter handling logic [fb3532d]
- Updated test expectations in `TestStreaming_ErrorHandling` to reflect earlier validation behavior [fb3532d]
<!-- Macroscope's changelog ends here -->

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fb3532d. 1 file reviewed, 2 issues evaluated, 2 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>pkg/mls/api/v1/service.go — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 529](https://github.com/xmtp/xmtp-node-go/blob/fb3532d1dea935b347b38156e9bca1642e2e3b4c/pkg/mls/api/v1/service.go#L529): The handler sends a gRPC header `("subscribed", "true")` before validating the request (filters present and non-empty installation keys). If validation fails, the method returns an error after sending this header, which may mislead clients that interpret the header as an indication of a successful subscription. This creates a potential externally visible contract inconsistency: clients receive a "subscribed" header but the call is rejected. Given the comment, this may be intentional for client compatibility, but it can still cause confusion. <b>[ Low confidence ]</b>
- [line 569](https://github.com/xmtp/xmtp-node-go/blob/fb3532d1dea935b347b38156e9bca1642e2e3b4c/pkg/mls/api/v1/service.go#L569): The `SubscribeWelcomeMessages` handler silently drops non-V1 welcome messages (e.g., `WelcomeMessage_WelcomePointer`) on both historical and live paths. In `sendToStream`, the code calls `msg.GetV1()` and if it returns `nil` (which it will for pointer variant messages), it logs "welcome message is nil, skipping" and continues without sending the message to the client. This causes an externally visible contract mismatch: `QueryWelcomeMessagesV1` explicitly returns both V1 and pointer variants, but `SubscribeWelcomeMessages` only forwards V1, thereby losing data for clients that subscribe to welcome messages. This is a runtime behavioral bug (silent data loss) and breaks parity between the query API and the subscription API. <b>[ Already posted ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming and historical fetch reliability with additional validation and defensive checks to avoid runtime errors, dropped messages, and malformed payloads.
  * Stronger filter sanitization and clearer error handling when no valid filters are provided; subscriptions and message streaming now use validated filters.
  * More robust welcome and envelope handling to skip or halt on malformed or missing messages gracefully.

* **Tests**
  * Strengthened assertions to fail fast on errors and improve test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->