### PR TITLE
feat(api): register gRPC server reflection

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/health"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/reflection"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -140,6 +141,7 @@ func (s *Server) startGRPC() error {
 	grpcServer := grpc.NewServer(options...)
 	healthcheck := health.NewServer()
 	healthgrpc.RegisterHealthServer(grpcServer, healthcheck)
+	reflection.Register(grpcServer)
 
 	publishToWakuRelay := func(ctx context.Context, msg *wakupb.WakuMessage) error {
 		_, err := s.Waku.Relay().Publish(ctx, msg)


### PR DESCRIPTION
## Summary

Register `google.golang.org/grpc/reflection` on the v1 node's gRPC server, matching xmtpd's public-endpoint behavior.

- `xmtpd/pkg/api/server.go` already registers both v1 and v1alpha reflection (lines 157, 222, 228) and even wraps the handler in h2c specifically so reflection works.
- Reflection is live on the production testnet endpoint today — `grpcurl grpc.testnet.xmtp.network:443 list` returns the full service list.
- The v1 node (`xmtp-node-go`) does **not** register reflection, so the same `grpcurl list` command against `grpc.dev.xmtp.network:443` returns `server does not support the reflection API`.

This PR closes that asymmetry. The change is two lines: one import, one registration call next to the existing `healthgrpc.RegisterHealthServer`.

## Why

Operational debugging and connectivity probes against the v1 endpoint currently require carrying a hand-built `.protoset` to invoke even the standard health-check method. Reflection eliminates that. The information it exposes (service and method descriptors) is already public via the open-source repo and SDKs, so there is no new disclosure — the precedent has been set by xmtpd shipping it publicly.

## Test plan

- [ ] CI builds clean
- [ ] After merge + deploy to dev, `grpcurl grpc.dev.xmtp.network:443 list` returns the registered services instead of the reflection error
- [ ] `grpcurl grpc.dev.xmtp.network:443 grpc.health.v1.Health/Check` returns `SERVING` without a `-protoset` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Register gRPC server reflection in `api.Server`
> Calls `reflection.Register(grpcServer)` in [server.go](https://github.com/xmtp/xmtp-node-go/pull/560/files#diff-734f9c34b34af099d24da13054e167f7df72706dc733edf21c61c0cc1548224a) after health server registration, enabling clients to query service and method metadata at runtime using standard gRPC reflection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f644365.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->