### PR TITLE
fix(mls/api): prune and rotate XIP-83 catch-up wave scans onto per-topic index probes

### DIFF
--- a/pkg/mls/api/v1/service.go
+++ b/pkg/mls/api/v1/service.go
@@ -56,13 +56,21 @@ type Service struct {
 
 	// Subscribe (XIP-83) tunables; overridable in tests. Default to the package consts
 	// (subscribePingInterval / subscribePongDeadline / maxPendingBytes / maxFrameBytes /
-	// catchUpScanPageLimit / maxMutateAdds).
-	pingInterval    time.Duration
-	pongDeadline    time.Duration
-	maxPendingBytes int
-	maxFrameBytes   int
-	scanPageLimit   int32
-	maxMutateAdds   int
+	// catchUpTopicPageLimit / catchUpBatchTopics / catchUpMaxConcurrentScans /
+	// catchUpMaxPendingBytes / maxMutateAdds).
+	pingInterval        time.Duration
+	pongDeadline        time.Duration
+	maxPendingBytes     int
+	maxFrameBytes       int
+	scanTopicPageLimit  int32
+	scanBatchTopics     int
+	scanMaxConcurrent   int
+	scanMaxPendingBytes int
+	maxMutateAdds       int
+	// scanBytesObserved, when non-nil (tests only), receives the catch-up
+	// lane's occupancy after each successful byte reservation, letting a test
+	// pin the admission bound instead of only its liveness.
+	scanBytesObserved func(int64)
 }
 
 func NewService(
@@ -75,19 +83,22 @@ func NewService(
 	cutoverChecker *migration.CutoverChecker,
 ) (s *Service, err error) {
 	s = &Service{
-		log:               log.Named("mls/v1"),
-		writerStore:       writerStore,
-		readOnlyStore:     readOnlyStore,
-		validationService: validationService,
-		subDispatcher:     subDispatcher,
-		disablePublish:    disablePublish,
-		cutoverChecker:    cutoverChecker,
-		pingInterval:      subscribePingInterval,
-		pongDeadline:      subscribePongDeadline,
-		maxPendingBytes:   maxPendingBytes,
-		maxFrameBytes:     maxFrameBytes,
-		scanPageLimit:     catchUpScanPageLimit,
-		maxMutateAdds:     maxMutateAdds,
+		log:                 log.Named("mls/v1"),
+		writerStore:         writerStore,
+		readOnlyStore:       readOnlyStore,
+		validationService:   validationService,
+		subDispatcher:       subDispatcher,
+		disablePublish:      disablePublish,
+		cutoverChecker:      cutoverChecker,
+		pingInterval:        subscribePingInterval,
+		pongDeadline:        subscribePongDeadline,
+		maxPendingBytes:     maxPendingBytes,
+		maxFrameBytes:       maxFrameBytes,
+		scanTopicPageLimit:  catchUpTopicPageLimit,
+		scanBatchTopics:     catchUpBatchTopics,
+		scanMaxConcurrent:   catchUpMaxConcurrentScans,
+		scanMaxPendingBytes: catchUpMaxPendingBytes,
+		maxMutateAdds:       maxMutateAdds,
 	}
 	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
 	if s.dbWorker, err = newDBWorker(s.ctx, log, s.readOnlyStore.Queries(), subDispatcher, DEFAULT_POLL_INTERVAL); err != nil {

--- a/pkg/mls/api/v1/subscribe.go
+++ b/pkg/mls/api/v1/subscribe.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/xmtp/xmtp-node-go/pkg/metrics"
@@ -33,19 +34,69 @@ const (
 	// writer is not parked by a slow stream.Send. Small: it only smooths Send latency.
 	sendQueueDepth = 8
 
-	// Wave-scan catch-up tuning (XIP-83 server requirement 4). A wave's replay is a
-	// single ascending-id scan merged across all of its topics — not per-topic
-	// bursts — paged by a global scan cursor and pinned to the ceiling (the newest
-	// id at wave start) so it terminates under sustained publishing. scanPageLimit
-	// is rows per DB round-trip.
-	catchUpScanPageLimit = 512
+	// Wave-scan catch-up tuning (XIP-83 server requirement 4, amended for batch
+	// rotation). A wave prunes topics whose cursor already sits at the ceiling,
+	// then replays the rest in rotating batches: one query per turn returns up
+	// to catchUpTopicPageLimit rows for EACH topic in the batch, every fetched
+	// row is delivered (turns never discard and re-fetch work), and ids ascend
+	// within every turn and per topic across the wave. The per-topic guarantee
+	// is the one the writer's high-water dedup and the client's replay guards
+	// rely on; only the live lane needs total cursor order. The ceiling (the
+	// newest id at wave start) pins every turn so the wave terminates under
+	// sustained publishing.
+	//
+	// A turn is bounded by catchUpBatchTopics × catchUpTopicPageLimit = 16,384
+	// rows: generous for real deep replays, which stream out in few round
+	// trips, while still capping what a hostile subscription — many topics,
+	// all far behind — can force into one query result. Topics retire from
+	// the rotation individually the moment a turn returns fewer than their
+	// per-topic limit. The lane's other two axes are bounded by the scan-slot
+	// and byte-budget constants below; the channel buffer is sized in
+	// turns-of-16,384, not messages.
+	catchUpTopicPageLimit = 64
+	catchUpBatchTopics    = 256
 	// catchUpChannelBuffer smooths handoff from the catch-up fetchers to the writer;
-	// when full, fetchers block (backpressure) rather than racing ahead of the client.
-	catchUpChannelBuffer = 64
-	// maxMutateAdds bounds a single wave's merged catch-up scan: the scan's floor arrays
-	// carry one entry per topic and ride every page query, so the raw adds one Mutate may
-	// carry are capped (pre-dedup — a stateless check). A client with a larger set splits
-	// it across Mutates, whose waves run concurrently (XIP-83 server requirement 8).
+	// when full, fetchers block (backpressure) rather than racing ahead of the
+	// client. Sized in TURNS, each of which may now carry up to the full
+	// per-turn row cap (16,384 messages): 4 buffered turns bounds the channel
+	// at ~65k messages, the same order as the 64 × 512-row pages it previously
+	// buffered. Typical turns are tiny or empty, so the smaller depth costs
+	// real replays nothing.
+	catchUpChannelBuffer = 4
+	// catchUpMaxConcurrentScans bounds how many of one stream's catch-up scans
+	// fetch at once. Each add-bearing Mutate's wave contributes up to two scans
+	// (group + welcome); a scan with rows to replay owns a slot from before its
+	// first wave-scan query until its done marker is in the channel, while a
+	// fully-current wave — the dominant reconnect case — prunes slot-free and
+	// completes without queuing (a parked current wave would only hold its
+	// topics gated, live traffic accumulating against maxPendingBytes, for no
+	// replay at all). Excess scans park on the slot channel (FIFO) and start
+	// as slots free, so a burst of stale, topic-dense Mutates cannot multiply
+	// full-turn row hands or per-stream query concurrency without bound. A
+	// parked wave holds only its topic floors (state its waveState carries
+	// anyway). Waves still overlap up to the cap (XIP-83 server requirement 8
+	// promises concurrent waves, not unboundedly many), and cross-wave
+	// completion order was never part of the contract.
+	catchUpMaxConcurrentScans = 4
+	// catchUpMaxPendingBytes caps the payload bytes catch-up scans have
+	// fetched but the writer has not yet consumed — the catch-up mirror of
+	// maxPendingBytes, which covers only the gated live lane. A scan reserves
+	// a turn's bytes after its query returns (sizes are unknowable beforehand)
+	// and parks until the writer frees room: backpressure, like the channel,
+	// never a stream drop. An empty lane admits any single turn, so one turn
+	// larger than the whole budget still replays (alone) instead of
+	// deadlocking. The budget thus bounds fetched-but-unconsumed bytes at
+	// max(budget, one turn); on top of that sit not-yet-reserved query
+	// results in flight (≤ catchUpMaxConcurrentScans turns) and the
+	// writer→sender pipeline, which the budget deliberately does not cover —
+	// the writer frees a batch when it takes it, and delivery is separately
+	// turn-bounded by sendQueueDepth plus the writer's and sender's hands.
+	catchUpMaxPendingBytes = 64 << 20 // 64 MiB
+	// maxMutateAdds bounds one Mutate's raw adds (pre-dedup — a stateless
+	// check). Batch rotation keeps any single query small regardless, but the
+	// wave still holds every topic's floor in memory for its lifetime. A
+	// client with a larger set splits it across Mutates, whose waves run
+	// concurrently (XIP-83 server requirement 8).
 	maxMutateAdds = 100_000
 
 	// maxPendingBytes caps live messages buffered while topics catch up. Exceeding it
@@ -101,8 +152,11 @@ type catchUpBatch struct {
 	groupMsgs   []*mlsv1.GroupMessage
 	welcomeMsgs []*mlsv1.WelcomeMessage
 	wave        int
-	done        bool
-	err         error
+	// bytes is the turn's payload size, reserved against the stream's catch-up
+	// byte budget by the fetcher; the writer frees it when it takes the batch.
+	bytes int
+	done  bool
+	err   error
 }
 
 // waveState tracks one Mutate's in-flight catch-up. A wave completes when its last
@@ -507,18 +561,104 @@ func (s *Service) Subscribe(stream mlsv1.MlsApi_SubscribeServer) error {
 		}
 	}
 
-	// catchUpGroups replays one wave's group topics as a single ascending-id scan
-	// merged across all of its groups (XIP-83 server requirement 4: a wave's replay is
-	// one cursor-ordered pass, not per-topic bursts). The scan is pinned to the newest
-	// id at wave start, so it terminates under sustained publishing; anything newer
-	// reaches the client through the gated live path and is folded into the wave when
-	// it completes. Pages are forwarded to the writer in scan order. It owns no shared
-	// state and never sends to the stream; it just queries and hands results over.
+	// Catch-up lane bounds (see the catchUpMaxConcurrentScans /
+	// catchUpMaxPendingBytes comments). Both are per-stream and shared by the
+	// group and welcome fetchers; neither is writer-owned state — the writer
+	// only ever frees, which cannot block. Guard non-positive tunables the
+	// same way the fetchers guard theirs: a zero cap would park every scan
+	// forever.
+	maxScans := s.scanMaxConcurrent
+	if maxScans < 1 {
+		maxScans = 1
+	}
+	scanSlots := make(chan struct{}, maxScans)
+	byteBudget := s.scanMaxPendingBytes
+	if byteBudget < 1 {
+		byteBudget = 1
+	}
+	var catchUpBytes atomic.Int64
+	catchUpBytesFreed := make(chan struct{}, 1)
+
+	// acquireScanSlot parks a scan until one of the stream's fetch slots frees
+	// (or the stream dies — the false return, on which the fetcher just
+	// abandons the scan like any other teardown path). Parked acquirers are
+	// served FIFO by the channel.
+	acquireScanSlot := func() bool {
+		select {
+		case scanSlots <- struct{}{}:
+			return true
+		case <-ctx.Done():
+		case <-s.ctx.Done():
+		}
+		return false
+	}
+	releaseScanSlot := func() { <-scanSlots }
+
+	// reserveCatchUpBytes parks until n payload bytes fit the catch-up budget,
+	// returning false only when the stream dies first. The CAS-from-zero arm
+	// admits exactly one turn into an empty lane whatever its size, so an
+	// over-budget turn replays alone rather than deadlocking.
+	reserveCatchUpBytes := func(n int) bool {
+		for {
+			cur := catchUpBytes.Load()
+			if cur == 0 || cur+int64(n) <= int64(byteBudget) {
+				if catchUpBytes.CompareAndSwap(cur, cur+int64(n)) {
+					if s.scanBytesObserved != nil {
+						s.scanBytesObserved(cur + int64(n))
+					}
+					return true
+				}
+				continue
+			}
+			select {
+			case <-catchUpBytesFreed:
+			case <-ctx.Done():
+				return false
+			case <-s.ctx.Done():
+				return false
+			}
+		}
+	}
+	// freeCatchUpBytes releases a batch's reservation once the writer has
+	// consumed it (sent, filtered, or dropped with its wave) and wakes one
+	// parked fetcher to re-check the budget. Fetchers that parked without a
+	// wakeup slot re-check on the next free — whenever the lane is over
+	// budget, reserved batches exist for the writer to consume, so frees (and
+	// wakeups) keep coming.
+	freeCatchUpBytes := func(n int) {
+		if n == 0 {
+			return
+		}
+		catchUpBytes.Add(-int64(n))
+		select {
+		case catchUpBytesFreed <- struct{}{}:
+		default:
+		}
+	}
+
+	// catchUpGroups replays one wave's group topics in rotating batches (see
+	// catchUpBatchTopics). Topics whose cursor already sits at the ceiling are
+	// pruned without a query — a topic can only contribute rows in
+	// (cursor, ceiling], and reconnect waves are overwhelmingly fully current,
+	// so most waves complete right there. Each turn queries one batch for up
+	// to the per-topic limit of rows per topic: a topic that fills its limit
+	// may have more, so it advances its own cursor and rotates to the back of
+	// the queue; every other topic is fully replayed up to the ceiling and
+	// retires. Every fetched row is delivered — turns never discard and
+	// re-fetch work. Anything newer than the ceiling reaches the client
+	// through the gated live path and is folded into the wave when it
+	// completes. It owns no shared state and never sends to the stream; it
+	// just queries and hands results over.
 	catchUpGroups := func(adds []mlsstore.GroupCatchup, wave int) {
 		// The ceiling pin assumes v3's id-visibility-order invariant: ids become visible to
 		// readers in id order (the live poller in worker.go advances from raw rows on the same
 		// assumption — a row committing out of order behind a reader is undeliverable
-		// stream-wide, a pre-existing v3 property).
+		// stream-wide, a pre-existing v3 property). This first snapshot runs
+		// slot-free — it is one index-tail probe — so the dominant
+		// fully-current reconnect wave prunes to nothing and completes without
+		// queuing behind a deep scan: parked with no replay to do, such a wave
+		// would only hold its topics gated while live traffic accumulates
+		// against maxPendingBytes.
 		ceiling, err := s.readOnlyStore.Queries().GetLatestGroupMessageID(ctx)
 		if err != nil {
 			if !errors.Is(err, context.Canceled) {
@@ -527,8 +667,42 @@ func (s *Service) Subscribe(stream mlsv1.MlsApi_SubscribeServer) error {
 			}
 			return
 		}
-		scanCursor := uint64(0)
-		for {
+		queue := make([]mlsstore.GroupCatchup, 0, len(adds))
+		for _, a := range adds {
+			if a.IdCursor < uint64(ceiling) {
+				queue = append(queue, a)
+			}
+		}
+		if len(queue) > 0 {
+			// Only a wave with rows to replay competes for a scan slot; the
+			// slot is held until the wave's done marker is in the channel.
+			if !acquireScanSlot() {
+				return
+			}
+			defer releaseScanSlot()
+			// Re-snapshot under the slot: the wait may have been long, and a
+			// fresher ceiling moves rows from the gated pending fold into the
+			// scan (never the reverse — the ceiling only grows, and the queue
+			// needs no re-prune: every queued cursor sits below the old
+			// ceiling, hence below the new). A refresh failure is benign; the
+			// first snapshot stays a valid pin.
+			c, cerr := s.readOnlyStore.Queries().GetLatestGroupMessageID(ctx)
+			if cerr == nil && c > ceiling {
+				ceiling = c
+			}
+		}
+		// Guard against non-positive tunables: a zero batch would spin the
+		// loop forever without consuming the queue, and a zero limit would
+		// make every topic look drained.
+		batchTopics := s.scanBatchTopics
+		if batchTopics < 1 {
+			batchTopics = 1
+		}
+		limit := s.scanTopicPageLimit
+		if limit < 1 {
+			limit = 1
+		}
+		for len(queue) > 0 {
 			select {
 			case <-ctx.Done():
 				return
@@ -536,12 +710,17 @@ func (s *Service) Subscribe(stream mlsv1.MlsApi_SubscribeServer) error {
 				return
 			default:
 			}
+			batch := queue
+			if len(batch) > batchTopics {
+				batch = queue[:batchTopics]
+			}
+			queue = queue[len(batch):]
 			msgs, err := s.readOnlyStore.QueryGroupMessagesWaveScan(
 				ctx,
-				adds,
-				scanCursor,
+				batch,
+				0,
 				uint64(ceiling),
-				s.scanPageLimit,
+				limit,
 			)
 			if err != nil {
 				if !errors.Is(err, context.Canceled) {
@@ -550,18 +729,50 @@ func (s *Service) Subscribe(stream mlsv1.MlsApi_SubscribeServer) error {
 				}
 				return
 			}
-			if len(msgs) > 0 {
-				scanCursor = msgs[len(msgs)-1].GetV1().GetId()
-				forward(catchUpBatch{groupMsgs: msgs, wave: wave})
+			// Per-topic scan positions, captured BEFORE the writer takes
+			// ownership of msgs (it filters the slice in place once handed
+			// over). msgs ascend, so each topic's entry ends at its max id.
+			counts := make(map[string]int, len(batch))
+			lastIDs := make(map[string]uint64, len(batch))
+			for _, m := range msgs {
+				v1 := m.GetV1()
+				k := string(v1.GetGroupId())
+				counts[k]++
+				lastIDs[k] = v1.GetId()
 			}
-			if len(msgs) < int(s.scanPageLimit) {
-				forward(catchUpBatch{wave: wave, done: true})
-				return
+			if len(msgs) > 0 {
+				turnBytes := 0
+				for _, m := range msgs {
+					turnBytes += len(m.GetV1().GetData())
+				}
+				if !reserveCatchUpBytes(turnBytes) {
+					return
+				}
+				forward(catchUpBatch{groupMsgs: msgs, wave: wave, bytes: turnBytes})
+			}
+			// A topic that filled its per-topic limit may have more rows:
+			// advance its own cursor and rotate it to the back. Every other
+			// topic is fully replayed up to the ceiling and retires.
+			for _, b := range batch {
+				k := string(b.GroupID)
+				if counts[k] < int(limit) {
+					continue
+				}
+				if b.IdCursor < lastIDs[k] {
+					b.IdCursor = lastIDs[k]
+				}
+				queue = append(queue, b)
 			}
 		}
+		forward(catchUpBatch{wave: wave, done: true})
 	}
 
-	// catchUpWelcomes is the welcome-topic analogue of catchUpGroups.
+	// catchUpWelcomes is the welcome-topic analogue of catchUpGroups. Topic
+	// truncation and rotation cursors come from the store's RAW per-topic
+	// progress, not the parsed slice: the store skips rows with an unknown
+	// message_type but they still consumed their topic's LIMIT slots, so
+	// paging by parsed rows would silently truncate the replay at the first
+	// skipped row.
 	catchUpWelcomes := func(adds []mlsstore.WelcomeCatchup, wave int) {
 		ceiling, err := s.readOnlyStore.Queries().GetLatestWelcomeMessageID(ctx)
 		if err != nil {
@@ -571,8 +782,32 @@ func (s *Service) Subscribe(stream mlsv1.MlsApi_SubscribeServer) error {
 			}
 			return
 		}
-		scanCursor := uint64(0)
-		for {
+		queue := make([]mlsstore.WelcomeCatchup, 0, len(adds))
+		for _, a := range adds {
+			if a.IdCursor < uint64(ceiling) {
+				queue = append(queue, a)
+			}
+		}
+		if len(queue) > 0 {
+			// Same slot discipline and ceiling re-snapshot as catchUpGroups.
+			if !acquireScanSlot() {
+				return
+			}
+			defer releaseScanSlot()
+			c, cerr := s.readOnlyStore.Queries().GetLatestWelcomeMessageID(ctx)
+			if cerr == nil && c > ceiling {
+				ceiling = c
+			}
+		}
+		batchTopics := s.scanBatchTopics
+		if batchTopics < 1 {
+			batchTopics = 1
+		}
+		limit := s.scanTopicPageLimit
+		if limit < 1 {
+			limit = 1
+		}
+		for len(queue) > 0 {
 			select {
 			case <-ctx.Done():
 				return
@@ -580,12 +815,17 @@ func (s *Service) Subscribe(stream mlsv1.MlsApi_SubscribeServer) error {
 				return
 			default:
 			}
-			msgs, lastRawID, rawCount, err := s.readOnlyStore.QueryWelcomeMessagesWaveScan(
+			batch := queue
+			if len(batch) > batchTopics {
+				batch = queue[:batchTopics]
+			}
+			queue = queue[len(batch):]
+			msgs, progress, err := s.readOnlyStore.QueryWelcomeMessagesWaveScan(
 				ctx,
-				adds,
-				scanCursor,
+				batch,
+				0,
 				uint64(ceiling),
-				s.scanPageLimit,
+				limit,
 			)
 			if err != nil {
 				if !errors.Is(err, context.Canceled) {
@@ -594,20 +834,28 @@ func (s *Service) Subscribe(stream mlsv1.MlsApi_SubscribeServer) error {
 				}
 				return
 			}
-			// Advance from the RAW scan position, not the parsed slice: the store skips rows
-			// with an unknown message_type but they still consumed LIMIT slots, so paging by
-			// parsed rows would silently truncate the replay at the first skipped row.
-			if rawCount > 0 {
-				scanCursor = lastRawID
-			}
 			if len(msgs) > 0 {
-				forward(catchUpBatch{welcomeMsgs: msgs, wave: wave})
+				turnBytes := 0
+				for _, m := range msgs {
+					turnBytes += len(welcomeData(m))
+				}
+				if !reserveCatchUpBytes(turnBytes) {
+					return
+				}
+				forward(catchUpBatch{welcomeMsgs: msgs, wave: wave, bytes: turnBytes})
 			}
-			if rawCount < int(s.scanPageLimit) {
-				forward(catchUpBatch{wave: wave, done: true})
-				return
+			for _, b := range batch {
+				p := progress[string(b.InstallationKey)]
+				if p.RawCount < int(limit) {
+					continue
+				}
+				if b.IdCursor < p.LastRawID {
+					b.IdCursor = p.LastRawID
+				}
+				queue = append(queue, b)
 			}
 		}
+		forward(catchUpBatch{wave: wave, done: true})
 	}
 
 	// Read client frames in a dedicated goroutine (gRPC Recv blocks) and forward them to
@@ -707,9 +955,9 @@ func (s *Service) Subscribe(stream mlsv1.MlsApi_SubscribeServer) error {
 						"a Mutate with adds requires a nonzero mutate_id",
 					)
 				}
-				// Each add becomes a floor entry in the wave's merged catch-up scan,
-				// riding every page query (see maxMutateAdds). Checked on the raw adds —
-				// stateless, before any state changes — so the rejected frame is atomic.
+				// Each add becomes a floor entry the wave holds for its lifetime
+				// (see maxMutateAdds). Checked on the raw adds — stateless, before
+				// any state changes — so the rejected frame is atomic.
 				if len(m.GetAdds()) > s.maxMutateAdds {
 					return status.Errorf(
 						codes.ResourceExhausted,
@@ -931,6 +1179,11 @@ func (s *Service) Subscribe(stream mlsv1.MlsApi_SubscribeServer) error {
 				// CATCHUP_COMPLETE.
 				return status.Errorf(codes.Unavailable, "catch-up failed: %v", b.err)
 			}
+			// Taking the batch consumes it — sent below, filtered, or dropped
+			// with a dead wave — so its byte reservation is freed on every one
+			// of those paths, here, before any of them branch. (The err return
+			// above skips this safely: error batches always carry zero bytes.)
+			freeCatchUpBytes(b.bytes)
 			w, waveActive := waves[b.wave]
 			if !waveActive {
 				continue // the wave completed early (all topics removed); drop the straggler

--- a/pkg/mls/api/v1/subscribe_test.go
+++ b/pkg/mls/api/v1/subscribe_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1370,15 +1371,154 @@ func TestQueryGroupMessagesWaveScan_CursorAboveInt64ReturnsNothing(t *testing.T)
 	require.Empty(t, msgs, "a cursor above MaxInt64 must clamp to no rows, not wrap negative")
 }
 
+// TestSubscribe_CurrentCursorWaveSkipsScan pins the wave short-circuit: a wave whose
+// every cursor already sits at the ceiling can replay nothing, so it must complete —
+// TopicsLive and all — without a single wave-scan query. Reconnecting clients are
+// overwhelmingly in this state, and before the short-circuit each such wave still cost
+// a DB round trip. A second, stale-cursor wave on the same stream then proves the
+// counter observes real scans (the zero above is not vacuous).
+func TestSubscribe_CurrentCursorWaveSkipsScan(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	svc, _, validationSvc, cleanup := newTestService(t, ctx)
+	defer cleanup()
+
+	groupA := []byte(test.RandomString(32))
+	groupB := []byte(test.RandomString(32))
+	mockValidateGroupMessages(validationSvc, groupA)
+	populateGroupMessages(t, ctx, svc, groupA, 5, "histA")
+	validationSvc.ExpectedCalls = nil
+	mockValidateGroupMessages(validationSvc, groupB)
+	populateGroupMessages(t, ctx, svc, groupB, 3, "histB")
+
+	// The ceiling is the global newest id, so a "current" topic must be cursored there.
+	latest, err := svc.readOnlyStore.Queries().GetLatestGroupMessageID(ctx)
+	require.NoError(t, err)
+
+	fake := &fakeReadStore{ReadMlsStore: svc.readOnlyStore}
+	svc.readOnlyStore = fake
+
+	stream := newFakeSubscribeStream(ctx)
+	errCh := make(chan error, 1)
+	go func() { errCh <- svc.Subscribe(stream) }()
+
+	stream.send(subReqMutate(&mlsv1.SubscribeRequest_V1_Mutate{
+		Adds: []*mlsv1.SubscribeRequest_V1_Mutate_Subscription{
+			addSub(groupTopic(groupA), uint64(latest)),
+		},
+		MutateId: 1,
+	}))
+	resps := waitForResponses(t, stream, 10*time.Second, "current-cursor wave to go live",
+		func(rs []*mlsv1.SubscribeResponse) bool {
+			return frameIndex(rs, func(r *mlsv1.SubscribeResponse) bool {
+				return topicsLiveHas(r, groupTopic(groupA))
+			}) >= 0
+		})
+	require.Zero(t, fake.groupScans.Load(), "a current-cursor wave must not query the store")
+	require.Empty(t, groupMsgsFrom(resps), "a current-cursor wave has nothing to replay")
+
+	stream.send(subReqMutate(&mlsv1.SubscribeRequest_V1_Mutate{
+		Adds: []*mlsv1.SubscribeRequest_V1_Mutate_Subscription{
+			addSub(groupTopic(groupB), 0),
+		},
+		MutateId: 2,
+	}))
+	waitForResponses(t, stream, 10*time.Second, "stale-cursor wave replay",
+		func(rs []*mlsv1.SubscribeResponse) bool { return len(groupMsgsFrom(rs)) >= 3 })
+	require.Positive(t, fake.groupScans.Load(), "a stale-cursor wave must scan")
+
+	stream.closeSend()
+	require.NoError(t, <-errCh)
+}
+
+// TestSubscribe_WaveRotatesInBatches pins the batch rotation with shrunken
+// tunables (batch of 2 topics, page of 2 rows) over three groups: no scan query
+// ever carries more than a batch of topics, a full page rotates its batch to
+// the back of the queue (so a topic is re-queried across turns rather than
+// replayed in one burst), and the replay still delivers every message exactly
+// once, ascending within each topic — the per-topic guarantee the writer's
+// high-water dedup relies on now that turns are not globally id-ordered.
+func TestSubscribe_WaveRotatesInBatches(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	svc, _, validationSvc, cleanup := newTestService(t, ctx)
+	defer cleanup()
+	svc.scanBatchTopics = 2
+	svc.scanTopicPageLimit = 2
+
+	groups := [][]byte{
+		[]byte(test.RandomString(32)),
+		[]byte(test.RandomString(32)),
+		[]byte(test.RandomString(32)),
+	}
+	for i, g := range groups {
+		validationSvc.ExpectedCalls = nil
+		mockValidateGroupMessages(validationSvc, g)
+		populateGroupMessages(t, ctx, svc, g, 3, fmt.Sprintf("hist%d", i))
+	}
+
+	fake := &fakeReadStore{ReadMlsStore: svc.readOnlyStore}
+	svc.readOnlyStore = fake
+
+	stream := newFakeSubscribeStream(ctx)
+	errCh := make(chan error, 1)
+	go func() { errCh <- svc.Subscribe(stream) }()
+
+	adds := make([]*mlsv1.SubscribeRequest_V1_Mutate_Subscription, len(groups))
+	for i, g := range groups {
+		adds[i] = addSub(groupTopic(g), 0)
+	}
+	stream.send(subReqMutate(&mlsv1.SubscribeRequest_V1_Mutate{Adds: adds, MutateId: 1}))
+
+	resps := waitForResponses(t, stream, 10*time.Second, "full rotated replay",
+		func(rs []*mlsv1.SubscribeResponse) bool { return len(groupMsgsFrom(rs)) >= 9 })
+	got := groupMsgsFrom(resps)
+	require.Len(t, got, 9, "every message exactly once, no duplicates from rotation")
+
+	perTopic := map[string][]uint64{}
+	for _, m := range got {
+		key := string(m.GetV1().GetGroupId())
+		perTopic[key] = append(perTopic[key], m.GetV1().GetId())
+	}
+	require.Len(t, perTopic, 3, "all three topics replayed")
+	for topic, ids := range perTopic {
+		require.Len(t, ids, 3, "topic %x complete", topic)
+		for i := 1; i < len(ids); i++ {
+			require.Greater(t, ids[i], ids[i-1], "topic %x ids must ascend", topic)
+		}
+	}
+
+	fake.scanMu.Lock()
+	calls := fake.groupScanFilters
+	fake.scanMu.Unlock()
+	seenTurns := map[string]int{}
+	for _, call := range calls {
+		require.LessOrEqual(t, len(call), 2, "a scan query must never carry more than a batch")
+		for _, topic := range call {
+			seenTurns[topic]++
+		}
+	}
+	rotated := false
+	for _, n := range seenTurns {
+		if n >= 2 {
+			rotated = true
+		}
+	}
+	require.True(t, rotated, "at least one topic must be re-queried across turns (rotation)")
+
+	stream.closeSend()
+	require.NoError(t, <-errCh)
+}
+
 // TestSubscribe_MultiPageCatchUp exercises catch-up pagination across more than
-// scanPageLimit messages: the scan-cursor continuation plus wave completion on the final
+// a topic's per-turn limit: the cursor continuation plus wave completion on the final
 // short page, with exactly one TopicsLive and one CatchupComplete.
 func TestSubscribe_MultiPageCatchUp(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	svc, _, validationSvc, cleanup := newTestService(t, ctx)
 	defer cleanup()
-	svc.scanPageLimit = 50 // small pages so a modest history spans several
+	svc.scanTopicPageLimit = 50 // small pages so a modest history spans several
 
 	groupA := []byte(test.RandomString(32))
 	mockValidateGroupMessages(validationSvc, groupA)
@@ -1481,6 +1621,13 @@ func TestSubscribe_NonZeroStartingCursor(t *testing.T) {
 // (including Queries(), so the wave's ceiling lookup is unaffected).
 type fakeReadStore struct {
 	mlsstore.ReadMlsStore
+	// groupScans counts QueryGroupMessagesWaveScan calls, letting a test assert a
+	// wave completed without touching the store (the current-cursor pruning), and
+	// groupScanFilters records each call's group ids so a test can assert batch
+	// rotation (bounded batches; a deep topic re-queried across turns).
+	groupScans        atomic.Int32
+	scanMu            sync.Mutex
+	groupScanFilters  [][]string
 	groupErr          error
 	groupGate         chan struct{}
 	gateGroup         []byte
@@ -1522,6 +1669,14 @@ func (f *fakeReadStore) QueryGroupMessagesWaveScan(
 	ceiling uint64,
 	limit int32,
 ) ([]*mlsv1.GroupMessage, error) {
+	f.groupScans.Add(1)
+	topics := make([]string, len(filters))
+	for i, flt := range filters {
+		topics[i] = string(flt.GroupID)
+	}
+	f.scanMu.Lock()
+	f.groupScanFilters = append(f.groupScanFilters, topics)
+	f.scanMu.Unlock()
 	if f.groupGate != nil && (f.gateGroup == nil || filtersInclude(filters, f.gateGroup)) {
 		f.parked()
 		select {
@@ -1542,17 +1697,17 @@ func (f *fakeReadStore) QueryWelcomeMessagesWaveScan(
 	scanCursor uint64,
 	ceiling uint64,
 	limit int32,
-) ([]*mlsv1.WelcomeMessage, uint64, int, error) {
+) ([]*mlsv1.WelcomeMessage, map[string]mlsstore.WaveScanTopicProgress, error) {
 	if f.welcomeGate != nil &&
 		(f.gateInstallation == nil || welcomeFiltersInclude(filters, f.gateInstallation)) {
 		f.parked()
 		select {
 		case <-f.welcomeGate:
 		case <-ctx.Done():
-			return nil, 0, 0, ctx.Err()
+			return nil, nil, ctx.Err()
 		}
 	}
-	msgs, lastRawID, rawCount, err := f.ReadMlsStore.QueryWelcomeMessagesWaveScan(
+	msgs, progress, err := f.ReadMlsStore.QueryWelcomeMessagesWaveScan(
 		ctx, filters, scanCursor, ceiling, limit,
 	)
 	if err == nil && len(f.corruptWelcomeIDs) > 0 {
@@ -1564,7 +1719,7 @@ func (f *fakeReadStore) QueryWelcomeMessagesWaveScan(
 		}
 		msgs = kept
 	}
-	return msgs, lastRawID, rawCount, err
+	return msgs, progress, err
 }
 
 // TestSubscribe_NonReadingClientIsReaped verifies a connected-but-non-reading client (a
@@ -1731,6 +1886,189 @@ func TestSubscribe_RemoveMidCatchUpFreesWaveSlot(t *testing.T) {
 	require.NoError(t, <-errCh)
 }
 
+// TestSubscribe_ScanSlotsQueueWaves pins both halves of the scan-concurrency
+// cap with one slot and three waves:
+//
+//   - a second stale wave must not start its scan until the first wave's scan
+//     finishes — deterministic because wave 1's done-batch enters the FIFO
+//     catch-up channel before its fetcher releases the slot, and wave 2's
+//     fetcher acquires the slot only after that release;
+//   - a fully-current wave must NOT queue: it prunes slot-free and completes
+//     while the sole slot is still parked inside the store, so its
+//     CatchupComplete arrives first of the three.
+//
+// A broken cap flips the first property (wave 2 overtakes the parked wave 1);
+// a current wave wrongly routed through the slot hangs the third
+// CatchupComplete until the gate opens and flips the {3, ...} prefix.
+func TestSubscribe_ScanSlotsQueueWaves(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	svc, _, validationSvc, cleanup := newTestService(t, ctx)
+	defer cleanup()
+	svc.scanMaxConcurrent = 1
+
+	groupA := []byte(test.RandomString(32))
+	groupB := []byte(test.RandomString(32))
+	groupC := []byte(test.RandomString(32))
+	mockValidateGroupMessages(validationSvc, groupA)
+	populateGroupMessages(t, ctx, svc, groupA, 2, "histA")
+	validationSvc.ExpectedCalls = nil
+	mockValidateGroupMessages(validationSvc, groupB)
+	populateGroupMessages(t, ctx, svc, groupB, 2, "histB")
+
+	latest, err := svc.readOnlyStore.Queries().GetLatestGroupMessageID(ctx)
+	require.NoError(t, err)
+
+	gate := make(chan struct{})
+	parked := make(chan struct{})
+	fake := &fakeReadStore{
+		ReadMlsStore: svc.readOnlyStore,
+		groupGate:    gate,
+		scanParked:   parked,
+	}
+	svc.readOnlyStore = fake
+
+	stream := newFakeSubscribeStream(ctx)
+	errCh := make(chan error, 1)
+	go func() { errCh <- svc.Subscribe(stream) }()
+
+	stream.send(subReqMutate(&mlsv1.SubscribeRequest_V1_Mutate{
+		Adds:     []*mlsv1.SubscribeRequest_V1_Mutate_Subscription{addSub(groupTopic(groupA), 0)},
+		MutateId: 1,
+	}))
+	select {
+	case <-parked:
+	case <-time.After(10 * time.Second):
+		t.Fatal("wave 1's scan never reached the store")
+	}
+
+	// Wave 2 is stale too: its scan needs the slot wave 1 is sitting on.
+	stream.send(subReqMutate(&mlsv1.SubscribeRequest_V1_Mutate{
+		Adds:     []*mlsv1.SubscribeRequest_V1_Mutate_Subscription{addSub(groupTopic(groupB), 0)},
+		MutateId: 2,
+	}))
+	// Wave 3 is fully current: it must prune slot-free and complete NOW, while
+	// the sole slot is parked in the store and wave 2 queues behind it.
+	stream.send(subReqMutate(&mlsv1.SubscribeRequest_V1_Mutate{
+		Adds: []*mlsv1.SubscribeRequest_V1_Mutate_Subscription{
+			addSub(groupTopic(groupC), uint64(latest)),
+		},
+		MutateId: 3,
+	}))
+	waitForResponses(t, stream, 10*time.Second, "current wave to bypass the slot queue",
+		func(rs []*mlsv1.SubscribeResponse) bool {
+			completes := catchupCompletesFrom(rs)
+			return len(completes) >= 1 && completes[0] == 3
+		})
+	// Give a hypothetically uncapped wave 2 ample time to (wrongly) reach the
+	// store and park at the gate before it opens. With the cap this only
+	// delays the gate.
+	time.Sleep(500 * time.Millisecond)
+	require.Equal(t, int32(1), fake.groupScans.Load(),
+		"only the parked wave 1 may query while it holds the sole slot")
+	close(gate)
+
+	resps := waitForResponses(t, stream, 10*time.Second, "all three waves to complete",
+		func(rs []*mlsv1.SubscribeResponse) bool { return len(catchupCompletesFrom(rs)) >= 3 })
+	require.Equal(t, []uint64{3, 1, 2}, catchupCompletesFrom(resps),
+		"current wave bypasses; the queued stale wave completes only after the slot holder")
+	require.Len(t, groupMsgsFrom(resps), 4, "both stale waves' history must be delivered in full")
+	require.Equal(t, int32(2), fake.groupScans.Load(),
+		"one turn per stale wave; the current wave never queries")
+
+	stream.closeSend()
+	require.NoError(t, <-errCh)
+}
+
+// TestSubscribe_CatchUpByteBudgetBackpressures starves the catch-up byte
+// budget (1 byte: every non-empty turn is over-budget) so each turn must be
+// admitted alone through the CAS-from-zero arm, with the group and welcome
+// scans contending for the same budget across many small rotation turns. The
+// replay must still deliver everything exactly once, ascending per topic, and
+// complete — a lost free or a lost wakeup deadlocks the wave and times the
+// test out.
+func TestSubscribe_CatchUpByteBudgetBackpressures(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	svc, _, validationSvc, cleanup := newTestService(t, ctx)
+	defer cleanup()
+	svc.scanMaxPendingBytes = 1
+	svc.scanTopicPageLimit = 2
+	svc.scanBatchTopics = 2
+	// Record the lane's peak occupancy at reservation time: with a 1-byte
+	// budget every admission must go through the empty-lane arm, so occupancy
+	// may never exceed a single turn — turns must not stack.
+	var peakLane atomic.Int64
+	svc.scanBytesObserved = func(n int64) {
+		for {
+			cur := peakLane.Load()
+			if n <= cur || peakLane.CompareAndSwap(cur, n) {
+				return
+			}
+		}
+	}
+
+	groupA := []byte(test.RandomString(32))
+	groupB := []byte(test.RandomString(32))
+	instA := []byte(test.RandomString(32))
+	hpke := []byte(test.RandomString(32))
+	mockValidateGroupMessages(validationSvc, groupA)
+	populateGroupMessages(t, ctx, svc, groupA, 5, "histA")
+	validationSvc.ExpectedCalls = nil
+	mockValidateGroupMessages(validationSvc, groupB)
+	populateGroupMessages(t, ctx, svc, groupB, 5, "histB")
+	populateWelcomeMessages(t, ctx, svc, instA, hpke, 5, "welA")
+
+	stream := newFakeSubscribeStream(ctx)
+	errCh := make(chan error, 1)
+	go func() { errCh <- svc.Subscribe(stream) }()
+
+	stream.send(subReqMutate(&mlsv1.SubscribeRequest_V1_Mutate{
+		Adds: []*mlsv1.SubscribeRequest_V1_Mutate_Subscription{
+			addSub(groupTopic(groupA), 0),
+			addSub(groupTopic(groupB), 0),
+			addSub(welcomeTopic(instA), 0),
+		},
+		MutateId: 1,
+	}))
+
+	resps := waitForResponses(t, stream, 10*time.Second, "full starved replay",
+		func(rs []*mlsv1.SubscribeResponse) bool {
+			return len(groupMsgsFrom(rs)) >= 10 && len(welcomeMsgsFrom(rs)) >= 5 &&
+				len(catchupCompletesFrom(rs)) >= 1
+		})
+	require.Equal(t, []uint64{1}, catchupCompletesFrom(resps))
+
+	perTopic := map[string][]uint64{}
+	for _, m := range groupMsgsFrom(resps) {
+		key := string(m.GetV1().GetGroupId())
+		perTopic[key] = append(perTopic[key], m.GetV1().GetId())
+	}
+	require.Len(t, perTopic, 2, "both group topics replayed")
+	for topic, ids := range perTopic {
+		require.Len(t, ids, 5, "topic %x exactly once", topic)
+		for i := 1; i < len(ids); i++ {
+			require.Greater(t, ids[i], ids[i-1], "topic %x ids must ascend", topic)
+		}
+	}
+	welcomes := welcomeMsgsFrom(resps)
+	require.Len(t, welcomes, 5, "welcome history exactly once")
+	for i := 1; i < len(welcomes); i++ {
+		require.Greater(t, welcomeID(welcomes[i]), welcomeID(welcomes[i-1]),
+			"welcome ids must ascend")
+	}
+
+	// The largest possible turn here is a full group batch: 2 topics × 2 rows
+	// of len("histX_n") = 7 payload bytes. Anything above that means two turns
+	// were admitted concurrently past the starved budget.
+	require.Positive(t, peakLane.Load(), "the observer must have seen reservations")
+	require.LessOrEqual(t, peakLane.Load(), int64(28),
+		"a starved budget must admit turns one at a time, never stacked")
+
+	stream.closeSend()
+	require.NoError(t, <-errCh)
+}
+
 // TestSubscribe_PendingBufferCapAborts verifies the maxPendingBytes guard: live messages
 // buffered while a topic is stuck catching up cannot grow without bound.
 func TestSubscribe_PendingBufferCapAborts(t *testing.T) {
@@ -1742,6 +2080,10 @@ func TestSubscribe_PendingBufferCapAborts(t *testing.T) {
 
 	groupA := []byte(test.RandomString(32))
 	mockValidateGroupMessages(validationSvc, groupA)
+	// One history row keeps the ceiling above the cursor: a fully-current topic
+	// is pruned without ever reaching the gated scan, and this test needs the
+	// wave parked mid-catch-up.
+	populateGroupMessages(t, ctx, svc, groupA, 1, "hist")
 	gate := make(chan struct{})
 	defer close(gate)
 	svc.readOnlyStore = &fakeReadStore{ReadMlsStore: svc.readOnlyStore, groupGate: gate}
@@ -2744,25 +3086,25 @@ func TestSubscribe_FoldSortsAcrossTopics(t *testing.T) {
 
 // TestSubscribe_WelcomeWaveScanSkipsUnparseableRows pins the welcome fetcher's paging
 // contract at the Subscribe level: a row the store cannot parse (an unknown message_type
-// from a future writer) still consumes a raw LIMIT slot, so the fetcher must advance its
-// cursor from the raw scan position (lastRawID) and terminate on a short RAW page —
-// paging by the parsed slice would silently truncate the wave at the first skipped row
-// inside a full page.
+// from a future writer) still consumes its topic's raw LIMIT slot, so the fetcher must
+// advance the topic's cursor from its raw scan position and retire it only on a short RAW
+// count — paging by the parsed slice would silently truncate the wave at the first
+// skipped row inside a full turn.
 func TestSubscribe_WelcomeWaveScanSkipsUnparseableRows(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	svc, _, _, cleanup := newTestService(t, ctx)
 	defer cleanup()
-	svc.scanPageLimit = 4 // small pages so the corrupt row sits inside a full page
+	svc.scanTopicPageLimit = 4 // small pages so the corrupt row sits inside a full page
 
 	inst := []byte(test.RandomString(32))
 	hpke := []byte(test.RandomString(32))
 	const total = 10
 	populateWelcomeMessages(t, ctx, svc, inst, hpke, total, "wel")
 
-	// Learn the real ids, then mark one INSIDE the first full raw page (not the final
-	// page) as unparseable: it keeps its raw slot but drops from the parsed slice.
-	all, _, rawCount, err := svc.readOnlyStore.QueryWelcomeMessagesWaveScan(
+	// Learn the real ids, then mark one INSIDE the first full raw turn (not the final
+	// turn) as unparseable: it keeps its raw slot but drops from the parsed slice.
+	all, progress, err := svc.readOnlyStore.QueryWelcomeMessagesWaveScan(
 		ctx,
 		[]mlsstore.WelcomeCatchup{{InstallationKey: inst}},
 		0,
@@ -2770,7 +3112,7 @@ func TestSubscribe_WelcomeWaveScanSkipsUnparseableRows(t *testing.T) {
 		total,
 	)
 	require.NoError(t, err)
-	require.Equal(t, total, rawCount)
+	require.Equal(t, total, progress[string(inst)].RawCount)
 	corruptID := welcomeID(all[2])
 	svc.readOnlyStore = &fakeReadStore{
 		ReadMlsStore:      svc.readOnlyStore,
@@ -2809,7 +3151,7 @@ func TestSubscribe_EveryHistoryPageCarriesWaveTag(t *testing.T) {
 	defer cancel()
 	svc, _, validationSvc, cleanup := newTestService(t, ctx)
 	defer cleanup()
-	svc.scanPageLimit = 50 // small pages so a modest history spans several
+	svc.scanTopicPageLimit = 50 // small pages so a modest history spans several
 
 	groupA := []byte(test.RandomString(32))
 	mockValidateGroupMessages(validationSvc, groupA)

--- a/pkg/mls/store/readStore.go
+++ b/pkg/mls/store/readStore.go
@@ -348,6 +348,15 @@ type WelcomeCatchup struct {
 	IdCursor        uint64
 }
 
+// WaveScanTopicProgress is one topic's raw scan position within a wave-scan
+// turn: how many raw rows its probe returned (parsed or skipped) and the last
+// raw id visited. A topic whose RawCount is below the per-topic limit is fully
+// replayed up to the ceiling.
+type WaveScanTopicProgress struct {
+	RawCount  int
+	LastRawID uint64
+}
+
 // clampCursor narrows a uint64 client cursor to the int64 the SQL columns use,
 // saturating at MaxInt64. A cursor above 2^63-1 can't match any real row id, so
 // it must return no rows; without the clamp the int64 conversion would wrap to a
@@ -360,23 +369,38 @@ func clampCursor(c uint64) int64 {
 	return int64(c)
 }
 
+// The LATERAL shape matters: each topic is one bounded range probe of the
+// (group_id, id) index, capped at limit rows PER TOPIC, so the result is
+// bounded by len(filters)×limit and every fetched row is returned — no work is
+// fetched twice. The obvious flat join with a global ORDER BY id invites the
+// planner to walk the whole (scanCursor, ceiling] id range filtering by topic
+// membership instead — which makes an EMPTY catch-up (the common reconnect
+// case) cost a full pass over the table. The outer ORDER BY is load-bearing:
+// per-topic ascending delivery is what the writer's high-water dedup and the
+// client's replay guards rely on, and an unordered result would only be
+// topic-major by planner accident.
 const queryGroupMessagesWaveScan = `
 SELECT g.id, g.created_at, g.group_id, g.data, g.is_commit, g.sender_hmac, g.should_push
-FROM group_messages g
-JOIN unnest($1::BYTEA[], $2::BIGINT[]) AS f (group_id, id_cursor)
-	ON g.group_id = f.group_id
-WHERE g.id > f.id_cursor AND g.id > $3 AND g.id <= $4
-ORDER BY g.id ASC
-LIMIT $5`
+FROM unnest($1::BYTEA[], $2::BIGINT[]) AS f (group_id, id_cursor)
+CROSS JOIN LATERAL (
+	SELECT m.id, m.created_at, m.group_id, m.data, m.is_commit, m.sender_hmac, m.should_push
+	FROM group_messages m
+	WHERE m.group_id = f.group_id
+		AND m.id > GREATEST(f.id_cursor, $3)
+		AND m.id <= $4
+	ORDER BY m.id ASC
+	LIMIT $5
+) AS g
+ORDER BY g.id ASC`
 
-// QueryGroupMessagesWaveScan fetches one page of a catch-up wave's replay: the
-// messages of many groups merged into a single ascending-id scan (XIP-83 server
-// requirement 4 — a wave's replay is one cursor-ordered pass across its topics,
-// not per-topic bursts). Each group's rows start above that group's own cursor;
-// the page as a whole starts above scanCursor (the previous page's last id) and
-// never exceeds ceiling (the newest id at wave start, so the scan terminates
-// under sustained publishing). A page shorter than limit means the wave is fully
-// replayed up to the ceiling.
+// QueryGroupMessagesWaveScan fetches one turn of a catch-up wave's replay: up
+// to limit rows for EACH filter group, merged into a single ascending-id
+// result. Each group's rows start above that group's own cursor (and above
+// scanCursor, an additional shared floor the rotating caller leaves at zero)
+// and never exceed ceiling (the newest id at wave start, so the scan
+// terminates under sustained publishing). Truncation is per group: a group
+// contributing exactly limit rows may have more, fewer means it is fully
+// replayed up to the ceiling. The caller derives both from the returned rows.
 //
 // Filter keys MUST be unique: unnest preserves duplicates and the join would
 // return a repeated group's rows more than once. The Subscribe handler
@@ -442,30 +466,39 @@ func (s *ReadStore) QueryGroupMessagesWaveScan(
 	return out, rows.Err()
 }
 
+// Same LATERAL-probe shape as queryGroupMessagesWaveScan, for the same
+// reasons: per-key bounded probes of (installation_key, id) with a per-topic
+// limit, and a load-bearing outer ORDER BY.
 const queryWelcomeMessagesWaveScan = `
 SELECT w.id, w.created_at, w.installation_key, w.data, w.hpke_public_key, w.wrapper_algorithm, w.welcome_metadata, w.message_type
-FROM welcome_messages w
-JOIN unnest($1::BYTEA[], $2::BIGINT[]) AS f (installation_key, id_cursor)
-	ON w.installation_key = f.installation_key
-WHERE w.id > f.id_cursor AND w.id > $3 AND w.id <= $4
-ORDER BY w.id ASC
-LIMIT $5`
+FROM unnest($1::BYTEA[], $2::BIGINT[]) AS f (installation_key, id_cursor)
+CROSS JOIN LATERAL (
+	SELECT m.id, m.created_at, m.installation_key, m.data, m.hpke_public_key, m.wrapper_algorithm, m.welcome_metadata, m.message_type
+	FROM welcome_messages m
+	WHERE m.installation_key = f.installation_key
+		AND m.id > GREATEST(f.id_cursor, $3)
+		AND m.id <= $4
+	ORDER BY m.id ASC
+	LIMIT $5
+) AS w
+ORDER BY w.id ASC`
 
-// QueryWelcomeMessagesWaveScan is the welcome-topic analogue of QueryGroupMessagesWaveScan.
-// A row with an unknown message_type is skipped from the parsed result but still consumed a
-// LIMIT slot, so the scan position is reported from the RAW rows: lastRawID is the last row
-// the query visited and rawCount how many. Callers MUST advance their cursor from lastRawID
-// and treat rawCount < limit as end-of-scan; paging by the parsed slice would silently
-// truncate the replay at the first skipped row inside a full page.
+// QueryWelcomeMessagesWaveScan is the welcome-topic analogue of
+// QueryGroupMessagesWaveScan. A row with an unknown message_type is skipped
+// from the parsed result but still consumed its topic's LIMIT slot, so scan
+// positions are reported from the RAW rows via the progress map (keyed by
+// installation key): callers MUST advance a topic's cursor from its LastRawID
+// and treat RawCount < limit as that topic's end-of-scan; paging by the parsed
+// slice would silently truncate the replay at the first skipped row.
 func (s *ReadStore) QueryWelcomeMessagesWaveScan(
 	ctx context.Context,
 	filters []WelcomeCatchup,
 	scanCursor uint64,
 	ceiling uint64,
 	limit int32,
-) ([]*mlsv1.WelcomeMessage, uint64, int, error) {
+) ([]*mlsv1.WelcomeMessage, map[string]WaveScanTopicProgress, error) {
 	if len(filters) == 0 || ceiling == 0 {
-		return nil, 0, 0, nil
+		return nil, nil, nil
 	}
 	keys := make([][]byte, len(filters))
 	cursors := make([]int64, len(filters))
@@ -483,13 +516,12 @@ func (s *ReadStore) QueryWelcomeMessagesWaveScan(
 		limit,
 	)
 	if err != nil {
-		return nil, 0, 0, err
+		return nil, nil, err
 	}
 	defer func() { _ = rows.Close() }()
 
 	var out []*mlsv1.WelcomeMessage
-	var lastRawID uint64
-	rawCount := 0
+	progress := make(map[string]WaveScanTopicProgress, len(filters))
 	for rows.Next() {
 		var (
 			id               int64
@@ -502,10 +534,12 @@ func (s *ReadStore) QueryWelcomeMessagesWaveScan(
 			messageType      int16
 		)
 		if err := rows.Scan(&id, &createdAt, &installationKey, &data, &hpkePublicKey, &wrapperAlgorithm, &welcomeMetadata, &messageType); err != nil {
-			return nil, 0, 0, err
+			return nil, nil, err
 		}
-		lastRawID = uint64(id)
-		rawCount++
+		p := progress[string(installationKey)]
+		p.RawCount++
+		p.LastRawID = uint64(id)
+		progress[string(installationKey)] = p
 		switch messageType {
 		case 0:
 			out = append(out, &mlsv1.WelcomeMessage{
@@ -543,7 +577,7 @@ func (s *ReadStore) QueryWelcomeMessagesWaveScan(
 			s.log.Error("unknown welcome message type", zap.Int16("message_type", messageType))
 		}
 	}
-	return out, lastRawID, rawCount, rows.Err()
+	return out, progress, rows.Err()
 }
 
 func (s *ReadStore) QueryCommitLog(

--- a/pkg/mls/store/store.go
+++ b/pkg/mls/store/store.go
@@ -69,7 +69,7 @@ type ReadMlsStore interface {
 		scanCursor uint64,
 		ceiling uint64,
 		limit int32,
-	) ([]*mlsv1.WelcomeMessage, uint64, int, error)
+	) ([]*mlsv1.WelcomeMessage, map[string]WaveScanTopicProgress, error)
 	QueryCommitLog(
 		ctx context.Context,
 		query *mlsv1.QueryCommitLogRequest,
@@ -440,7 +440,7 @@ func (s *Store) QueryWelcomeMessagesWaveScan(
 	scanCursor uint64,
 	ceiling uint64,
 	limit int32,
-) ([]*mlsv1.WelcomeMessage, uint64, int, error) {
+) ([]*mlsv1.WelcomeMessage, map[string]WaveScanTopicProgress, error) {
 	return s.readstore.QueryWelcomeMessagesWaveScan(ctx, filters, scanCursor, ceiling, limit)
 }
 

--- a/pkg/mls/store/store_test.go
+++ b/pkg/mls/store/store_test.go
@@ -1271,9 +1271,10 @@ func TestQueryWelcomeMessagesV1_Paginate(t *testing.T) {
 
 // TestQueryWelcomeMessagesWaveScan_UnknownTypeRowsAdvanceRawCursor pins the wave scan's
 // paging contract: a row with an unknown message_type is skipped from the parsed result
-// but still consumes a LIMIT slot, so the raw scan position (lastRawID / rawCount) — not
-// the parsed slice — must drive the cursor. Paging by parsed rows would end the scan on
-// the first short page and silently truncate the replay.
+// but still consumes its topic's LIMIT slot, so the topic's raw scan position (RawCount /
+// LastRawID in the progress map) — not the parsed slice — must drive the cursor. Paging
+// by parsed rows would end the scan on the first short turn and silently truncate the
+// replay.
 func TestQueryWelcomeMessagesWaveScan_UnknownTypeRowsAdvanceRawCursor(t *testing.T) {
 	store, cleanup := NewTestStore(t)
 	defer cleanup()
@@ -1301,27 +1302,28 @@ func TestQueryWelcomeMessagesWaveScan_UnknownTypeRowsAdvanceRawCursor(t *testing
 	ceiling, err := store.queries.GetLatestWelcomeMessageID(ctx)
 	require.NoError(t, err)
 
-	// Page exactly as the Subscribe welcome fetcher does: advance from the raw scan
-	// position, terminate on a short raw page.
+	// Page exactly as the Subscribe welcome fetcher does: advance the topic's own
+	// cursor from its raw scan position, terminate when its raw count comes up short.
 	const limit = 4
+	key := string(installationKey)
 	filters := []WelcomeCatchup{{InstallationKey: installationKey, IdCursor: 0}}
 	var got []*mlsv1.WelcomeMessage
-	scanCursor := uint64(0)
 	done := false
-	for i := 0; i < 10 && !done; i++ { // bound the loop; 3 pages suffice
-		msgs, lastRawID, rawCount, err := store.QueryWelcomeMessagesWaveScan(
+	for i := 0; i < 10 && !done; i++ { // bound the loop; 3 turns suffice
+		msgs, progress, err := store.QueryWelcomeMessagesWaveScan(
 			ctx,
 			filters,
-			scanCursor,
+			0,
 			uint64(ceiling),
 			limit,
 		)
 		require.NoError(t, err)
-		if rawCount > 0 {
-			scanCursor = lastRawID
-		}
 		got = append(got, msgs...)
-		done = rawCount < limit
+		p := progress[key]
+		if p.RawCount > 0 && filters[0].IdCursor < p.LastRawID {
+			filters[0].IdCursor = p.LastRawID
+		}
+		done = p.RawCount < limit
 	}
 	require.True(t, done, "the scan must terminate on a short raw page")
 	require.Len(t, got, 9, "every parseable row must be returned despite the skipped row")


### PR DESCRIPTION
## Why

Production incident (P1 "Network DB has high CPU usage", Datadog monitor 78294686): the production `mls` RDS climbed from ~1% to a sustained ~65% CPU between Jul 28 and Aug 3 with **no change in request volume**. Performance Insights attributed essentially the entire load (3.9 of 3.9 average active sessions, all CPU) to one statement: the XIP-83 bidi `Subscribe` welcome catch-up wave scan. The bidi subscriber population (~6 endpoints) reconnected ~1,450×/hour due to aggressive client transport keepalive, and every reconnect wave paid a scan of the whole `welcome_messages` id window **even when the client was already fully caught up** — a cost that grows with the (append-only, unpruned) table.

## What

Four changes to the catch-up path, for both group and welcome topics:

1. **Prune** — topics whose cursor already sits at the ceiling can match no rows (`id > cursor AND id <= ceiling`), so they are dropped before any query. A fully-current reconnect wave — the overwhelmingly dominant production case — completes with **zero** DB round trips.
2. **Rotate with per-topic budgets** — remaining topics are scanned in rotating batches of ≤256. One query per turn returns up to **64 rows per topic** (no outer LIMIT), so a turn is bounded at 16,384 rows and **every fetched row is delivered exactly once — no work is discarded and re-fetched**. A topic that fills its budget advances its own cursor to its own last id and rotates to the back; every other topic retires individually, so drained topics stop being probed at all. The welcome store reports per-topic raw scan positions so unknown-`message_type` rows keep consuming their topic's budget without truncating the replay.
3. **LATERAL probes** — the wave-scan SQL becomes `unnest → CROSS JOIN LATERAL` bounded probes of the existing `(group_id, id)` / `(installation_key, id)` indexes instead of a flat join over the global id window. An empty catch-up costs k index probes, independent of table size. The outer `ORDER BY id` is kept deliberately: per-topic ascending delivery is load-bearing for the writer's high-water dedup and the client's replay guards (unordered SQL would only be topic-major by planner accident), and it now sorts at most one bounded turn. No new indexes or migrations.
4. **Bound the catch-up lane** — at most 4 of a stream's scans fetch concurrently: a scan with rows to replay holds a slot from before its first wave-scan query until its done marker is in the channel, excess scans queue FIFO, and **fully-current waves — the dominant reconnect case — prune slot-free**, so they never wait behind a deep replay while their topics sit gated. Fetched-but-unconsumed payload bytes are held under a 64 MiB budget with backpressure: a scan reserves its turn's bytes after the query returns and parks until the writer frees room, and an empty lane admits any single turn, so an over-budget turn replays alone instead of deadlocking. Both bounds are per-stream, channel-and-atomic based — the single-writer, no-mutex model is unchanged.

### Ordering contract change

Replay ids ascend **within each turn and per topic across the wave**, not globally across the wave. Both consumers are per-topic (writer high-water dedup; the client's `claims`/`replayed` guards — see xmtp/libxmtp#3934, which also removes a client telemetry warn that assumed the old wave-global order). The live lane keeps total cursor order and is untouched. XIP-83 server requirement 4's wording needs a matching amendment — tracked separately.

### Resource bounds (stated honestly)

Per query: ≤16,384 rows. The lane's other two axes are bounded in code (change 4): concurrent scans ≤4 per stream, and fetched-but-unconsumed bytes ≤ max(64 MiB, one turn). On top of that sit not-yet-reserved query results in flight (≤4 turns) and the writer→sender pipeline, which the budget deliberately does not cover — delivery is separately turn-bounded by the send queue depth (8) plus the writer's and sender's hands. Residuals, stated plainly: a single turn is bounded in rows, not bytes, so pathologically fat payloads can still make one turn large (shrinking that requires the id-only-probe + payload-rejoin rework); a stream can starve its own deep wave's large turns by continually starting small waves (bounded self-harm — budget and slots are per-stream); and a wave whose topics were all removed still runs its scan to completion against the slot cap (its output is dropped, and dropped batches drain at writer speed).

## Adversarial review

Two independent adversarial rounds (ownership audit, termination proofs, SQL equivalence via live-Postgres EXPLAIN and probing, protocol contract, test-vacuity checks). Findings across both rounds, all addressed: a post-handoff read of the forwarded slice raced with the writer's in-place filtering (caught by `-race`; positions are now captured before `forward()`); `TestSubscribe_PendingBufferCapAborts` was silently broken by pruning (now populates history so the pending-cap is genuinely exercised); non-positive tunables could spin the rotation loop (guarded); the in-flight memory bound above was understated (buffer resized + documented). The reviews could not refute: per-topic truncation soundness (no loss, duplication, or spin at any boundary, including all-unparseable welcome turns and above-ceiling-only topics), single-writer ownership of every touched datum, row-exact SQL semantics ("≤ limit rows per topic above its floor, ≤ ceiling, ascending within the turn," verified against live Postgres), exactly-once per-topic-ascending delivery across rotation turns including topic remove/re-add, and exactly one CatchupComplete per wave on every path.

A third round targeted the resource-bound delta. It confirmed deadlock freedom (every park has a ctx escape; one wakeup tap per free suffices for any number of parked scans; worst-case reserved occupancy is exactly max(budget, one turn)) and surfaced one real behavioral finding, fixed before push: the ceiling snapshot and prune originally ran **under** the scan slot, so a fully-current reconnect wave could queue behind a deep replay while its topics sat gated — live traffic accumulating against the pending-buffer abort. Current waves now prune slot-free and only compete for a slot when they have rows to replay (pinned by test). The same round corrected the peak-memory prose (the budget bounds fetched-but-unconsumed bytes; the writer→sender pipeline is separately turn-bounded) and motivated a reservation-time occupancy observer so the byte test pins the admission bound, not just liveness.

## Verification

- Tests: `TestSubscribe_CurrentCursorWaveSkipsScan` (zero store calls for a current wave, counter proven live), `TestSubscribe_WaveRotatesInBatches` (batch ceiling per query, cross-turn re-query, exactly-once per-topic-ascending delivery), `TestSubscribe_ScanSlotsQueueWaves` (deterministic slot queuing **and** current-wave bypass: CatchupComplete order {3, 1, 2} with one slot), `TestSubscribe_CatchUpByteBudgetBackpressures` (1-byte starved budget: exactly-once ascending delivery across contending group+welcome scans, no deadlock, single-turn peak occupancy pinned via observer), updated per-topic unparseable-row tests at store and Subscribe level
- `go test ./...` — entire repo, 0 failures; `pkg/mls/...` clean under `-race`; `golangci-lint` 0 issues

## Companions

- xmtp/libxmtp#3934 — client per-topic replay progress (deploy-order-independent)
- xmtp/libxmtp#3933 — relaxed client keepalive defaults (stops the reconnect churn that multiplied this cost)
- Production mitigation already live: herald fleets opted out of bidi + generous keepalive overrides (convos-assistants#3170, infrastructure PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rewrite MLS Subscribe catch-up wave scans to use per-topic index probes with batch rotation and bounded concurrency
> - Replaces the single global-page-limit catch-up scan with per-topic `CROSS JOIN LATERAL` probes in [readStore.go](https://github.com/xmtp/xmtp-node-go/pull/565/files#diff-dd33ec3fb3a437dba033e0c35fbfd35b7087521015056d342cfb162356bb54be), so deep topics no longer starve shallow ones and empty topics don't consume quota.
> - Adds scan slot semaphore (`scanMaxConcurrent`), catch-up byte budget (`scanMaxPendingBytes`), and topic batch rotation (`scanBatchTopics`) to [subscribe.go](https://github.com/xmtp/xmtp-node-go/pull/565/files#diff-4d0bdf82f9e0725ea45bba80575bad96dce9c1961f1fb9b600bf633b6ee6dcbe), replacing unbounded buffering with backpressure.
> - Waves where all topic cursors are already current skip scan slot acquisition entirely, avoiding unnecessary DB round-trips.
> - `QueryWelcomeMessagesWaveScan` now returns a `map[string]WaveScanTopicProgress` keyed by installation key so callers advance per-topic cursors using raw progress, preventing truncation when unknown message types are present.
> - Behavioral Change: catch-up now queues excess waves FIFO under a concurrency cap rather than running all waves concurrently; byte budget backpressures fetchers instead of buffering unboundedly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 469b2ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
