### PR TITLE
Reduce logging

### DIFF
--- a/pkg/api/interceptor.go
+++ b/pkg/api/interceptor.go
@@ -116,7 +116,7 @@ func (rli *RateLimitInterceptor) applyLimits(
 	}
 
 	if err := rli.limiter.Spend(limitType, bucket, uint16(cost), isPriority); err != nil {
-		rli.log.Info("rate limited",
+		rli.log.Debug("rate limited",
 			logging.String("client_ip", ip),
 			logging.Bool("priority", isPriority),
 			logging.String("method", method),

--- a/pkg/api/telemetry.go
+++ b/pkg/api/telemetry.go
@@ -76,16 +76,21 @@ func (ti *TelemetryInterceptor) record(
 	logFn := ti.log.Debug
 
 	if err != nil {
-		logFn = ti.log.Info
 		fields = append(fields, zap.Error(err))
 		grpcErr, _ := status.FromError(err)
 		if grpcErr != nil {
-			errCode := grpcErr.Code().String()
+			if grpcErr.Code() == codes.ResourceExhausted ||
+				grpcErr.Code() == codes.InvalidArgument {
+				logFn = ti.log.Debug
+			} else {
+				logFn = ti.log.Error
+			}
 			fields = append(fields, []zapcore.Field{
-				zap.String("error_code", errCode),
+				zap.String("error_code", grpcErr.Code().String()),
 				zap.String("error_message", grpcErr.Message()),
 			}...)
 		} else {
+			logFn = ti.log.Error
 			fields = append(fields, []zapcore.Field{
 				zap.String("error_code", codes.Internal.String()),
 				zap.String("error_message", err.Error()),

--- a/pkg/mls/api/v1/service.go
+++ b/pkg/mls/api/v1/service.go
@@ -405,7 +405,7 @@ func (s *Service) SubscribeGroupMessages(
 	}
 
 	log := s.log.Named("subscribe-group-messages").With(zap.Int("filters", len(req.Filters)))
-	log.Info("subscription started")
+	log.Debug("subscription started")
 	// Send a header (any header) to fix an issue with Tonic based GRPC clients.
 	// See: https://github.com/xmtp/libxmtp/pull/58
 	_ = stream.SendHeader(metadata.Pairs("subscribed", "true"))
@@ -567,7 +567,7 @@ func (s *Service) SubscribeWelcomeMessages(
 	}
 
 	log := s.log.Named("subscribe-welcome-messages").With(zap.Int("filters", len(req.Filters)))
-	log.Info("subscription started")
+	log.Debug("subscription started")
 
 	// Send a header (any header) to fix an issue with Tonic based GRPC clients.
 	// See: https://github.com/xmtp/libxmtp/pull/58

--- a/pkg/mls/store/backfiller_group_messages.go
+++ b/pkg/mls/store/backfiller_group_messages.go
@@ -196,7 +196,7 @@ func (b *IsCommitBackfiller) Run() {
 						}
 
 						if len(ids) == 0 {
-							b.log.Info("No messages to classify")
+							b.log.Debug("No messages to classify")
 							foundMessages = false
 							return nil
 						}

--- a/pkg/mls/store/backfiller_installations.go
+++ b/pkg/mls/store/backfiller_installations.go
@@ -84,7 +84,7 @@ func (b *InstallationsBackfiller) Run() {
 						}
 
 						if len(installations) == 0 {
-							b.log.Info("No installations to backfill")
+							b.log.Debug("No installations to backfill")
 							foundMessages = false
 							return nil
 						}

--- a/pkg/mls/store/store.go
+++ b/pkg/mls/store/store.go
@@ -187,14 +187,14 @@ func (s *Store) PublishIdentityUpdate(
 			IdentityUpdateProto: protoBytes,
 		})
 
-		log.Info("Inserted inbox log", zap.Any("sequence_id", sequence_id))
+		log.Debug("Inserted inbox log", zap.Any("sequence_id", sequence_id))
 
 		if err != nil {
 			return err
 		}
 
 		for _, new_member := range state.StateDiff.NewMembers {
-			log.Info("New member", zap.Any("member", new_member))
+			log.Debug("New member", zap.Any("member", new_member))
 			if address, ok := new_member.Kind.(*associations.MemberIdentifier_EthereumAddress); ok {
 				_, err = txQueries.InsertAddressLog(ctx, queries.InsertAddressLogParams{
 					Address:               address.EthereumAddress,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Reduce log verbosity for rate limiting, subscriptions, and backfill workers
Downgrades several high-frequency log statements from Info to Debug across multiple packages to reduce noise in production logs.

- In [interceptor.go](https://github.com/xmtp/xmtp-node-go/pull/556/files#diff-67d229c52434ff3934aa5a96707a41539b637297d757fff76ff9912e00d9cdd3), rate-limited gRPC requests now log at Debug instead of Info.
- In [telemetry.go](https://github.com/xmtp/xmtp-node-go/pull/556/files#diff-becfc2eb1fd01d33c96dacb5ab700195278c452239545f287d41ff6ddf544ac6), `ResourceExhausted` and `InvalidArgument` errors now log at Debug; all other errors log at Error (previously Info).
- In [service.go](https://github.com/xmtp/xmtp-node-go/pull/556/files#diff-6d11ce32bdc179716d251a2646ec61f8b921f7d7eecd5e50d98b9ce1592287b4), subscription start events for group and welcome messages now log at Debug.
- In [store.go](https://github.com/xmtp/xmtp-node-go/pull/556/files#diff-8ae91da76478f07e4469f3b427e850132f6e8cc6b048929f83c6ba9b4ddbadfd) and the backfiller workers, inbox log insertions, new member entries, and "nothing to process" states now log at Debug.
- Behavioral Change: error-level logging is now used for most gRPC failures in the telemetry interceptor, which is an increase in severity for non-rate-limit errors.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31e770e.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->