### PR TITLE
perf(mls/api): coalesce already-queued live Subscribe messages into fewer frames

### DIFF
--- a/pkg/mls/api/v1/subscribe.go
+++ b/pkg/mls/api/v1/subscribe.go
@@ -33,6 +33,12 @@ const (
 	// sendQueueDepth buffers frame batches between the writer and the sender goroutine, so the
 	// writer is not parked by a slow stream.Send. Small: it only smooths Send latency.
 	sendQueueDepth = 8
+	// liveCoalesceMax bounds how many already-queued live messages the writer drains into
+	// one send after receiving one, packing a burst of small per-message frames into fewer
+	// (byte-batched) frames without blocking. Purely a fairness cap so a hot producer cannot
+	// keep the writer in the live branch and starve ping/mutation handling; frame size is
+	// separately bounded by maxFrameBytes.
+	liveCoalesceMax = 256
 
 	// Wave-scan catch-up tuning (XIP-83 server requirement 4, amended for batch
 	// rotation). A wave prunes topics whose cursor already sits at the ceiling,
@@ -1239,36 +1245,65 @@ func (s *Service) Subscribe(stream mlsv1.MlsApi_SubscribeServer) error {
 			if !open {
 				return status.Errorf(codes.Aborted, "subscription closed: consumer too slow")
 			}
-			t := env.ContentTopic
-			if catchingUp[t] {
-				pending[t] = append(pending[t], env)
-				pendingBytes += len(env.Message)
-				if pendingBytes > s.maxPendingBytes {
-					return status.Errorf(
-						codes.ResourceExhausted,
-						"catch-up buffer exceeded; reconnect from cursor",
-					)
-				}
-				continue
-			}
 			// Live tail: tagged 0. The dispatcher delivers each kind in ascending id
 			// order and the writer sends in arrival order, so the live lane stays
 			// totally ordered per kind (XIP-83 server requirement 4).
-			var frames []*mlsv1.SubscribeResponse
-			if topic.IsMLSV1Welcome(t) {
-				if m, err := getWelcomeMessageFromEnvelope(env); err == nil {
-					frames = buildWelcomeFrames([]*mlsv1.WelcomeMessage{m}, 0)
-				} else {
-					log.Error("error parsing welcome message", zap.Error(err))
+			//
+			// Coalesce any messages already queued behind this one — without blocking, so
+			// no added latency — into as few frames as possible. buildWelcome/GroupFrames
+			// pack per kind up to maxFrameBytes, so a burst of small live messages that
+			// would otherwise stream as one tiny frame each (pressuring the h2 inbound
+			// data-frame guard on clients streaming many small welcomes/messages) goes out
+			// in a handful of full frames. Messages for still-catching-up topics keep
+			// buffering to the gated lane, exactly as before.
+			var liveWelcomes []*mlsv1.WelcomeMessage
+			var liveGroups []*mlsv1.GroupMessage
+			route := func(e *v1proto.Envelope) error {
+				t := e.ContentTopic
+				if catchingUp[t] {
+					pending[t] = append(pending[t], e)
+					pendingBytes += len(e.Message)
+					if pendingBytes > s.maxPendingBytes {
+						return status.Errorf(
+							codes.ResourceExhausted,
+							"catch-up buffer exceeded; reconnect from cursor",
+						)
+					}
+					return nil
 				}
-			} else {
-				if m, err := getGroupMessageFromEnvelope(env); err == nil {
-					frames = buildGroupFrames([]*mlsv1.GroupMessage{m}, 0)
+				if topic.IsMLSV1Welcome(t) {
+					if m, err := getWelcomeMessageFromEnvelope(e); err == nil {
+						liveWelcomes = append(liveWelcomes, m)
+					} else {
+						log.Error("error parsing welcome message", zap.Error(err))
+					}
 				} else {
-					log.Error("error parsing group message", zap.Error(err))
+					if m, err := getGroupMessageFromEnvelope(e); err == nil {
+						liveGroups = append(liveGroups, m)
+					} else {
+						log.Error("error parsing group message", zap.Error(err))
+					}
+				}
+				return nil
+			}
+			if err := route(env); err != nil {
+				return err
+			}
+		drainLive:
+			for i := 0; i < liveCoalesceMax; i++ {
+				select {
+				case next, ok := <-sub.MessagesCh:
+					if !ok {
+						return status.Errorf(codes.Aborted, "subscription closed: consumer too slow")
+					}
+					if err := route(next); err != nil {
+						return err
+					}
+				default:
+					break drainLive // channel momentarily empty: flush what we have
 				}
 			}
-			if err := send(frames); err != nil {
+			if err := send(buildWelcomeFrames(liveWelcomes, 0), buildGroupFrames(liveGroups, 0)); err != nil {
 				return err
 			}
 

--- a/pkg/mls/api/v1/subscribe_test.go
+++ b/pkg/mls/api/v1/subscribe_test.go
@@ -66,13 +66,28 @@ func (f *fakeSubscribeStream) responses() []*mlsv1.SubscribeResponse {
 // --- mlsv1.MlsApi_SubscribeServer ---
 
 func (f *fakeSubscribeStream) Send(resp *mlsv1.SubscribeResponse) error {
-	if f.blockSend != nil {
-		<-f.blockSend
+	f.mu.Lock()
+	block := f.blockSend
+	f.mu.Unlock()
+	if block != nil {
+		<-block
 	}
 	f.mu.Lock()
 	f.sent = append(f.sent, resp)
 	f.mu.Unlock()
 	return nil
+}
+
+// freezeSends makes every subsequent Send block until the returned release func is called.
+// Unlike setting blockSend directly, it is safe to call after Subscribe has started (the
+// field is guarded by mu), so a test can quiesce the sender mid-stream to force frames to
+// queue.
+func (f *fakeSubscribeStream) freezeSends() (release func()) {
+	ch := make(chan struct{})
+	f.mu.Lock()
+	f.blockSend = ch
+	f.mu.Unlock()
+	return func() { close(ch) }
 }
 
 func (f *fakeSubscribeStream) Recv() (*mlsv1.SubscribeRequest, error) {
@@ -2142,6 +2157,80 @@ func TestSubscribe_FramesSplitByMaxFrameBytes(t *testing.T) {
 	}
 	require.Equal(t, n, frames, "at maxFrameBytes=1 each message must be sent in its own frame")
 	require.Len(t, groupMsgsFrom(resps), n)
+
+	stream.closeSend()
+	require.NoError(t, <-errCh)
+}
+
+// TestSubscribe_LiveBurstCoalescesWhenQueued pins the live-lane coalescing drain: a burst of
+// live messages queued behind the one the writer is processing is packed into fewer frames
+// (bounded by liveCoalesceMax / maxFrameBytes) instead of one tiny frame each, while every
+// message is still delivered exactly once, in ascending id order, tagged live (mutate_id 0).
+//
+// Determinism: publishing only after CatchupComplete keeps every message on the live path (not
+// the gated catch-up lane). Freezing the sender first caps in-flight frames at sendQueueDepth,
+// so a 64-message burst cannot be flushed as 64 singles — the writer must coalesce the
+// remainder — making the coalescing assertion deterministic rather than timing-dependent.
+func TestSubscribe_LiveBurstCoalescesWhenQueued(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	svc, _, validationSvc, cleanup := newTestService(t, ctx)
+	defer cleanup()
+
+	groupId := []byte(test.RandomString(32))
+	mockValidateGroupMessages(validationSvc, groupId)
+
+	stream := newFakeSubscribeStream(ctx)
+	errCh := make(chan error, 1)
+	go func() { errCh <- svc.Subscribe(stream) }()
+
+	// No history: subscribe, then wait for catch-up to complete so the topic is fully live
+	// before publishing — otherwise early messages would ride the gated catch-up lane and be
+	// tagged with the wave rather than delivered live.
+	stream.send(subReqMutate(&mlsv1.SubscribeRequest_V1_Mutate{
+		Adds:     []*mlsv1.SubscribeRequest_V1_Mutate_Subscription{addSub(groupTopic(groupId), 0)},
+		MutateId: 1,
+	}))
+	waitForResponses(t, stream, 5*time.Second, "CatchupComplete",
+		func(rs []*mlsv1.SubscribeResponse) bool { return len(catchupCompletesFrom(rs)) >= 1 })
+
+	// Quiesce the sender so the burst queues on the subscription channel and the writer must
+	// coalesce it (in-flight frames are bounded by sendQueueDepth), then release to flush.
+	release := stream.freezeSends()
+	const n = 64
+	populateGroupMessages(t, ctx, svc, groupId, n, "live")
+	release()
+
+	resps := waitForResponses(
+		t,
+		stream,
+		10*time.Second,
+		fmt.Sprintf("%d live group messages", n),
+		func(rs []*mlsv1.SubscribeResponse) bool { return len(groupMsgsTagged(rs, 0)) >= n },
+	)
+
+	// Correctness: every message delivered exactly once, in order, tagged live (0).
+	live := groupMsgsTagged(resps, 0)
+	require.Len(t, live, n, "every live message delivered exactly once, tagged mutate_id 0")
+	validateMessageOrdering(t, live)
+	validateNoDuplicates(t, live)
+
+	// Coalescing: with the sender frozen during the burst, at least one live frame must carry
+	// several messages — proving the drain packed a queued burst rather than one-per-frame.
+	maxPerFrame := 0
+	for _, r := range resps {
+		if m := r.GetV1().GetMessages(); m != nil && m.GetMutateId() == 0 {
+			if k := len(m.GetGroupMessages()); k > maxPerFrame {
+				maxPerFrame = k
+			}
+		}
+	}
+	require.Greater(
+		t,
+		maxPerFrame,
+		1,
+		"a queued live burst must coalesce into at least one multi-message frame",
+	)
 
 	stream.closeSend()
 	require.NoError(t, <-errCh)


### PR DESCRIPTION
## Why

Clients on Rust `h2` ≥ 0.4.16 abort the XIP-83 bidi wire with a GOAWAY
`ENHANCE_YOUR_CALM: too_many_data_frames` when the server streams too many
small DATA frames on the response half: `h2`'s inbound anti-DoS budget counts
each `<256 B` frame. The catch-up lane already coalesces (history packs up to
`maxFrameBytes` = 2 MiB per frame), but the **live lane sent one frame per
message**, so a burst of small live welcomes/messages streamed as a burst of
tiny frames.

The client side is fixed separately (h2 0.4.19 raises the budget to
`connection_window/2` ≈ 1 GB via `DataFrameBudget::Auto`). This change is
**server-side defense-in-depth**: it keeps the server from emitting a
small-frame flood at all, protecting any client whose h2 build still carries
the tighter budget (older libxmtp, browsers, third parties) — not load-bearing
now that the client is patched, but cheap insurance.

## What

In the writer's live-delivery branch, after receiving one message, drain any
messages **already queued** on the subscription channel — **without blocking**
(a bounded, non-blocking `select { case: default: break }`, cap
`liveCoalesceMax = 256`) — and pack them through the existing per-kind
byte-batched builders (`buildWelcomeFrames`/`buildGroupFrames`) instead of one
frame per message. No added latency: it only coalesces what is already
buffered; a trickle still goes out one frame at a time.

- A `route` closure applies the **unchanged** gating: messages for
  still-catching-up topics buffer to `pending` (with the same
  `maxPendingBytes` guard); others accumulate into per-kind slices.
- Live frames stay tagged `mutate_id 0`; per-topic ascending-id order and the
  high-water dedup are preserved (the builders are unchanged).
- Mid-drain channel close returns `codes.Aborted` exactly as before.

Purely a framing optimization — no wire/proto/API change, no client change
required.

## Scope & trade-offs

- Live lane only; catch-up was already coalesced.
- Within one drain, all welcomes are emitted before all groups. Cross-kind
  order is not part of the contract (welcomes and group messages are always
  distinct topics/kinds; per-kind order is what requirement 4 guarantees, and
  cross-kind order was never deterministic — two workers race on the dispatcher
  lock), so this is benign.
- `liveCoalesceMax` is a fairness cap so a hot producer cannot keep the writer
  in the live branch and starve ping/pong and mutation handling; frame size is
  separately bounded by `maxFrameBytes`.
- A drain buffers up to `liveCoalesceMax` pending messages back-to-back before
  returning to the outer select, so a wave's catch-up completion (which drains
  `pending`) can be deferred by up to one drain. Under simultaneous deep
  catch-up **and** a hot live burst on the same topics, this slightly raises
  peak `pendingBytes`; it stays bounded and per-append-checked against the
  64 MiB cap, and overflow still just drops the stream for reconnect-from-cursor
  (no data loss).

## Testing

- New `TestSubscribe_LiveBurstCoalescesWhenQueued`: publishes a 64-message live
  burst *after* CatchupComplete (so every message is on the live path) with the
  sender frozen (a race-safe `freezeSends()` test hook caps in-flight frames at
  `sendQueueDepth`, so the burst cannot flush as 64 singles). Asserts every
  message delivered exactly once, ascending order, tagged live (0), **and** that
  at least one live frame carries several messages — deterministically proving
  the drain coalesced. Passes 15/15 under `-race`.
- Full `pkg/mls/api/v1` suite: 50/50 pass under `-race`; `go vet`, `gofmt`, and
  `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Coalesce queued live `Subscribe` messages into fewer frames
> - After receiving a live message on `sub.MessagesCh`, the `Service.Subscribe` handler now drains up to `liveCoalesceMax` additional immediately-available envelopes and packs them into a single `send(...)` call, instead of sending one tiny frame per message.
> - Messages for topics still catching up continue to buffer on the pending lane with the same `ResourceExhausted` overflow guard, now handled inside a local `route(e)` function.
> - Test harness changes in [subscribe_test.go](https://github.com/xmtp/xmtp-node-go/pull/567/files#diff-3c0f27a57e425060d66693c8423cbd811577f6ad20e20bde492987b5f34847d5) make `blockSend` race-safe and add a `freezeSends` helper; new test `TestSubscribe_LiveBurstCoalescesWhenQueued` verifies a 64-message burst delivers exactly once, in order, with at least one multi-message frame.
> - Behavioral Change: live frames may now contain multiple messages packed up to `maxFrameBytes`; receivers must already handle multi-message frames since `buildWelcomeFrames`/`buildGroupFrames` already produce them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ff52b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->