### PR TITLE
fix(mls/api): XIP-83 Subscribe — flush send-error, history_only overlap, reusable send timer

### DIFF
--- a/pkg/mls/api/v1/subscribe.go
+++ b/pkg/mls/api/v1/subscribe.go
@@ -209,7 +209,15 @@ func (s *Service) Subscribe(stream mlsv1.MlsApi_SubscribeServer) error {
 		closeOutbound()
 		select {
 		case <-senderDone:
-			return nil // the sender drained every queued frame
+			// The sender finished — but it may have stopped early on a Send error, leaving the
+			// wave's terminal frames (history tail + CatchupComplete) unsent. Surface that rather
+			// than a false OK that misleads the client into believing the drain completed.
+			select {
+			case err := <-sendErrCh:
+				return err
+			default:
+				return nil
+			}
 		case <-ctx.Done():
 			return nil // client disconnected; gRPC surfaces the cancellation
 		case <-time.After(s.pongDeadline):
@@ -229,6 +237,12 @@ func (s *Service) Subscribe(stream mlsv1.MlsApi_SubscribeServer) error {
 	// writer calls it, in order. lastActivity advances when a batch is accepted by the sender
 	// and is what gates the liveness Ping, so the Ping probes the client's receive path on a
 	// send-idle schedule (it is deliberately NOT reset by inbound frames — see requestChannel).
+	// sendTimer bounds a single send(); reused across calls (send runs only on the writer
+	// goroutine) instead of allocating a time.After timer — live for the whole deadline — on
+	// every send under high throughput.
+	sendTimer := time.NewTimer(s.pongDeadline)
+	stopTimer(sendTimer)
+	defer sendTimer.Stop()
 	send := func(batches ...[]*mlsv1.SubscribeResponse) error {
 		var flat []*mlsv1.SubscribeResponse
 		for _, batch := range batches {
@@ -237,6 +251,8 @@ func (s *Service) Subscribe(stream mlsv1.MlsApi_SubscribeServer) error {
 		if len(flat) == 0 {
 			return nil
 		}
+		sendTimer.Reset(s.pongDeadline)
+		defer stopTimer(sendTimer)
 		select {
 		case outbound <- flat:
 			lastActivity = time.Now()
@@ -247,7 +263,7 @@ func (s *Service) Subscribe(stream mlsv1.MlsApi_SubscribeServer) error {
 			return nil
 		case <-s.ctx.Done():
 			return status.Errorf(codes.Unavailable, "service is shutting down")
-		case <-time.After(s.pongDeadline):
+		case <-sendTimer.C:
 			return status.Errorf(codes.Unavailable, "send stalled; client not reading")
 		}
 	}
@@ -745,6 +761,20 @@ func (s *Service) Subscribe(stream mlsv1.MlsApi_SubscribeServer) error {
 				newlyLive := 0
 				for _, t := range addOrder {
 					a := addByTopic[t]
+					// A topic with an in-flight history_only catch-up has an active wave but no
+					// live registration (history_only never sets subscribed/catchingUp). A second
+					// overlapping add for it would start a competing wave and reset the high-water
+					// floor, re-delivering history the first wave already sent — reject. (This
+					// covers the common no-remove overlap; a remove+re-add of such a topic is an
+					// even more unusual sequence that dropTopic narrows but does not fully close.)
+					if _, hasWave := topicWave[t]; hasWave {
+						if _, live := subscribed[t]; !live && !catchingUp[t] {
+							return status.Errorf(
+								codes.InvalidArgument,
+								"add targets a topic with an in-flight history_only catch-up",
+							)
+						}
+					}
 					// Re-adding a topic already active on this stream is a no-op unless its
 					// cursor is below the current floor, which restarts catch-up to replay
 					// (XIP-83). The floor seeds to the starting cursor on a fresh add (below),
@@ -1003,4 +1033,15 @@ func welcomeData(m *mlsv1.WelcomeMessage) []byte {
 		return v1.GetData()
 	}
 	return m.GetWelcomePointer().GetWelcomePointer()
+}
+
+// stopTimer stops t and drains a pending fire if there is one, so a later Reset cannot observe a
+// stale value. Safe on an already-stopped or already-fired-and-drained timer.
+func stopTimer(t *time.Timer) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
 }

--- a/pkg/mls/api/v1/subscribe_test.go
+++ b/pkg/mls/api/v1/subscribe_test.go
@@ -895,6 +895,49 @@ func TestSubscribe_HistoryOnlyOnLiveTopicRejected(t *testing.T) {
 	}
 }
 
+// TestSubscribe_AddOverInflightHistoryOnlyRejected verifies that a second add for a topic whose
+// history_only catch-up is still in flight is rejected: a competing wave would re-deliver history
+// the first wave already sent (and orphan it). The gate holds the history_only wave mid-fetch.
+func TestSubscribe_AddOverInflightHistoryOnlyRejected(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	svc, _, validationSvc, cleanup := newTestService(t, ctx)
+	defer cleanup()
+
+	groupA := []byte(test.RandomString(32))
+	mockValidateGroupMessages(validationSvc, groupA)
+	populateGroupMessages(t, ctx, svc, groupA, 5, "hist")
+	gate := make(chan struct{})
+	defer close(gate)
+	svc.readOnlyStore = &fakeReadStore{ReadMlsStore: svc.readOnlyStore, groupGate: gate}
+
+	stream := newFakeSubscribeStream(ctx)
+	errCh := make(chan error, 1)
+	go func() { errCh <- svc.Subscribe(stream) }()
+
+	// history_only add: its catch-up wave blocks on the gate, staying in flight.
+	stream.send(subReqMutate(&mlsv1.SubscribeRequest_V1_Mutate{
+		Adds: []*mlsv1.SubscribeRequest_V1_Mutate_Subscription{
+			addSub(groupTopic(groupA), 0),
+		},
+		HistoryOnly: true,
+		MutateId:    1,
+	}))
+	// A second add for the same topic while that wave is in flight must be rejected.
+	stream.send(subReqMutate(&mlsv1.SubscribeRequest_V1_Mutate{
+		Adds:     []*mlsv1.SubscribeRequest_V1_Mutate_Subscription{addSub(groupTopic(groupA), 0)},
+		MutateId: 2,
+	}))
+
+	select {
+	case err := <-errCh:
+		require.Equal(t, codes.InvalidArgument, status.Code(err),
+			"an add overlapping an in-flight history_only wave must be rejected")
+	case <-time.After(5 * time.Second):
+		t.Fatal("overlapping add was not rejected")
+	}
+}
+
 // TestSubscribe_HalfCloseDrainsCatchUpThenCloses is the bounded catch-up ("catchUpOnce")
 // shape end to end: Mutate{history_only} then immediately half-close; the server finishes
 // the wave — history, marker, CatchupComplete — and then closes the stream itself.


### PR DESCRIPTION
## XIP-83 `Subscribe` — three correctness/resource fixes

Follow-up to #562. While building the **decentralized (d14n) binding** of this same handler on xmtpd ([xmtp/xmtpd#2020](https://github.com/xmtp/xmtpd/pull/2020)) and putting it through an independent multi-agent review, three issues surfaced that also exist in this v3 handler. (The d14n review caught them precisely because it was a fresh look at a sibling of code #562's own review had already passed — e.g. #562 fixed the flush *timeout* false-OK but not the *send-error* one below.)

### 1. `flush()` reported a false OK after a sender send-error
`flush()` returned `nil` on `senderDone` without checking `sendErrCh`. If the sender goroutine had already stopped on a `stream.Send` error, the graceful-completion path returned a clean OK while the wave's terminal frames (history tail + `CatchupComplete`) were never written — silent truncation with no reconnect signal. Now drains `sendErrCh` after `senderDone` and propagates the error (mirrors the existing timeout case, which already fails rather than false-OKs).

### 2. A second add overlapping an in-flight `history_only` wave
A `history_only` add never registers in `subscribed`/`catchingUp`, and there was no in-flight guard, so a second add for the same topic while its `history_only` catch-up was still running started a competing wave and reset the high-water floor — re-delivering history the first wave already sent (and orphaning it). Now rejected with `InvalidArgument`. (Covers the common no-remove overlap; a remove+re-add of such a topic is a narrower sequence `dropTopic` partially settles — noted in a comment.)

### 3. Per-send `time.After` allocation
`send()` allocated a `time.After` timer on every call (live for the whole pong deadline), accumulating under high throughput. Replaced with a reused per-session timer (send runs only on the writer goroutine).

### Not changed (deliberately)
A cursor above `MaxInt64` is **left as-is** — #562 intentionally clamps it to "no history" with a clean close (`TestSubscribe_CursorAboveInt64ReturnsNoHistory`), and that decision is respected here. (The d14n binding rejects it instead, because its per-originator cursor path silently *drops* the entry and replays from 0 rather than clamping — a different, genuinely-buggy code path. Flagging the cross-binding inconsistency in case you want to align them.)

### Tests
- `TestSubscribe_AddOverInflightHistoryOnlyRejected` (new; gates the wave mid-fetch to hold it in flight).
- Full `TestSubscribe*` suite green under `-race`; `go vet` + gofmt + golangci-lint clean.

The flush send-error and the timer reuse are exercised functionally by the existing suite (closures, not unit-testable in isolation); both are structurally identical to the equivalent fixes already tested on the d14n side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flush send-error propagation, history_only overlap rejection, and reusable send timer in `Subscribe`
> - In `flush()` in [subscribe.go](https://github.com/xmtp/xmtp-node-go/pull/563/files#diff-4d0bdf82f9e0725ea45bba80575bad96dce9c1961f1fb9b600bf633b6ee6dcbe), reads from `sendErrCh` after `senderDone` signals so the actual `stream.Send` error is returned instead of a false success.
> - Replaces per-call `time.After` in `send()` with a reusable `sendTimer` (reset each call, drained via a new `stopTimer` helper) to avoid stale timer events on subsequent resets.
> - Rejects an `add` request with `InvalidArgument` when the topic already has an in-flight `history_only` catch-up wave and is neither subscribed nor catching up.
> - Adds `TestSubscribe_AddOverInflightHistoryOnlyRejected` to verify the overlap rejection under a gated read store.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c511c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->